### PR TITLE
refactor: extract DataSource trait from diff/sync engine

### DIFF
--- a/src/datasource.rs
+++ b/src/datasource.rs
@@ -1,0 +1,95 @@
+//! DataSource trait for abstracting database backends
+//!
+//! This module defines the [`DataSource`] trait that both [`LocalDb`](crate::local::LocalDb)
+//! and [`D1Client`](crate::remote::D1Client) implement, allowing the diff and sync engines
+//! to work with any pair of data sources.
+
+use crate::error::Result;
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+
+/// Table schema information
+#[derive(Debug, Clone)]
+pub struct TableInfo {
+    #[allow(dead_code)]
+    pub name: String,
+    pub columns: Vec<ColumnInfo>,
+    pub primary_key: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ColumnInfo {
+    pub name: String,
+    #[allow(dead_code)]
+    pub col_type: String,
+    #[allow(dead_code)]
+    pub notnull: bool,
+    pub pk: bool,
+}
+
+/// A row with its primary key and optional timestamp
+#[derive(Debug, Clone)]
+pub struct RowMeta {
+    #[allow(dead_code)]
+    pub pk_value: String,
+    pub updated_at: Option<String>,
+    pub content_hash: String,
+}
+
+/// Abstraction over a database that can be used as a sync source or destination.
+///
+/// Both local SQLite databases and remote Cloudflare D1 instances implement
+/// this trait, allowing the diff and sync engines to work generically with
+/// any pair of data sources.
+pub trait DataSource: Sync {
+    /// List all user tables (excluding internal/system tables).
+    fn list_tables(&self) -> impl std::future::Future<Output = Result<Vec<String>>> + Send;
+
+    /// Get schema info for a table (columns, primary keys).
+    fn table_info(
+        &self,
+        table: &str,
+    ) -> impl std::future::Future<Output = Result<TableInfo>> + Send;
+
+    /// Check if a table has a specific column.
+    ///
+    /// Default implementation delegates to `table_info`.
+    #[allow(dead_code)]
+    fn has_column(
+        &self,
+        table: &str,
+        column: &str,
+    ) -> impl std::future::Future<Output = Result<bool>> + Send {
+        async move {
+            let info = self.table_info(table).await?;
+            Ok(info.columns.iter().any(|c| c.name == column))
+        }
+    }
+
+    /// Get row metadata for change detection.
+    ///
+    /// Returns a map of primary key value -> RowMeta containing the content
+    /// hash and optional timestamp for each row.
+    fn get_row_metadata(
+        &self,
+        table: &str,
+        timestamp_column: &str,
+    ) -> impl std::future::Future<Output = Result<HashMap<String, RowMeta>>> + Send;
+
+    /// Get full row data for specific primary key values.
+    fn get_rows(
+        &self,
+        table: &str,
+        pk_values: &[String],
+    ) -> impl std::future::Future<Output = Result<Vec<HashMap<String, JsonValue>>>> + Send;
+
+    /// Insert or replace rows in the table. Returns the number of rows written.
+    fn upsert_rows(
+        &self,
+        table: &str,
+        rows: &[HashMap<String, JsonValue>],
+    ) -> impl std::future::Future<Output = Result<usize>> + Send;
+
+    /// Get the number of rows in a table.
+    fn row_count(&self, table: &str) -> impl std::future::Future<Output = Result<usize>> + Send;
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,9 +1,8 @@
 //! Change detection between local and remote databases
 
 use crate::config::ConflictResolution;
+use crate::datasource::DataSource;
 use crate::error::Result;
-use crate::local::LocalDb;
-use crate::remote::D1Client;
 use std::collections::HashSet;
 use tracing::{debug, info};
 
@@ -135,17 +134,17 @@ impl TableDiff {
     }
 }
 
-/// Compare local and remote data for a table
-pub async fn diff_table(
-    local: &LocalDb,
-    remote: &D1Client,
+/// Compare two data sources for a table
+pub async fn diff_table<A: DataSource, B: DataSource>(
+    local: &A,
+    remote: &B,
     table: &str,
     timestamp_column: &str,
 ) -> Result<TableDiff> {
     info!("Computing diff for table: {}", table);
 
     // Get metadata from both sides
-    let local_meta = local.get_row_metadata(table, timestamp_column)?;
+    let local_meta = local.get_row_metadata(table, timestamp_column).await?;
     let remote_meta = remote.get_row_metadata(table, timestamp_column).await?;
 
     let local_keys: HashSet<&String> = local_meta.keys().collect();
@@ -210,9 +209,9 @@ pub async fn diff_table(
 /// Compare all tables
 /// Reserved for batch operations
 #[allow(dead_code)]
-pub async fn diff_all(
-    local: &LocalDb,
-    remote: &D1Client,
+pub async fn diff_all<A: DataSource, B: DataSource>(
+    local: &A,
+    remote: &B,
     tables: &[String],
     timestamp_column: &str,
 ) -> Result<Vec<TableDiff>> {

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,5 +1,6 @@
 //! Local SQLite database operations
 
+use crate::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
 use crate::error::{Result, SyncError};
 use crate::table::TableSchema;
 use rusqlite::{Connection, OpenFlags, Row};
@@ -7,53 +8,29 @@ use serde_json::Value as JsonValue;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
 use tracing::{debug, info};
 
 /// Wrapper for local SQLite database
 pub struct LocalDb {
-    conn: Connection,
-}
-
-/// Table schema information
-#[derive(Debug, Clone)]
-pub struct TableInfo {
-    #[allow(dead_code)]
-    pub name: String,
-    pub columns: Vec<ColumnInfo>,
-    pub primary_key: Vec<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ColumnInfo {
-    pub name: String,
-    #[allow(dead_code)]
-    pub col_type: String,
-    #[allow(dead_code)]
-    pub notnull: bool,
-    pub pk: bool,
-}
-
-/// A row with its primary key and optional timestamp
-#[derive(Debug, Clone)]
-pub struct RowMeta {
-    #[allow(dead_code)]
-    pub pk_value: String,
-    pub updated_at: Option<String>,
-    pub content_hash: String,
+    conn: Mutex<Connection>,
 }
 
 impl LocalDb {
+    fn conn(&self) -> MutexGuard<'_, Connection> {
+        self.conn.lock().expect("mutex poisoned")
+    }
+
     /// Open a local SQLite database
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
         info!("Opening local database: {}", path.display());
 
-        let conn = Connection::open_with_flags(
-            path,
-            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        )?;
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
 
-        Ok(Self { conn })
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
     }
 
     /// Open read-only for diff operations
@@ -61,294 +38,31 @@ impl LocalDb {
         let path = path.as_ref();
         info!("Opening local database (read-only): {}", path.display());
 
-        let conn = Connection::open_with_flags(
-            path,
-            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        )?;
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
 
-        Ok(Self { conn })
-    }
-
-    /// List all user tables (excluding sqlite internals)
-    pub fn list_tables(&self) -> Result<Vec<String>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT name FROM sqlite_master
-             WHERE type = 'table'
-             AND name NOT LIKE 'sqlite_%'
-             ORDER BY name",
-        )?;
-
-        let tables: Vec<String> = stmt
-            .query_map([], |row| row.get(0))?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-
-        debug!("Found {} tables", tables.len());
-        Ok(tables)
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
     }
 
     /// Get the database schema for table name validation.
     ///
     /// Queries sqlite_master to get all user tables.
     pub fn get_schema(&self) -> Result<TableSchema> {
-        let tables = self.list_tables()?;
+        let conn = self.conn();
+        let tables = list_tables_inner(&conn)?;
         Ok(TableSchema::new(tables))
-    }
-
-    /// Get schema info for a table
-    pub fn table_info(&self, table: &str) -> Result<TableInfo> {
-        let mut stmt = self
-            .conn
-            .prepare(&format!("PRAGMA table_info(\"{}\")", table))?;
-
-        let columns: Vec<ColumnInfo> = stmt
-            .query_map([], |row| {
-                Ok(ColumnInfo {
-                    name: row.get(1)?,
-                    col_type: row.get(2)?,
-                    notnull: row.get::<_, i32>(3)? != 0,
-                    pk: row.get::<_, i32>(5)? != 0,
-                })
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-
-        if columns.is_empty() {
-            return Err(SyncError::TableNotFound(table.to_string()));
-        }
-
-        let primary_key: Vec<String> = columns
-            .iter()
-            .filter(|c| c.pk)
-            .map(|c| c.name.clone())
-            .collect();
-
-        if primary_key.is_empty() {
-            return Err(SyncError::NoPrimaryKey(table.to_string()));
-        }
-
-        Ok(TableInfo {
-            name: table.to_string(),
-            columns,
-            primary_key,
-        })
-    }
-
-    /// Check if table has a specific column
-    pub fn has_column(&self, table: &str, column: &str) -> Result<bool> {
-        let info = self.table_info(table)?;
-        Ok(info.columns.iter().any(|c| c.name == column))
-    }
-
-    /// Get row metadata for change detection
-    /// Returns a map of pk_value -> RowMeta
-    pub fn get_row_metadata(
-        &self,
-        table: &str,
-        timestamp_column: &str,
-    ) -> Result<HashMap<String, RowMeta>> {
-        let info = self.table_info(table)?;
-        let pk_cols = &info.primary_key;
-        let has_timestamp = self.has_column(table, timestamp_column)?;
-
-        // Build the SELECT query
-        let pk_select = pk_cols
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(" || '|' || ");
-
-        let timestamp_select = if has_timestamp {
-            format!(", \"{}\"", timestamp_column)
-        } else {
-            String::new()
-        };
-
-        // For content hash, exclude timestamp columns (updated_at, created_at)
-        let timestamp_columns = ["updated_at", "created_at"];
-        let hash_cols: Vec<_> = info
-            .columns
-            .iter()
-            .filter(|c| !timestamp_columns.contains(&c.name.as_str()))
-            .collect();
-        let all_cols = hash_cols
-            .iter()
-            .map(|c| format!("\"{}\"", c.name))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        let sql = format!(
-            "SELECT {}, {} {} FROM \"{}\"",
-            pk_select, all_cols, timestamp_select, table
-        );
-
-        debug!("Executing: {}", sql);
-
-        let mut stmt = self.conn.prepare(&sql)?;
-        let hash_col_count = hash_cols.len();
-
-        let mut result = HashMap::new();
-
-        let mut rows = stmt.query([])?;
-        while let Some(row) = rows.next()? {
-            // Primary key can be integer or string - handle both
-            let pk_value = get_value_as_string(row, 0)?;
-
-            // Collect column values for hashing (excluding timestamp columns)
-            let mut hasher = Sha256::new();
-            for i in 0..hash_col_count {
-                let val = get_value_as_string(row, i + 1)?;
-                hasher.update(val.as_bytes());
-                hasher.update(b"|");
-            }
-            let content_hash = hex::encode(hasher.finalize());
-
-            // Handle updated_at as either integer (Unix timestamp) or string
-            // Index is 1 (pk) + hash_col_count (content columns) = hash_col_count + 1
-            let updated_at: Option<String> = if has_timestamp {
-                let ts_idx = hash_col_count + 1;
-                // Try integer first (Unix timestamp), then string
-                if let Ok(ts) = row.get::<_, Option<i64>>(ts_idx) {
-                    ts.map(|t| t.to_string())
-                } else {
-                    row.get::<_, Option<String>>(ts_idx).unwrap_or_default()
-                }
-            } else {
-                None
-            };
-
-            result.insert(
-                pk_value.clone(),
-                RowMeta {
-                    pk_value,
-                    updated_at,
-                    content_hash,
-                },
-            );
-        }
-
-        debug!("Got {} rows from {}", result.len(), table);
-        Ok(result)
-    }
-
-    /// Get full row data for specific primary keys
-    pub fn get_rows(
-        &self,
-        table: &str,
-        pk_values: &[String],
-    ) -> Result<Vec<HashMap<String, JsonValue>>> {
-        if pk_values.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let info = self.table_info(table)?;
-        let pk_cols = &info.primary_key;
-
-        // Build primary key expression
-        let pk_expr = pk_cols
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(" || '|' || ");
-
-        // Build column list
-        let cols = info
-            .columns
-            .iter()
-            .map(|c| format!("\"{}\"", c.name))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        // Build IN clause
-        let placeholders = pk_values.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-
-        let sql = format!(
-            "SELECT {} FROM \"{}\" WHERE {} IN ({})",
-            cols, table, pk_expr, placeholders
-        );
-
-        debug!("Fetching {} rows from {}", pk_values.len(), table);
-
-        let mut stmt = self.conn.prepare(&sql)?;
-
-        let params: Vec<&dyn rusqlite::ToSql> = pk_values
-            .iter()
-            .map(|v| v as &dyn rusqlite::ToSql)
-            .collect();
-
-        let mut rows = stmt.query(params.as_slice())?;
-        let mut result = Vec::new();
-
-        while let Some(row) = rows.next()? {
-            let mut row_data = HashMap::new();
-            for (i, col) in info.columns.iter().enumerate() {
-                let value = get_json_value(row, i)?;
-                row_data.insert(col.name.clone(), value);
-            }
-            result.push(row_data);
-        }
-
-        Ok(result)
-    }
-
-    /// Insert or replace rows
-    pub fn upsert_rows(
-        &mut self,
-        table: &str,
-        rows: &[HashMap<String, JsonValue>],
-    ) -> Result<usize> {
-        if rows.is_empty() {
-            return Ok(0);
-        }
-
-        let info = self.table_info(table)?;
-        let cols: Vec<&str> = info.columns.iter().map(|c| c.name.as_str()).collect();
-
-        // Build INSERT OR REPLACE statement
-        let col_list = cols
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let placeholders = cols.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-
-        let sql = format!(
-            "INSERT OR REPLACE INTO \"{}\" ({}) VALUES ({})",
-            table, col_list, placeholders
-        );
-
-        debug!("Upserting {} rows into {}", rows.len(), table);
-
-        let tx = self.conn.transaction()?;
-        let mut count = 0;
-
-        {
-            let mut stmt = tx.prepare(&sql)?;
-            for row in rows {
-                let params: Vec<JsonToSql> = cols
-                    .iter()
-                    .map(|col| JsonToSql(row.get(*col).cloned().unwrap_or(JsonValue::Null)))
-                    .collect();
-
-                let param_refs: Vec<&dyn rusqlite::ToSql> =
-                    params.iter().map(|p| p as &dyn rusqlite::ToSql).collect();
-
-                stmt.execute(param_refs.as_slice())?;
-                count += 1;
-            }
-        }
-
-        tx.commit()?;
-        info!("Upserted {} rows into {}", count, table);
-        Ok(count)
     }
 
     /// Delete rows by primary key
     #[allow(dead_code)]
-    pub fn delete_rows(&mut self, table: &str, pk_values: &[String]) -> Result<usize> {
+    pub fn delete_rows(&self, table: &str, pk_values: &[String]) -> Result<usize> {
         if pk_values.is_empty() {
             return Ok(0);
         }
 
-        let info = self.table_info(table)?;
+        let conn = self.conn();
+        let info = table_info_inner(&conn, table)?;
         let pk_cols = &info.primary_key;
 
         let pk_expr = pk_cols
@@ -371,17 +85,304 @@ impl LocalDb {
             .map(|v| v as &dyn rusqlite::ToSql)
             .collect();
 
-        let count = self.conn.execute(&sql, params.as_slice())?;
+        let count = conn.execute(&sql, params.as_slice())?;
         info!("Deleted {} rows from {}", count, table);
         Ok(count)
     }
+}
 
-    /// Get row count for a table
-    pub fn row_count(&self, table: &str) -> Result<usize> {
+impl DataSource for LocalDb {
+    async fn list_tables(&self) -> Result<Vec<String>> {
+        let conn = self.conn();
+        list_tables_inner(&conn)
+    }
+
+    async fn table_info(&self, table: &str) -> Result<TableInfo> {
+        let conn = self.conn();
+        table_info_inner(&conn, table)
+    }
+
+    async fn get_row_metadata(
+        &self,
+        table: &str,
+        timestamp_column: &str,
+    ) -> Result<HashMap<String, RowMeta>> {
+        let conn = self.conn();
+        get_row_metadata_inner(&conn, table, timestamp_column)
+    }
+
+    async fn get_rows(
+        &self,
+        table: &str,
+        pk_values: &[String],
+    ) -> Result<Vec<HashMap<String, JsonValue>>> {
+        let conn = self.conn();
+        get_rows_inner(&conn, table, pk_values)
+    }
+
+    async fn upsert_rows(&self, table: &str, rows: &[HashMap<String, JsonValue>]) -> Result<usize> {
+        let conn = self.conn();
+        upsert_rows_inner(&conn, table, rows)
+    }
+
+    async fn row_count(&self, table: &str) -> Result<usize> {
+        let conn = self.conn();
         let sql = format!("SELECT COUNT(*) FROM \"{}\"", table);
-        let count: usize = self.conn.query_row(&sql, [], |row| row.get(0))?;
+        let count: usize = conn.query_row(&sql, [], |row| row.get(0))?;
         Ok(count)
     }
+}
+
+// -- Internal functions that operate on a borrowed Connection --
+
+fn list_tables_inner(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT name FROM sqlite_master
+         WHERE type = 'table'
+         AND name NOT LIKE 'sqlite_%'
+         ORDER BY name",
+    )?;
+
+    let tables: Vec<String> = stmt
+        .query_map([], |row| row.get(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    debug!("Found {} tables", tables.len());
+    Ok(tables)
+}
+
+fn table_info_inner(conn: &Connection, table: &str) -> Result<TableInfo> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info(\"{}\")", table))?;
+
+    let columns: Vec<ColumnInfo> = stmt
+        .query_map([], |row| {
+            Ok(ColumnInfo {
+                name: row.get(1)?,
+                col_type: row.get(2)?,
+                notnull: row.get::<_, i32>(3)? != 0,
+                pk: row.get::<_, i32>(5)? != 0,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    if columns.is_empty() {
+        return Err(SyncError::TableNotFound(table.to_string()));
+    }
+
+    let primary_key: Vec<String> = columns
+        .iter()
+        .filter(|c| c.pk)
+        .map(|c| c.name.clone())
+        .collect();
+
+    if primary_key.is_empty() {
+        return Err(SyncError::NoPrimaryKey(table.to_string()));
+    }
+
+    Ok(TableInfo {
+        name: table.to_string(),
+        columns,
+        primary_key,
+    })
+}
+
+fn get_row_metadata_inner(
+    conn: &Connection,
+    table: &str,
+    timestamp_column: &str,
+) -> Result<HashMap<String, RowMeta>> {
+    let info = table_info_inner(conn, table)?;
+    let pk_cols = &info.primary_key;
+    let has_timestamp = info.columns.iter().any(|c| c.name == timestamp_column);
+
+    // Build the SELECT query
+    let pk_select = pk_cols
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect::<Vec<_>>()
+        .join(" || '|' || ");
+
+    let timestamp_select = if has_timestamp {
+        format!(", \"{}\"", timestamp_column)
+    } else {
+        String::new()
+    };
+
+    // For content hash, exclude timestamp columns (updated_at, created_at)
+    let timestamp_columns = ["updated_at", "created_at"];
+    let hash_cols: Vec<_> = info
+        .columns
+        .iter()
+        .filter(|c| !timestamp_columns.contains(&c.name.as_str()))
+        .collect();
+    let all_cols = hash_cols
+        .iter()
+        .map(|c| format!("\"{}\"", c.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let sql = format!(
+        "SELECT {}, {} {} FROM \"{}\"",
+        pk_select, all_cols, timestamp_select, table
+    );
+
+    debug!("Executing: {}", sql);
+
+    let mut stmt = conn.prepare(&sql)?;
+    let hash_col_count = hash_cols.len();
+
+    let mut result = HashMap::new();
+
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        // Primary key can be integer or string - handle both
+        let pk_value = get_value_as_string(row, 0)?;
+
+        // Collect column values for hashing (excluding timestamp columns)
+        let mut hasher = Sha256::new();
+        for i in 0..hash_col_count {
+            let val = get_value_as_string(row, i + 1)?;
+            hasher.update(val.as_bytes());
+            hasher.update(b"|");
+        }
+        let content_hash = hex::encode(hasher.finalize());
+
+        // Handle updated_at as either integer (Unix timestamp) or string
+        // Index is 1 (pk) + hash_col_count (content columns) = hash_col_count + 1
+        let updated_at: Option<String> = if has_timestamp {
+            let ts_idx = hash_col_count + 1;
+            // Try integer first (Unix timestamp), then string
+            if let Ok(ts) = row.get::<_, Option<i64>>(ts_idx) {
+                ts.map(|t| t.to_string())
+            } else {
+                row.get::<_, Option<String>>(ts_idx).unwrap_or_default()
+            }
+        } else {
+            None
+        };
+
+        result.insert(
+            pk_value.clone(),
+            RowMeta {
+                pk_value,
+                updated_at,
+                content_hash,
+            },
+        );
+    }
+
+    debug!("Got {} rows from {}", result.len(), table);
+    Ok(result)
+}
+
+fn get_rows_inner(
+    conn: &Connection,
+    table: &str,
+    pk_values: &[String],
+) -> Result<Vec<HashMap<String, JsonValue>>> {
+    if pk_values.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let info = table_info_inner(conn, table)?;
+    let pk_cols = &info.primary_key;
+
+    // Build primary key expression
+    let pk_expr = pk_cols
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect::<Vec<_>>()
+        .join(" || '|' || ");
+
+    // Build column list
+    let cols = info
+        .columns
+        .iter()
+        .map(|c| format!("\"{}\"", c.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    // Build IN clause
+    let placeholders = pk_values.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+
+    let sql = format!(
+        "SELECT {} FROM \"{}\" WHERE {} IN ({})",
+        cols, table, pk_expr, placeholders
+    );
+
+    debug!("Fetching {} rows from {}", pk_values.len(), table);
+
+    let mut stmt = conn.prepare(&sql)?;
+
+    let params: Vec<&dyn rusqlite::ToSql> = pk_values
+        .iter()
+        .map(|v| v as &dyn rusqlite::ToSql)
+        .collect();
+
+    let mut rows = stmt.query(params.as_slice())?;
+    let mut result = Vec::new();
+
+    while let Some(row) = rows.next()? {
+        let mut row_data = HashMap::new();
+        for (i, col) in info.columns.iter().enumerate() {
+            let value = get_json_value(row, i)?;
+            row_data.insert(col.name.clone(), value);
+        }
+        result.push(row_data);
+    }
+
+    Ok(result)
+}
+
+fn upsert_rows_inner(
+    conn: &Connection,
+    table: &str,
+    rows: &[HashMap<String, JsonValue>],
+) -> Result<usize> {
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let info = table_info_inner(conn, table)?;
+    let cols: Vec<&str> = info.columns.iter().map(|c| c.name.as_str()).collect();
+
+    // Build INSERT OR REPLACE statement
+    let col_list = cols
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let placeholders = cols.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+
+    let sql = format!(
+        "INSERT OR REPLACE INTO \"{}\" ({}) VALUES ({})",
+        table, col_list, placeholders
+    );
+
+    debug!("Upserting {} rows into {}", rows.len(), table);
+
+    let tx = conn.unchecked_transaction()?;
+    let mut count = 0;
+
+    {
+        let mut stmt = tx.prepare(&sql)?;
+        for row in rows {
+            let params: Vec<JsonToSql> = cols
+                .iter()
+                .map(|col| JsonToSql(row.get(*col).cloned().unwrap_or(JsonValue::Null)))
+                .collect();
+
+            let param_refs: Vec<&dyn rusqlite::ToSql> =
+                params.iter().map(|p| p as &dyn rusqlite::ToSql).collect();
+
+            stmt.execute(param_refs.as_slice())?;
+            count += 1;
+        }
+    }
+
+    tx.commit()?;
+    info!("Upserted {} rows into {}", count, table);
+    Ok(count)
 }
 
 /// Helper to get a row value as string for hashing

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,12 @@
 //! - [`sync`] - Push/pull orchestration
 //! - [`error`] - Error types
 //! - [`table`] - Table name validation
+//! - [`datasource`] - DataSource trait for abstracting database backends
 //! - [`batch`] - Batch operations for multi-row upserts
 
 mod batch;
 mod config;
+mod datasource;
 mod diff;
 mod error;
 mod local;
@@ -33,6 +35,7 @@ mod sync;
 mod table;
 
 use crate::config::Config;
+use crate::datasource::DataSource;
 use crate::diff::diff_table;
 use crate::local::LocalDb;
 use crate::remote::D1Client;
@@ -185,7 +188,7 @@ async fn run_push(config: &Config, table: Option<String>, dry_run: bool) -> erro
 async fn run_pull(config: &Config, table: Option<String>, dry_run: bool) -> error::Result<()> {
     info!("Pull mode: D1 -> local");
 
-    let mut local = LocalDb::open(config.local_db_path())?;
+    let local = LocalDb::open(config.local_db_path())?;
     let remote = D1Client::with_retry_config(
         config.cloudflare_account_id.clone(),
         config.database_id.clone(),
@@ -204,7 +207,7 @@ async fn run_pull(config: &Config, table: Option<String>, dry_run: bool) -> erro
         }
         None => None,
     };
-    let results = pull_all(&mut local, &remote, config, tables, dry_run).await?;
+    let results = pull_all(&local, &remote, config, tables, dry_run).await?;
 
     // Print summary
     println!("\n--- Pull Summary ---");
@@ -261,80 +264,11 @@ async fn run_diff(config: &Config, table: Option<String>) -> error::Result<()> {
             println!("  {}", diff.summary());
 
             // Show details
-            if !diff.local_only.is_empty() {
-                println!(
-                    "    Local only: {}",
-                    diff.local_only
-                        .iter()
-                        .take(5)
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-                if diff.local_only.len() > 5 {
-                    println!("      ... and {} more", diff.local_only.len() - 5);
-                }
-            }
-
-            if !diff.remote_only.is_empty() {
-                println!(
-                    "    Remote only: {}",
-                    diff.remote_only
-                        .iter()
-                        .take(5)
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-                if diff.remote_only.len() > 5 {
-                    println!("      ... and {} more", diff.remote_only.len() - 5);
-                }
-            }
-
-            if !diff.local_newer.is_empty() {
-                println!(
-                    "    Local newer: {}",
-                    diff.local_newer
-                        .iter()
-                        .take(5)
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-                if diff.local_newer.len() > 5 {
-                    println!("      ... and {} more", diff.local_newer.len() - 5);
-                }
-            }
-
-            if !diff.remote_newer.is_empty() {
-                println!(
-                    "    Remote newer: {}",
-                    diff.remote_newer
-                        .iter()
-                        .take(5)
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-                if diff.remote_newer.len() > 5 {
-                    println!("      ... and {} more", diff.remote_newer.len() - 5);
-                }
-            }
-
-            if !diff.content_differs.is_empty() {
-                println!(
-                    "    Content differs: {}",
-                    diff.content_differs
-                        .iter()
-                        .take(5)
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-                if diff.content_differs.len() > 5 {
-                    println!("      ... and {} more", diff.content_differs.len() - 5);
-                }
-            }
+            print_diff_category("Local only", &diff.local_only);
+            print_diff_category("Remote only", &diff.remote_only);
+            print_diff_category("Local newer", &diff.local_newer);
+            print_diff_category("Remote newer", &diff.remote_newer);
+            print_diff_category("Content differs", &diff.content_differs);
         } else {
             println!("\n{}: in sync ({} rows)", table_name, diff.identical.len());
         }
@@ -345,6 +279,18 @@ async fn run_diff(config: &Config, table: Option<String>) -> error::Result<()> {
     }
 
     Ok(())
+}
+
+/// Print a diff category (e.g. "Local only") with up to 5 sample keys.
+fn print_diff_category(label: &str, keys: &[String]) {
+    if keys.is_empty() {
+        return;
+    }
+    let preview: Vec<_> = keys.iter().take(5).map(String::as_str).collect();
+    println!("    {}: {}", label, preview.join(", "));
+    if keys.len() > 5 {
+        println!("      ... and {} more", keys.len() - 5);
+    }
 }
 
 async fn run_status(config: &Config) -> error::Result<()> {
@@ -380,12 +326,12 @@ async fn run_status(config: &Config) -> error::Result<()> {
     match LocalDb::open_readonly(config.local_db_path()) {
         Ok(local) => {
             println!("  Connection: OK");
-            let tables = local.list_tables()?;
+            let tables = local.list_tables().await?;
             println!("  Tables: {}", tables.len());
 
             for table in &tables {
                 if config.should_sync_table(table) {
-                    let count = local.row_count(table)?;
+                    let count = local.row_count(table).await?;
                     println!("    {}: {} rows", table, count);
                 }
             }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,8 +1,8 @@
 //! Cloudflare D1 HTTP API client
 
 use crate::config::RetryConfig;
+use crate::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
 use crate::error::{Result, SyncError};
-use crate::local::RowMeta;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -189,18 +189,14 @@ impl D1Client {
         )
     }
 
-    /// Execute a SQL query (internal, without retry)
-    async fn query_internal(
-        &self,
-        sql: &str,
-        params: Vec<JsonValue>,
-    ) -> Result<Vec<HashMap<String, JsonValue>>> {
+    /// Send a SQL statement to D1 and return the parsed response (without retry).
+    async fn send_request(&self, sql: &str, params: Vec<JsonValue>) -> Result<D1Result> {
         let request = D1Request {
             sql: sql.to_string(),
             params,
         };
 
-        debug!("D1 query: {}", sql);
+        debug!("D1 request: {}", sql);
 
         let response = self
             .client
@@ -218,7 +214,6 @@ impl D1Client {
             })?;
 
         let status = response.status();
-        // Extract Retry-After header before consuming response body
         let retry_after = extract_retry_after_header(response.headers());
         let body = response.text().await?;
 
@@ -240,16 +235,23 @@ impl D1Client {
             return Err(SyncError::Remote("Unknown D1 error".to_string()));
         }
 
-        let results = d1_response
+        Ok(d1_response
             .result
-            .and_then(|r| r.into_iter().next())
-            .and_then(|r| r.results)
-            .unwrap_or_default();
-
-        Ok(results)
+            .and_then(|mut r| {
+                if r.is_empty() {
+                    None
+                } else {
+                    Some(r.remove(0))
+                }
+            })
+            .unwrap_or(D1Result {
+                results: None,
+                success: true,
+                meta: None,
+            }))
     }
 
-    /// Execute a SQL query with retry
+    /// Execute a SQL query with retry, returning result rows.
     async fn query(
         &self,
         sql: &str,
@@ -259,75 +261,24 @@ impl D1Client {
         with_retry(&self.retry_config, || {
             let sql = sql.clone();
             let params = params.clone();
-            async move { self.query_internal(&sql, params).await }
+            async move {
+                let result = self.send_request(&sql, params).await?;
+                Ok(result.results.unwrap_or_default())
+            }
         })
         .await
     }
 
-    /// Execute a write query (internal, without retry)
-    async fn execute_internal(&self, sql: &str, params: Vec<JsonValue>) -> Result<i64> {
-        let request = D1Request {
-            sql: sql.to_string(),
-            params,
-        };
-
-        debug!("D1 execute: {}", sql);
-
-        let response = self
-            .client
-            .post(self.endpoint())
-            .bearer_auth(&self.api_token)
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    SyncError::ConnectionTimeout
-                } else {
-                    SyncError::Http(e)
-                }
-            })?;
-
-        let status = response.status();
-        // Extract Retry-After header before consuming response body
-        let retry_after = extract_retry_after_header(response.headers());
-        let body = response.text().await?;
-
-        if !status.is_success() {
-            return Err(parse_http_error(status, &body, retry_after));
-        }
-
-        let d1_response: D1Response = serde_json::from_str(&body)?;
-
-        if !d1_response.success {
-            if let Some(errors) = d1_response.errors {
-                if let Some(err) = errors.first() {
-                    return Err(SyncError::D1Api {
-                        message: err.message.clone(),
-                        code: err.code,
-                    });
-                }
-            }
-            return Err(SyncError::Remote("Unknown D1 error".to_string()));
-        }
-
-        let changes = d1_response
-            .result
-            .and_then(|r| r.into_iter().next())
-            .and_then(|r| r.meta)
-            .and_then(|m| m.changes)
-            .unwrap_or(0);
-
-        Ok(changes)
-    }
-
-    /// Execute a write query (INSERT, UPDATE, DELETE) with retry
+    /// Execute a write query (INSERT, UPDATE, DELETE) with retry, returning change count.
     async fn execute(&self, sql: &str, params: Vec<JsonValue>) -> Result<i64> {
         let sql = sql.to_string();
         with_retry(&self.retry_config, || {
             let sql = sql.clone();
             let params = params.clone();
-            async move { self.execute_internal(&sql, params).await }
+            async move {
+                let result = self.send_request(&sql, params).await?;
+                Ok(result.meta.and_then(|m| m.changes).unwrap_or(0))
+            }
         })
         .await
     }
@@ -343,8 +294,139 @@ impl D1Client {
         Ok(())
     }
 
-    /// List all tables in D1
-    pub async fn list_tables(&self) -> Result<Vec<String>> {
+    /// Delete rows by primary key
+    #[allow(dead_code)]
+    pub async fn delete_rows(&self, table: &str, pk_values: &[String]) -> Result<usize> {
+        if pk_values.is_empty() {
+            return Ok(0);
+        }
+
+        let info = self.table_info(table).await?;
+        let pk_expr = info
+            .primary_key
+            .iter()
+            .map(|c| format!("\"{}\"", c))
+            .collect::<Vec<_>>()
+            .join(" || '|' || ");
+
+        let mut total_changes = 0;
+
+        // Delete in batches respecting D1 bind parameter limit
+        let batch_size = crate::batch::D1_MAX_BIND_PARAMS;
+        for chunk in pk_values.chunks(batch_size) {
+            let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let sql = format!(
+                "DELETE FROM \"{}\" WHERE {} IN ({})",
+                table, pk_expr, placeholders
+            );
+
+            let params: Vec<JsonValue> =
+                chunk.iter().map(|v| JsonValue::String(v.clone())).collect();
+            let changes = self.execute(&sql, params).await?;
+            total_changes += changes as usize;
+        }
+
+        info!("Deleted {} rows from D1 table {}", total_changes, table);
+        Ok(total_changes)
+    }
+
+    /// Insert or replace rows with custom batch configuration.
+    ///
+    /// Groups rows into batches respecting count, size, and D1 bind parameter
+    /// limits, then executes multi-row INSERT statements for better performance.
+    ///
+    /// `on_batch` is called after each batch completes with the number of rows
+    /// in that batch, allowing callers to update progress indicators.
+    pub async fn upsert_rows_batched(
+        &self,
+        table: &str,
+        rows: &[HashMap<String, JsonValue>],
+        batch_config: &crate::config::BatchConfig,
+        on_batch: impl Fn(usize),
+    ) -> Result<usize> {
+        use crate::batch::{batch_rows, generate_batch_insert, D1_MAX_BIND_PARAMS};
+
+        if rows.is_empty() {
+            return Ok(0);
+        }
+
+        let info = self.table_info(table).await?;
+        let columns: Vec<String> = info.columns.iter().map(|c| c.name.clone()).collect();
+
+        // Fail fast if a single row already exceeds D1's param limit
+        if columns.len() > D1_MAX_BIND_PARAMS {
+            return Err(SyncError::ParamLimitExceeded {
+                table: table.to_string(),
+                row_count: 1,
+                col_count: columns.len(),
+                limit: D1_MAX_BIND_PARAMS,
+            });
+        }
+
+        // Guard against empty columns (would cause division by zero)
+        if columns.is_empty() {
+            return Err(SyncError::Remote(format!(
+                "Table '{}' has no columns",
+                table
+            )));
+        }
+
+        let batches = batch_rows(rows, &columns, batch_config);
+
+        let mut total_changes = 0;
+
+        debug!(
+            "Upserting {} rows in {} batches to table {} ({} cols, max {} rows/batch by param limit)",
+            rows.len(),
+            batches.len(),
+            table,
+            columns.len(),
+            D1_MAX_BIND_PARAMS / columns.len(),
+        );
+
+        for (i, batch) in batches.iter().enumerate() {
+            let (sql, params) = generate_batch_insert(table, &columns, &batch.rows);
+
+            if sql.is_empty() {
+                continue;
+            }
+
+            // Defense in depth: catch batch_rows bugs before hitting D1
+            if params.len() > D1_MAX_BIND_PARAMS {
+                return Err(SyncError::ParamLimitExceeded {
+                    table: table.to_string(),
+                    row_count: batch.rows.len(),
+                    col_count: columns.len(),
+                    limit: D1_MAX_BIND_PARAMS,
+                });
+            }
+
+            debug!(
+                "Batch {}/{}: {} rows, {} params, ~{} bytes",
+                i + 1,
+                batches.len(),
+                batch.rows.len(),
+                params.len(),
+                batch.estimated_bytes
+            );
+
+            let changes = self.execute(&sql, params).await?;
+            total_changes += changes as usize;
+            on_batch(batch.rows.len());
+        }
+
+        info!(
+            "Upserted {} rows into D1 table {} ({} batches)",
+            total_changes,
+            table,
+            batches.len()
+        );
+        Ok(total_changes)
+    }
+}
+
+impl DataSource for D1Client {
+    async fn list_tables(&self) -> Result<Vec<String>> {
         let results = self
             .query(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
@@ -365,64 +447,70 @@ impl D1Client {
         Ok(tables)
     }
 
-    /// Get table column info
-    pub async fn table_columns(&self, table: &str) -> Result<Vec<String>> {
+    async fn table_info(&self, table: &str) -> Result<TableInfo> {
         let results = self
             .query(&format!("PRAGMA table_info(\"{}\")", table), vec![])
             .await?;
 
-        let columns: Vec<String> = results
+        let columns: Vec<ColumnInfo> = results
             .into_iter()
-            .filter_map(|row| {
-                row.get("name")
+            .map(|row| ColumnInfo {
+                name: row
+                    .get("name")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-            })
-            .collect();
-
-        Ok(columns)
-    }
-
-    /// Get primary key columns for a table
-    pub async fn primary_key_columns(&self, table: &str) -> Result<Vec<String>> {
-        let results = self
-            .query(&format!("PRAGMA table_info(\"{}\")", table), vec![])
-            .await?;
-
-        let pk_cols: Vec<String> = results
-            .into_iter()
-            .filter(|row| {
-                row.get("pk")
+                    .unwrap_or("")
+                    .to_string(),
+                col_type: row
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                notnull: row
+                    .get("notnull")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n != 0)
+                    .unwrap_or(false),
+                pk: row
+                    .get("pk")
                     .and_then(|v| v.as_i64())
                     .map(|n| n > 0)
-                    .unwrap_or(false)
-            })
-            .filter_map(|row| {
-                row.get("name")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
+                    .unwrap_or(false),
             })
             .collect();
 
-        if pk_cols.is_empty() {
+        if columns.is_empty() {
+            return Err(SyncError::TableNotFound(table.to_string()));
+        }
+
+        let primary_key: Vec<String> = columns
+            .iter()
+            .filter(|c| c.pk)
+            .map(|c| c.name.clone())
+            .collect();
+
+        if primary_key.is_empty() {
             return Err(SyncError::NoPrimaryKey(table.to_string()));
         }
 
-        Ok(pk_cols)
+        Ok(TableInfo {
+            name: table.to_string(),
+            columns,
+            primary_key,
+        })
     }
 
-    /// Get row metadata for change detection
-    pub async fn get_row_metadata(
+    async fn get_row_metadata(
         &self,
         table: &str,
         timestamp_column: &str,
     ) -> Result<HashMap<String, RowMeta>> {
-        let pk_cols = self.primary_key_columns(table).await?;
-        let columns = self.table_columns(table).await?;
+        let info = self.table_info(table).await?;
+        let columns: Vec<String> = info.columns.iter().map(|c| c.name.clone()).collect();
         let has_timestamp = columns.iter().any(|c| c == timestamp_column);
 
         // Build the SELECT query
-        let pk_select = pk_cols
+        let pk_select = info
+            .primary_key
             .iter()
             .map(|c| format!("\"{}\"", c))
             .collect::<Vec<_>>()
@@ -501,8 +589,7 @@ impl D1Client {
         Ok(metadata)
     }
 
-    /// Get full row data for specific primary keys
-    pub async fn get_rows(
+    async fn get_rows(
         &self,
         table: &str,
         pk_values: &[String],
@@ -511,25 +598,23 @@ impl D1Client {
             return Ok(vec![]);
         }
 
-        let pk_cols = self.primary_key_columns(table).await?;
-        let columns = self.table_columns(table).await?;
+        let info = self.table_info(table).await?;
 
-        let pk_expr = pk_cols
+        let pk_expr = info
+            .primary_key
             .iter()
             .map(|c| format!("\"{}\"", c))
             .collect::<Vec<_>>()
             .join(" || '|' || ");
 
-        let cols = columns
+        let cols = info
+            .columns
             .iter()
-            .map(|c| format!("\"{}\"", c))
+            .map(|c| format!("\"{}\"", c.name))
             .collect::<Vec<_>>()
             .join(", ");
 
         // D1 allows at most 100 bind params per query.
-        // For single-column PKs that's 100 rows; for composite PKs
-        // each row still contributes one param to the IN clause (the
-        // concatenated PK expression is compared server-side), so 100 is safe.
         let batch_size = crate::batch::D1_MAX_BIND_PARAMS;
         let mut all_results = Vec::new();
 
@@ -549,151 +634,13 @@ impl D1Client {
         Ok(all_results)
     }
 
-    /// Insert or replace rows using multi-row INSERT statements.
-    ///
-    /// Uses the default batch configuration. Effective batch size depends on
-    /// column count due to D1's 100 bind-parameter limit.
-    #[allow(dead_code)]
-    pub async fn upsert_rows(
-        &self,
-        table: &str,
-        rows: &[HashMap<String, JsonValue>],
-    ) -> Result<usize> {
+    async fn upsert_rows(&self, table: &str, rows: &[HashMap<String, JsonValue>]) -> Result<usize> {
         use crate::config::BatchConfig;
         self.upsert_rows_batched(table, rows, &BatchConfig::default(), |_| {})
             .await
     }
 
-    /// Insert or replace rows with custom batch configuration.
-    ///
-    /// Groups rows into batches respecting count, size, and D1 bind parameter
-    /// limits, then executes multi-row INSERT statements for better performance.
-    ///
-    /// `on_batch` is called after each batch completes with the number of rows
-    /// in that batch, allowing callers to update progress indicators.
-    pub async fn upsert_rows_batched(
-        &self,
-        table: &str,
-        rows: &[HashMap<String, JsonValue>],
-        batch_config: &crate::config::BatchConfig,
-        on_batch: impl Fn(usize),
-    ) -> Result<usize> {
-        use crate::batch::{batch_rows, generate_batch_insert, D1_MAX_BIND_PARAMS};
-
-        if rows.is_empty() {
-            return Ok(0);
-        }
-
-        let columns = self.table_columns(table).await?;
-
-        // Fail fast if a single row already exceeds D1's param limit
-        if columns.len() > D1_MAX_BIND_PARAMS {
-            return Err(SyncError::ParamLimitExceeded {
-                table: table.to_string(),
-                row_count: 1,
-                col_count: columns.len(),
-                limit: D1_MAX_BIND_PARAMS,
-            });
-        }
-
-        // Guard against empty columns (would cause division by zero)
-        if columns.is_empty() {
-            return Err(SyncError::Remote(format!(
-                "Table '{}' has no columns",
-                table
-            )));
-        }
-
-        let batches = batch_rows(rows, &columns, batch_config);
-
-        let mut total_changes = 0;
-
-        debug!(
-            "Upserting {} rows in {} batches to table {} ({} cols, max {} rows/batch by param limit)",
-            rows.len(),
-            batches.len(),
-            table,
-            columns.len(),
-            D1_MAX_BIND_PARAMS / columns.len(),
-        );
-
-        for (i, batch) in batches.iter().enumerate() {
-            let (sql, params) = generate_batch_insert(table, &columns, &batch.rows);
-
-            if sql.is_empty() {
-                continue;
-            }
-
-            // Defense in depth: catch batch_rows bugs before hitting D1
-            if params.len() > D1_MAX_BIND_PARAMS {
-                return Err(SyncError::ParamLimitExceeded {
-                    table: table.to_string(),
-                    row_count: batch.rows.len(),
-                    col_count: columns.len(),
-                    limit: D1_MAX_BIND_PARAMS,
-                });
-            }
-
-            debug!(
-                "Batch {}/{}: {} rows, {} params, ~{} bytes",
-                i + 1,
-                batches.len(),
-                batch.rows.len(),
-                params.len(),
-                batch.estimated_bytes
-            );
-
-            let changes = self.execute(&sql, params).await?;
-            total_changes += changes as usize;
-            on_batch(batch.rows.len());
-        }
-
-        info!(
-            "Upserted {} rows into D1 table {} ({} batches)",
-            total_changes,
-            table,
-            batches.len()
-        );
-        Ok(total_changes)
-    }
-
-    /// Delete rows by primary key
-    #[allow(dead_code)]
-    pub async fn delete_rows(&self, table: &str, pk_values: &[String]) -> Result<usize> {
-        if pk_values.is_empty() {
-            return Ok(0);
-        }
-
-        let pk_cols = self.primary_key_columns(table).await?;
-        let pk_expr = pk_cols
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(" || '|' || ");
-
-        let mut total_changes = 0;
-
-        // Delete in batches respecting D1 bind parameter limit
-        let batch_size = crate::batch::D1_MAX_BIND_PARAMS;
-        for chunk in pk_values.chunks(batch_size) {
-            let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-            let sql = format!(
-                "DELETE FROM \"{}\" WHERE {} IN ({})",
-                table, pk_expr, placeholders
-            );
-
-            let params: Vec<JsonValue> =
-                chunk.iter().map(|v| JsonValue::String(v.clone())).collect();
-            let changes = self.execute(&sql, params).await?;
-            total_changes += changes as usize;
-        }
-
-        info!("Deleted {} rows from D1 table {}", total_changes, table);
-        Ok(total_changes)
-    }
-
-    /// Get row count for a table
-    pub async fn row_count(&self, table: &str) -> Result<usize> {
+    async fn row_count(&self, table: &str) -> Result<usize> {
         let results = self
             .query(
                 &format!("SELECT COUNT(*) as count FROM \"{}\"", table),

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,6 +1,7 @@
 //! Sync orchestration
 
 use crate::config::{Config, ConflictResolution};
+use crate::datasource::DataSource;
 use crate::diff::{diff_table, TableDiff};
 use crate::error::Result;
 use crate::local::LocalDb;
@@ -30,7 +31,11 @@ impl SyncResult {
     }
 }
 
-/// Push local changes to remote (local -> D1)
+/// Push local changes to remote (local -> D1).
+///
+/// Takes concrete types rather than `DataSource` generics because
+/// `push` uses `D1Client::upsert_rows_batched` with progress callbacks,
+/// which is transport-specific and not part of the `DataSource` trait.
 pub async fn push_table(
     local: &LocalDb,
     remote: &D1Client,
@@ -60,7 +65,7 @@ pub async fn push_table(
     }
 
     // Fetch full row data from local
-    let rows = local.get_rows(table, &rows_to_push)?;
+    let rows = local.get_rows(table, &rows_to_push).await?;
 
     if rows.is_empty() {
         warn!("No rows found locally for push");
@@ -91,7 +96,7 @@ pub async fn push_table(
 
 /// Pull remote changes to local (D1 -> local)
 pub async fn pull_table(
-    local: &mut LocalDb,
+    local: &LocalDb,
     remote: &D1Client,
     table: &str,
     diff: &TableDiff,
@@ -135,7 +140,7 @@ pub async fn pull_table(
     );
     pb.set_message(format!("Pulling {}", table));
 
-    let count = local.upsert_rows(table, &rows)?;
+    let count = local.upsert_rows(table, &rows).await?;
     result.rows_pulled = count;
 
     pb.finish_with_message(format!("Pulled {} rows", result.rows_pulled));
@@ -144,13 +149,14 @@ pub async fn pull_table(
 }
 
 /// Get list of tables to sync based on config
-pub async fn get_tables_to_sync(
-    local: &LocalDb,
-    remote: &D1Client,
+pub async fn get_tables_to_sync<A: DataSource, B: DataSource>(
+    local: &A,
+    remote: &B,
     config: &Config,
 ) -> Result<Vec<String>> {
     // Get tables from both sides
-    let local_tables: std::collections::HashSet<_> = local.list_tables()?.into_iter().collect();
+    let local_tables: std::collections::HashSet<_> =
+        local.list_tables().await?.into_iter().collect();
     let remote_tables: std::collections::HashSet<_> =
         remote.list_tables().await?.into_iter().collect();
 
@@ -164,7 +170,7 @@ pub async fn get_tables_to_sync(
     // Filter out tables without primary keys (required for change detection)
     let mut syncable = Vec::new();
     for table in common {
-        match local.table_info(&table) {
+        match local.table_info(&table).await {
             Ok(info) if !info.primary_key.is_empty() => {
                 syncable.push(table);
             }
@@ -238,7 +244,7 @@ pub async fn push_all(
 
 /// Pull all tables
 pub async fn pull_all(
-    local: &mut LocalDb,
+    local: &LocalDb,
     remote: &D1Client,
     config: &Config,
     tables: Option<Vec<String>>,


### PR DESCRIPTION
## Summary
- Extracts a `DataSource` trait (`src/datasource.rs`) abstracting the common interface between `LocalDb` and `D1Client`
- Refactors `diff_table()`, `diff_all()`, and `get_tables_to_sync()` to use generics (`<A: DataSource, B: DataSource>`) instead of concrete types
- Moves shared types (`TableInfo`, `ColumnInfo`, `RowMeta`) from `local.rs` to `datasource.rs`
- Uses RPITIT (return-position impl Trait in traits) for async -- no `async_trait` dependency needed
- Wraps `LocalDb::Connection` in `Mutex` for interior mutability, enabling `&self` on the trait's `upsert_rows`

Closes #21. Prerequisite for #20 (stash/retrieve commands).

## Test plan
- [x] All 55 existing tests pass unchanged (`cargo test`)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] Pure refactor -- no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)