### PR TITLE
feat: --output json + structured exit codes (#32, #33)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -121,6 +121,40 @@ impl SyncError {
     }
 }
 
+impl SyncError {
+    /// Map error variants to structured exit codes for agent consumption.
+    ///
+    /// - 0: success (not an error)
+    /// - 1: general/unknown error
+    /// - 2: configuration error (don't retry, fix config)
+    /// - 3: connection/network error (transient, safe to retry)
+    /// - 4: conflict error (needs human decision)
+    /// - 5: target not found (database missing, API unreachable)
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            SyncError::Config(_) | SyncError::ConfigNotFound(_) => 2,
+            SyncError::InvalidTableName { .. } | SyncError::NoPrimaryKey(_) => 2,
+            SyncError::ParamLimitExceeded { .. } => 2,
+
+            SyncError::Http(_)
+            | SyncError::RateLimited { .. }
+            | SyncError::ServerError { .. }
+            | SyncError::ConnectionTimeout
+            | SyncError::RetryExhausted { .. } => 3,
+
+            SyncError::ConcurrentWrite => 4,
+
+            SyncError::TableNotFound(_)
+            | SyncError::RelayNotFound(_)
+            | SyncError::InvalidUrl(_) => 5,
+
+            SyncError::D1Api { .. } | SyncError::BadRequest { .. } => 5,
+
+            _ => 1,
+        }
+    }
+}
+
 pub type Result<T> = std::result::Result<T, SyncError>;
 
 #[cfg(test)]
@@ -207,5 +241,92 @@ mod tests {
         let msg = format!("{}", err);
         assert!(msg.contains("5 attempts"));
         assert!(msg.contains("503"));
+    }
+
+    #[test]
+    fn test_exit_code_config_errors() {
+        assert_eq!(SyncError::Config("bad".into()).exit_code(), 2);
+        assert_eq!(SyncError::ConfigNotFound("x".into()).exit_code(), 2);
+        assert_eq!(
+            SyncError::InvalidTableName {
+                name: "x".into(),
+                available: "a, b".into()
+            }
+            .exit_code(),
+            2
+        );
+        assert_eq!(SyncError::NoPrimaryKey("t".into()).exit_code(), 2);
+        assert_eq!(
+            SyncError::ParamLimitExceeded {
+                table: "t".into(),
+                row_count: 1,
+                col_count: 100,
+                limit: 50
+            }
+            .exit_code(),
+            2
+        );
+    }
+
+    #[test]
+    fn test_exit_code_network_errors() {
+        assert_eq!(
+            SyncError::RateLimited {
+                retry_after: Some(30)
+            }
+            .exit_code(),
+            3
+        );
+        assert_eq!(
+            SyncError::ServerError {
+                status: 503,
+                message: "down".into()
+            }
+            .exit_code(),
+            3
+        );
+        assert_eq!(SyncError::ConnectionTimeout.exit_code(), 3);
+        assert_eq!(
+            SyncError::RetryExhausted {
+                attempts: 5,
+                last_error: "err".into()
+            }
+            .exit_code(),
+            3
+        );
+    }
+
+    #[test]
+    fn test_exit_code_conflict() {
+        assert_eq!(SyncError::ConcurrentWrite.exit_code(), 4);
+    }
+
+    #[test]
+    fn test_exit_code_not_found() {
+        assert_eq!(SyncError::TableNotFound("t".into()).exit_code(), 5);
+        assert_eq!(SyncError::RelayNotFound("r".into()).exit_code(), 5);
+        assert_eq!(SyncError::InvalidUrl("u".into()).exit_code(), 5);
+        assert_eq!(
+            SyncError::D1Api {
+                message: "err".into(),
+                code: None
+            }
+            .exit_code(),
+            5
+        );
+        assert_eq!(
+            SyncError::BadRequest {
+                status: 400,
+                message: "bad".into()
+            }
+            .exit_code(),
+            5
+        );
+    }
+
+    #[test]
+    fn test_exit_code_general() {
+        assert_eq!(SyncError::Remote("err".into()).exit_code(), 1);
+        assert_eq!(SyncError::Stash("err".into()).exit_code(), 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod datasource;
 mod diff;
 mod error;
 mod local;
+mod output;
 mod remote;
 mod stash;
 mod sync;
@@ -40,6 +41,10 @@ use crate::config::{Config, ResolvedTarget};
 use crate::datasource::DataSource;
 use crate::diff::diff_table;
 use crate::local::LocalDb;
+use crate::output::{
+    CommandOutput, DiffOutput, ErrorOutput, OutputFormat, StatusConfig, StatusDb, StatusOutput,
+    StatusTable,
+};
 use crate::remote::D1Client;
 use crate::sync::{get_tables_to_sync, pull_all, push_all, sync_all};
 use clap::{Parser, Subcommand};
@@ -62,6 +67,10 @@ struct Cli {
     /// Enable verbose output
     #[arg(short, long)]
     verbose: bool,
+
+    /// Output format: text (default) or json
+    #[arg(short, long, default_value = "text")]
+    output: OutputFormat,
 
     #[command(subcommand)]
     command: Commands,
@@ -146,31 +155,62 @@ enum Commands {
     },
 }
 
+/// Print a JSON error and exit with the appropriate code.
+fn exit_json_error(command: &'static str, err: &error::SyncError) -> ! {
+    let out = ErrorOutput {
+        command,
+        status: "error",
+        error: err.to_string(),
+        exit_code: err.exit_code(),
+    };
+    println!("{}", serde_json::to_string(&out).unwrap());
+    std::process::exit(err.exit_code());
+}
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    let fmt = cli.output;
 
-    // Set up logging
-    let level = if cli.verbose {
-        Level::DEBUG
-    } else {
-        Level::INFO
+    // Set up logging -- suppress tracing output in JSON mode so stdout is clean
+    let level = match fmt {
+        OutputFormat::Json => Level::WARN,
+        OutputFormat::Text if cli.verbose => Level::DEBUG,
+        OutputFormat::Text => Level::INFO,
     };
 
     let subscriber = FmtSubscriber::builder()
         .with_max_level(level)
         .with_target(false)
+        .with_writer(std::io::stderr)
         .compact()
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("Failed to set tracing subscriber");
 
+    // Determine command name for JSON output
+    let command_name: &'static str = match &cli.command {
+        Commands::Push { .. } => "push",
+        Commands::Pull { .. } => "pull",
+        Commands::Sync { .. } => "sync",
+        Commands::Diff { .. } => "diff",
+        Commands::Status => "status",
+        Commands::Stash { .. } => "stash",
+        Commands::Retrieve { .. } => "retrieve",
+        Commands::Watch { .. } => "watch",
+    };
+
     // Load config
     let config = match Config::load(&cli.config) {
         Ok(c) => c,
         Err(e) => {
-            error!("Failed to load config from {}: {}", cli.config.display(), e);
-            std::process::exit(1);
+            match fmt {
+                OutputFormat::Json => exit_json_error(command_name, &e),
+                OutputFormat::Text => {
+                    error!("Failed to load config from {}: {}", cli.config.display(), e)
+                }
+            }
+            std::process::exit(e.exit_code());
         }
     };
 
@@ -179,34 +219,48 @@ async fn main() {
     let target = match &cli.command {
         Commands::Stash { .. } | Commands::Retrieve { .. } => None,
         _ => Some(config.resolve_target().unwrap_or_else(|e| {
-            error!("Failed to resolve target: {}", e);
-            std::process::exit(1);
+            match fmt {
+                OutputFormat::Json => exit_json_error(command_name, &e),
+                OutputFormat::Text => error!("Failed to resolve target: {}", e),
+            }
+            std::process::exit(e.exit_code());
         })),
     };
 
     // Execute command
     let result = match cli.command {
         Commands::Push { table, dry_run } => {
-            run_push(&config, target.unwrap(), table, dry_run).await
+            run_push(&config, target.unwrap(), table, dry_run, fmt).await
         }
         Commands::Pull { table, dry_run } => {
-            run_pull(&config, target.unwrap(), table, dry_run).await
+            run_pull(&config, target.unwrap(), table, dry_run, fmt).await
         }
         Commands::Sync { table, dry_run } => {
-            run_sync(&config, target.unwrap(), table, dry_run).await
+            run_sync(&config, target.unwrap(), table, dry_run, fmt).await
         }
-        Commands::Diff { table } => run_diff(&config, target.unwrap(), table).await,
-        Commands::Status => run_status(&config, target.unwrap()).await,
-        Commands::Stash { table, dry_run } => run_stash(&config, table, dry_run).await,
-        Commands::Retrieve { table, dry_run } => run_retrieve(&config, table, dry_run).await,
+        Commands::Diff { table } => run_diff(&config, target.unwrap(), table, fmt).await,
+        Commands::Status => run_status(&config, target.unwrap(), fmt).await,
+        Commands::Stash { table, dry_run } => run_stash(&config, table, dry_run, fmt).await,
+        Commands::Retrieve { table, dry_run } => run_retrieve(&config, table, dry_run, fmt).await,
         Commands::Watch { interval, dry_run } => {
-            watch::run_watch(&config, &config_path, target.unwrap(), interval, dry_run).await
+            watch::run_watch(
+                &config,
+                &config_path,
+                target.unwrap(),
+                interval,
+                dry_run,
+                fmt,
+            )
+            .await
         }
     };
 
     if let Err(e) = result {
-        error!("Error: {}", e);
-        std::process::exit(1);
+        match fmt {
+            OutputFormat::Json => exit_json_error(command_name, &e),
+            OutputFormat::Text => error!("Error: {}", e),
+        }
+        std::process::exit(e.exit_code());
     }
 }
 
@@ -237,11 +291,12 @@ async fn run_push(
     target: ResolvedTarget,
     table: Option<String>,
     dry_run: bool,
+    fmt: OutputFormat,
 ) -> error::Result<()> {
     let local = LocalDb::open_readonly(config.local_db_path())?;
     let tables = resolve_tables(&local, table)?;
 
-    match target {
+    let results = match target {
         ResolvedTarget::D1 {
             account_id,
             database_id,
@@ -250,13 +305,21 @@ async fn run_push(
             info!("Push mode: local -> D1");
             let remote = open_d1(&account_id, &database_id, &api_token, config);
             remote.test_connection().await?;
-            let results = push_all(&local, &remote, config, tables, dry_run).await?;
-            print_summary("Push", &results, |r| r.rows_pushed, "push", dry_run);
+            push_all(&local, &remote, config, tables, dry_run).await?
         }
         ResolvedTarget::Sqlite { database } => {
             info!("Push mode: local -> SQLite ({})", database);
             let target_db = LocalDb::open(&database)?;
-            let results = push_all(&local, &target_db, config, tables, dry_run).await?;
+            push_all(&local, &target_db, config, tables, dry_run).await?
+        }
+    };
+
+    match fmt {
+        OutputFormat::Json => {
+            let out = CommandOutput::from_sync_results("push", &results, dry_run);
+            println!("{}", serde_json::to_string(&out).unwrap());
+        }
+        OutputFormat::Text => {
             print_summary("Push", &results, |r| r.rows_pushed, "push", dry_run);
         }
     }
@@ -268,11 +331,12 @@ async fn run_pull(
     target: ResolvedTarget,
     table: Option<String>,
     dry_run: bool,
+    fmt: OutputFormat,
 ) -> error::Result<()> {
     let local = LocalDb::open(config.local_db_path())?;
     let tables = resolve_tables(&local, table)?;
 
-    match target {
+    let results = match target {
         ResolvedTarget::D1 {
             account_id,
             database_id,
@@ -281,13 +345,21 @@ async fn run_pull(
             info!("Pull mode: D1 -> local");
             let remote = open_d1(&account_id, &database_id, &api_token, config);
             remote.test_connection().await?;
-            let results = pull_all(&local, &remote, config, tables, dry_run).await?;
-            print_summary("Pull", &results, |r| r.rows_pulled, "pull", dry_run);
+            pull_all(&local, &remote, config, tables, dry_run).await?
         }
         ResolvedTarget::Sqlite { database } => {
             info!("Pull mode: SQLite ({}) -> local", database);
             let source_db = LocalDb::open_readonly(&database)?;
-            let results = pull_all(&local, &source_db, config, tables, dry_run).await?;
+            pull_all(&local, &source_db, config, tables, dry_run).await?
+        }
+    };
+
+    match fmt {
+        OutputFormat::Json => {
+            let out = CommandOutput::from_sync_results("pull", &results, dry_run);
+            println!("{}", serde_json::to_string(&out).unwrap());
+        }
+        OutputFormat::Text => {
             print_summary("Pull", &results, |r| r.rows_pulled, "pull", dry_run);
         }
     }
@@ -299,6 +371,7 @@ async fn run_sync(
     target: ResolvedTarget,
     table: Option<String>,
     dry_run: bool,
+    fmt: OutputFormat,
 ) -> error::Result<()> {
     let local = LocalDb::open(config.local_db_path())?;
     let tables = resolve_tables(&local, table)?;
@@ -321,24 +394,31 @@ async fn run_sync(
         }
     };
 
-    println!("\n--- Sync Summary ---");
-    let mut total_pushed = 0;
-    let mut total_pulled = 0;
-    for result in &results {
-        if result.has_changes() {
-            println!(
-                "  {}: {} pushed, {} pulled",
-                result.table, result.rows_pushed, result.rows_pulled
-            );
-            total_pushed += result.rows_pushed;
-            total_pulled += result.rows_pulled;
+    match fmt {
+        OutputFormat::Json => {
+            let out = CommandOutput::from_sync_results("sync", &results, dry_run);
+            println!("{}", serde_json::to_string(&out).unwrap());
         }
-    }
-
-    if total_pushed == 0 && total_pulled == 0 {
-        println!("  No changes to sync");
-    } else if dry_run {
-        println!("\n  (dry run - no actual changes made)");
+        OutputFormat::Text => {
+            println!("\n--- Sync Summary ---");
+            let mut total_pushed = 0;
+            let mut total_pulled = 0;
+            for result in &results {
+                if result.has_changes() {
+                    println!(
+                        "  {}: {} pushed, {} pulled",
+                        result.table, result.rows_pushed, result.rows_pulled
+                    );
+                    total_pushed += result.rows_pushed;
+                    total_pulled += result.rows_pulled;
+                }
+            }
+            if total_pushed == 0 && total_pulled == 0 {
+                println!("  No changes to sync");
+            } else if dry_run {
+                println!("\n  (dry run - no actual changes made)");
+            }
+        }
     }
 
     Ok(())
@@ -348,6 +428,7 @@ async fn run_diff(
     config: &Config,
     target: ResolvedTarget,
     table: Option<String>,
+    fmt: OutputFormat,
 ) -> error::Result<()> {
     info!("Computing differences...");
     let local = LocalDb::open_readonly(config.local_db_path())?;
@@ -368,7 +449,7 @@ async fn run_diff(
                 }
                 None => get_tables_to_sync(&local, &remote, config).await?,
             };
-            print_diffs(&local, &remote, &tables, &config.sync.timestamp_column).await
+            output_diffs(&local, &remote, &tables, &config.sync.timestamp_column, fmt).await
         }
         ResolvedTarget::Sqlite { database } => {
             let target_db = LocalDb::open_readonly(&database)?;
@@ -380,40 +461,60 @@ async fn run_diff(
                 }
                 None => get_tables_to_sync(&local, &target_db, config).await?,
             };
-            print_diffs(&local, &target_db, &tables, &config.sync.timestamp_column).await
+            output_diffs(
+                &local,
+                &target_db,
+                &tables,
+                &config.sync.timestamp_column,
+                fmt,
+            )
+            .await
         }
     }
 }
 
-async fn print_diffs<A: DataSource, B: DataSource>(
+async fn output_diffs<A: DataSource, B: DataSource>(
     local: &A,
     remote: &B,
     tables: &[String],
     timestamp_column: &str,
+    fmt: OutputFormat,
 ) -> error::Result<()> {
-    println!("\n--- Differences ---");
-    let mut has_any_changes = false;
-
+    let mut diffs = Vec::new();
     for table_name in tables {
         let diff = diff_table(local, remote, table_name, timestamp_column).await?;
-
-        if diff.has_changes() {
-            has_any_changes = true;
-            println!("\n{}", table_name);
-            println!("  {}", diff.summary());
-
-            print_diff_category("Local only", &diff.local_only);
-            print_diff_category("Remote only", &diff.remote_only);
-            print_diff_category("Local newer", &diff.local_newer);
-            print_diff_category("Remote newer", &diff.remote_newer);
-            print_diff_category("Content differs", &diff.content_differs);
-        } else {
-            println!("\n{}: in sync ({} rows)", table_name, diff.identical.len());
-        }
+        diffs.push((table_name.clone(), diff));
     }
 
-    if !has_any_changes {
-        println!("\nAll tables are in sync!");
+    match fmt {
+        OutputFormat::Json => {
+            let out = DiffOutput::from_diffs(diffs);
+            println!("{}", serde_json::to_string(&out).unwrap());
+        }
+        OutputFormat::Text => {
+            println!("\n--- Differences ---");
+            let mut has_any_changes = false;
+
+            for (table_name, diff) in &diffs {
+                if diff.has_changes() {
+                    has_any_changes = true;
+                    println!("\n{}", table_name);
+                    println!("  {}", diff.summary());
+
+                    print_diff_category("Local only", &diff.local_only);
+                    print_diff_category("Remote only", &diff.remote_only);
+                    print_diff_category("Local newer", &diff.local_newer);
+                    print_diff_category("Remote newer", &diff.remote_newer);
+                    print_diff_category("Content differs", &diff.content_differs);
+                } else {
+                    println!("\n{}: in sync ({} rows)", table_name, diff.identical.len());
+                }
+            }
+
+            if !has_any_changes {
+                println!("\nAll tables are in sync!");
+            }
+        }
     }
 
     Ok(())
@@ -459,107 +560,195 @@ fn print_diff_category(label: &str, keys: &[String]) {
     }
 }
 
-async fn run_status(config: &Config, target: ResolvedTarget) -> error::Result<()> {
-    println!("--- Configuration ---");
-    println!("  Config file: loaded");
-    println!("  Local DB: {}", config.local_db_path());
+async fn run_status(
+    config: &Config,
+    target: ResolvedTarget,
+    fmt: OutputFormat,
+) -> error::Result<()> {
+    let target_type = match &target {
+        ResolvedTarget::D1 { .. } => "d1",
+        ResolvedTarget::Sqlite { .. } => "sqlite",
+    };
 
-    match &target {
-        ResolvedTarget::D1 {
-            account_id,
-            database_id,
-            ..
-        } => {
-            println!("  Target: D1");
-            println!(
-                "  Account ID: {}...",
-                &account_id[..8.min(account_id.len())]
-            );
-            println!(
-                "  Database ID: {}...",
-                &database_id[..8.min(database_id.len())]
-            );
-        }
-        ResolvedTarget::Sqlite { database } => {
-            println!("  Target: SQLite ({})", database);
-        }
-    }
-
-    println!("  Timestamp column: {}", config.sync.timestamp_column);
-    println!(
-        "  Conflict resolution: {:?}",
-        config.sync.conflict_resolution
-    );
-
-    if !config.sync.tables.is_empty() {
-        println!("  Tables (explicit): {}", config.sync.tables.join(", "));
-    }
-    if !config.sync.exclude_tables.is_empty() {
-        println!(
-            "  Excluded tables: {}",
-            config.sync.exclude_tables.join(", ")
-        );
-    }
-
-    // Test local connection
-    println!("\n--- Local Database ---");
-    match LocalDb::open_readonly(config.local_db_path()) {
+    // Gather local DB info
+    let local_status = match LocalDb::open_readonly(config.local_db_path()) {
         Ok(local) => {
-            println!("  Connection: OK");
             let tables = local.list_tables().await?;
-            println!("  Tables: {}", tables.len());
-
+            let mut table_rows = Vec::new();
             for table in &tables {
                 if config.should_sync_table(table) {
                     let count = local.row_count(table).await?;
-                    println!("    {}: {} rows", table, count);
+                    table_rows.push(StatusTable {
+                        name: table.clone(),
+                        rows: count,
+                    });
                 }
             }
+            StatusDb {
+                connected: true,
+                error: None,
+                tables: table_rows,
+            }
         }
-        Err(e) => {
-            println!("  Connection: FAILED - {}", e);
-        }
-    }
+        Err(e) => StatusDb {
+            connected: false,
+            error: Some(e.to_string()),
+            tables: vec![],
+        },
+    };
 
-    // Test target connection
-    match target {
+    // Gather target info
+    let target_status = match &target {
         ResolvedTarget::D1 {
             account_id,
             database_id,
             api_token,
         } => {
-            println!("\n--- Remote D1 ---");
-            let remote = open_d1(&account_id, &database_id, &api_token, config);
+            let remote = open_d1(account_id, database_id, api_token, config);
             match remote.test_connection().await {
                 Ok(()) => {
-                    println!("  Connection: OK");
                     let tables = remote.list_tables().await?;
-                    println!("  Tables: {}", tables.len());
+                    let mut table_rows = Vec::new();
                     for table in &tables {
                         if config.should_sync_table(table) {
                             let count = remote.row_count(table).await?;
-                            println!("    {}: {} rows", table, count);
+                            table_rows.push(StatusTable {
+                                name: table.clone(),
+                                rows: count,
+                            });
                         }
                     }
+                    StatusDb {
+                        connected: true,
+                        error: None,
+                        tables: table_rows,
+                    }
                 }
-                Err(e) => println!("  Connection: FAILED - {}", e),
+                Err(e) => StatusDb {
+                    connected: false,
+                    error: Some(e.to_string()),
+                    tables: vec![],
+                },
             }
         }
-        ResolvedTarget::Sqlite { database } => {
-            println!("\n--- Target SQLite ---");
-            match LocalDb::open_readonly(&database) {
-                Ok(target_db) => {
-                    println!("  Connection: OK");
-                    let tables = target_db.list_tables().await?;
-                    println!("  Tables: {}", tables.len());
-                    for table in &tables {
-                        if config.should_sync_table(table) {
-                            let count = target_db.row_count(table).await?;
-                            println!("    {}: {} rows", table, count);
-                        }
+        ResolvedTarget::Sqlite { database } => match LocalDb::open_readonly(database) {
+            Ok(target_db) => {
+                let tables = target_db.list_tables().await?;
+                let mut table_rows = Vec::new();
+                for table in &tables {
+                    if config.should_sync_table(table) {
+                        let count = target_db.row_count(table).await?;
+                        table_rows.push(StatusTable {
+                            name: table.clone(),
+                            rows: count,
+                        });
                     }
                 }
-                Err(e) => println!("  Connection: FAILED - {}", e),
+                StatusDb {
+                    connected: true,
+                    error: None,
+                    tables: table_rows,
+                }
+            }
+            Err(e) => StatusDb {
+                connected: false,
+                error: Some(e.to_string()),
+                tables: vec![],
+            },
+        },
+    };
+
+    match fmt {
+        OutputFormat::Json => {
+            let out = StatusOutput {
+                command: "status",
+                status: "ok",
+                config: StatusConfig {
+                    local_db: config.local_db_path().to_string(),
+                    target_type: target_type.to_string(),
+                    timestamp_column: config.sync.timestamp_column.clone(),
+                    conflict_resolution: format!("{:?}", config.sync.conflict_resolution),
+                    tables: config.sync.tables.clone(),
+                    exclude_tables: config.sync.exclude_tables.clone(),
+                },
+                local: local_status,
+                target: target_status,
+            };
+            println!("{}", serde_json::to_string(&out).unwrap());
+        }
+        OutputFormat::Text => {
+            println!("--- Configuration ---");
+            println!("  Config file: loaded");
+            println!("  Local DB: {}", config.local_db_path());
+
+            match &target {
+                ResolvedTarget::D1 {
+                    account_id,
+                    database_id,
+                    ..
+                } => {
+                    println!("  Target: D1");
+                    println!(
+                        "  Account ID: {}...",
+                        &account_id[..8.min(account_id.len())]
+                    );
+                    println!(
+                        "  Database ID: {}...",
+                        &database_id[..8.min(database_id.len())]
+                    );
+                }
+                ResolvedTarget::Sqlite { database } => {
+                    println!("  Target: SQLite ({})", database);
+                }
+            }
+
+            println!("  Timestamp column: {}", config.sync.timestamp_column);
+            println!(
+                "  Conflict resolution: {:?}",
+                config.sync.conflict_resolution
+            );
+
+            if !config.sync.tables.is_empty() {
+                println!("  Tables (explicit): {}", config.sync.tables.join(", "));
+            }
+            if !config.sync.exclude_tables.is_empty() {
+                println!(
+                    "  Excluded tables: {}",
+                    config.sync.exclude_tables.join(", ")
+                );
+            }
+
+            // Local DB
+            println!("\n--- Local Database ---");
+            if local_status.connected {
+                println!("  Connection: OK");
+                println!("  Tables: {}", local_status.tables.len());
+                for t in &local_status.tables {
+                    println!("    {}: {} rows", t.name, t.rows);
+                }
+            } else {
+                println!(
+                    "  Connection: FAILED - {}",
+                    local_status.error.as_deref().unwrap_or("unknown")
+                );
+            }
+
+            // Target
+            match &target {
+                ResolvedTarget::D1 { .. } => println!("\n--- Remote D1 ---"),
+                ResolvedTarget::Sqlite { .. } => println!("\n--- Target SQLite ---"),
+            }
+            if target_status.connected {
+                println!("  Connection: OK");
+                println!("  Tables: {}", target_status.tables.len());
+                for t in &target_status.tables {
+                    println!("    {}: {} rows", t.name, t.rows);
+                }
+            } else {
+                println!(
+                    "  Connection: FAILED - {}",
+                    target_status.error.as_deref().unwrap_or("unknown")
+                );
             }
         }
     }
@@ -574,7 +763,12 @@ fn require_stash_config(config: &Config) -> error::Result<&config::StashConfig> 
         .ok_or_else(|| error::SyncError::Config("No [stash] section in config".into()))
 }
 
-async fn run_stash(config: &Config, table: Option<String>, dry_run: bool) -> error::Result<()> {
+async fn run_stash(
+    config: &Config,
+    table: Option<String>,
+    dry_run: bool,
+    fmt: OutputFormat,
+) -> error::Result<()> {
     let stash_config = require_stash_config(config)?;
     info!("Stash mode: local -> S3 relay");
 
@@ -589,11 +783,24 @@ async fn run_stash(config: &Config, table: Option<String>, dry_run: bool) -> err
     )
     .await?;
 
-    print_summary("Stash", &results, |r| r.rows_pushed, "stash", dry_run);
+    match fmt {
+        OutputFormat::Json => {
+            let out = CommandOutput::from_sync_results("stash", &results, dry_run);
+            println!("{}", serde_json::to_string(&out).unwrap());
+        }
+        OutputFormat::Text => {
+            print_summary("Stash", &results, |r| r.rows_pushed, "stash", dry_run);
+        }
+    }
     Ok(())
 }
 
-async fn run_retrieve(config: &Config, table: Option<String>, dry_run: bool) -> error::Result<()> {
+async fn run_retrieve(
+    config: &Config,
+    table: Option<String>,
+    dry_run: bool,
+    fmt: OutputFormat,
+) -> error::Result<()> {
     let stash_config = require_stash_config(config)?;
     info!("Retrieve mode: S3 relay -> local");
 
@@ -608,6 +815,14 @@ async fn run_retrieve(config: &Config, table: Option<String>, dry_run: bool) -> 
     )
     .await?;
 
-    print_summary("Retrieve", &results, |r| r.rows_pulled, "retrieve", dry_run);
+    match fmt {
+        OutputFormat::Json => {
+            let out = CommandOutput::from_sync_results("retrieve", &results, dry_run);
+            println!("{}", serde_json::to_string(&out).unwrap());
+        }
+        OutputFormat::Text => {
+            print_summary("Retrieve", &results, |r| r.rows_pulled, "retrieve", dry_run);
+        }
+    }
     Ok(())
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,359 @@
+//! Structured output for agent-friendly JSON responses.
+//!
+//! When `--output json` is passed, commands emit a single JSON object to stdout
+//! instead of human-readable text. The watch daemon emits one JSON line per tick
+//! (JSONL format).
+
+use crate::diff::TableDiff;
+use crate::sync::SyncResult;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+impl std::str::FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            _ => Err(format!(
+                "invalid output format '{}', expected 'text' or 'json'",
+                s
+            )),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct CommandOutput {
+    pub command: &'static str,
+    pub status: &'static str,
+    pub dry_run: bool,
+    pub tables: Vec<TableOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct TableOutput {
+    pub name: String,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub rows_pushed: usize,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub rows_pulled: usize,
+}
+
+fn is_zero(n: &usize) -> bool {
+    *n == 0
+}
+
+#[derive(Serialize)]
+pub struct DiffOutput {
+    pub command: &'static str,
+    pub status: &'static str,
+    pub tables: Vec<TableDiffOutput>,
+}
+
+#[derive(Serialize)]
+pub struct TableDiffOutput {
+    pub name: String,
+    pub local_only: Vec<String>,
+    pub remote_only: Vec<String>,
+    pub local_newer: Vec<String>,
+    pub remote_newer: Vec<String>,
+    pub content_differs: Vec<String>,
+    pub identical_count: usize,
+}
+
+#[derive(Serialize)]
+pub struct StatusOutput {
+    pub command: &'static str,
+    pub status: &'static str,
+    pub config: StatusConfig,
+    pub local: StatusDb,
+    pub target: StatusDb,
+}
+
+#[derive(Serialize)]
+pub struct StatusConfig {
+    pub local_db: String,
+    pub target_type: String,
+    pub timestamp_column: String,
+    pub conflict_resolution: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tables: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub exclude_tables: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct StatusDb {
+    pub connected: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub tables: Vec<StatusTable>,
+}
+
+#[derive(Serialize)]
+pub struct StatusTable {
+    pub name: String,
+    pub rows: usize,
+}
+
+#[derive(Serialize)]
+pub struct WatchTickOutput {
+    pub command: &'static str,
+    pub tick: u64,
+    pub status: &'static str,
+    pub tables: Vec<TableOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ErrorOutput {
+    pub command: &'static str,
+    pub status: &'static str,
+    pub error: String,
+    pub exit_code: i32,
+}
+
+impl CommandOutput {
+    pub fn from_sync_results(command: &'static str, results: &[SyncResult], dry_run: bool) -> Self {
+        Self {
+            command,
+            status: "ok",
+            dry_run,
+            tables: results
+                .iter()
+                .filter(|r| r.has_changes())
+                .map(|r| TableOutput {
+                    name: r.table.clone(),
+                    rows_pushed: r.rows_pushed,
+                    rows_pulled: r.rows_pulled,
+                })
+                .collect(),
+            error: None,
+        }
+    }
+}
+
+impl DiffOutput {
+    pub fn from_diffs(diffs: Vec<(String, TableDiff)>) -> Self {
+        Self {
+            command: "diff",
+            status: "ok",
+            tables: diffs
+                .into_iter()
+                .map(|(name, d)| TableDiffOutput {
+                    name,
+                    identical_count: d.identical.len(),
+                    local_only: d.local_only,
+                    remote_only: d.remote_only,
+                    local_newer: d.local_newer,
+                    remote_newer: d.remote_newer,
+                    content_differs: d.content_differs,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl WatchTickOutput {
+    pub fn from_results(tick: u64, results: &[SyncResult]) -> Self {
+        Self {
+            command: "watch",
+            tick,
+            status: "ok",
+            tables: results
+                .iter()
+                .filter(|r| r.has_changes())
+                .map(|r| TableOutput {
+                    name: r.table.clone(),
+                    rows_pushed: r.rows_pushed,
+                    rows_pulled: r.rows_pulled,
+                })
+                .collect(),
+            error: None,
+        }
+    }
+
+    pub fn from_error(tick: u64, err: &str) -> Self {
+        Self {
+            command: "watch",
+            tick,
+            status: "error",
+            tables: vec![],
+            error: Some(err.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::TableDiff;
+    use crate::sync::SyncResult;
+
+    #[test]
+    fn test_output_format_parse() {
+        assert_eq!("text".parse::<OutputFormat>().unwrap(), OutputFormat::Text);
+        assert_eq!("json".parse::<OutputFormat>().unwrap(), OutputFormat::Json);
+        assert!("xml".parse::<OutputFormat>().is_err());
+    }
+
+    #[test]
+    fn test_command_output_json_serialization() {
+        let results = vec![
+            SyncResult {
+                table: "abilities".into(),
+                rows_pushed: 42,
+                rows_pulled: 0,
+            },
+            SyncResult {
+                table: "items".into(),
+                rows_pushed: 0,
+                rows_pulled: 0,
+            },
+        ];
+
+        let out = CommandOutput::from_sync_results("push", &results, false);
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["command"], "push");
+        assert_eq!(v["status"], "ok");
+        assert_eq!(v["dry_run"], false);
+        // Only abilities should appear (items had 0 changes)
+        assert_eq!(v["tables"].as_array().unwrap().len(), 1);
+        assert_eq!(v["tables"][0]["name"], "abilities");
+        assert_eq!(v["tables"][0]["rows_pushed"], 42);
+        // error should be absent (skip_serializing_if)
+        assert!(v.get("error").is_none());
+    }
+
+    #[test]
+    fn test_command_output_dry_run() {
+        let results = vec![SyncResult {
+            table: "t".into(),
+            rows_pushed: 10,
+            rows_pulled: 5,
+        }];
+
+        let out = CommandOutput::from_sync_results("sync", &results, true);
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["dry_run"], true);
+        assert_eq!(v["tables"][0]["rows_pushed"], 10);
+        assert_eq!(v["tables"][0]["rows_pulled"], 5);
+    }
+
+    #[test]
+    fn test_diff_output_json_serialization() {
+        let mut diff = TableDiff::new("abilities");
+        diff.local_only = vec!["pk1".into(), "pk2".into()];
+        diff.remote_only = vec!["pk3".into()];
+        diff.identical = vec!["pk4".into(), "pk5".into()];
+
+        let out = DiffOutput::from_diffs(vec![("abilities".into(), diff)]);
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["command"], "diff");
+        assert_eq!(v["tables"][0]["name"], "abilities");
+        assert_eq!(v["tables"][0]["local_only"].as_array().unwrap().len(), 2);
+        assert_eq!(v["tables"][0]["remote_only"].as_array().unwrap().len(), 1);
+        assert_eq!(v["tables"][0]["identical_count"], 2);
+    }
+
+    #[test]
+    fn test_watch_tick_output() {
+        let results = vec![SyncResult {
+            table: "t".into(),
+            rows_pushed: 3,
+            rows_pulled: 7,
+        }];
+
+        let out = WatchTickOutput::from_results(5, &results);
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["command"], "watch");
+        assert_eq!(v["tick"], 5);
+        assert_eq!(v["status"], "ok");
+        assert!(v.get("error").is_none());
+    }
+
+    #[test]
+    fn test_watch_tick_error_output() {
+        let out = WatchTickOutput::from_error(3, "connection timeout");
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["tick"], 3);
+        assert_eq!(v["error"], "connection timeout");
+    }
+
+    #[test]
+    fn test_error_output_json() {
+        let out = ErrorOutput {
+            command: "push",
+            status: "error",
+            error: "Config file not found".into(),
+            exit_code: 2,
+        };
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["command"], "push");
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["exit_code"], 2);
+    }
+
+    #[test]
+    fn test_status_output_json() {
+        let out = StatusOutput {
+            command: "status",
+            status: "ok",
+            config: StatusConfig {
+                local_db: "game.db".into(),
+                target_type: "sqlite".into(),
+                timestamp_column: "updated_at".into(),
+                conflict_resolution: "NewerWins".into(),
+                tables: vec![],
+                exclude_tables: vec![],
+            },
+            local: StatusDb {
+                connected: true,
+                error: None,
+                tables: vec![StatusTable {
+                    name: "abilities".into(),
+                    rows: 100,
+                }],
+            },
+            target: StatusDb {
+                connected: true,
+                error: None,
+                tables: vec![StatusTable {
+                    name: "abilities".into(),
+                    rows: 95,
+                }],
+            },
+        };
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["command"], "status");
+        assert_eq!(v["config"]["local_db"], "game.db");
+        assert_eq!(v["local"]["connected"], true);
+        assert_eq!(v["local"]["tables"][0]["rows"], 100);
+        assert_eq!(v["target"]["tables"][0]["rows"], 95);
+    }
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -8,6 +8,7 @@
 use crate::config::{Config, ResolvedTarget};
 use crate::error::{Result, SyncError};
 use crate::local::LocalDb;
+use crate::output::{OutputFormat, WatchTickOutput};
 use crate::remote::D1Client;
 use crate::sync::sync_all;
 use std::fs;
@@ -218,6 +219,7 @@ pub async fn run_watch(
     target: ResolvedTarget,
     interval_secs: u64,
     dry_run: bool,
+    fmt: OutputFormat,
 ) -> Result<()> {
     let pid_path = pid_lock_path(config_path);
     let _pid_lock = PidLock::acquire(&pid_path)?;
@@ -247,6 +249,10 @@ pub async fn run_watch(
                         );
                         if let Err(e) = remote.test_connection().await {
                             warn!("Connection test failed on tick #{}: {}. Will retry next tick.", tick_count, e);
+                            if fmt == OutputFormat::Json {
+                                let out = WatchTickOutput::from_error(tick_count, &e.to_string());
+                                println!("{}", serde_json::to_string(&out).unwrap());
+                            }
                             continue;
                         }
                         sync_all(&local, &remote, config, None, dry_run).await
@@ -263,7 +269,10 @@ pub async fn run_watch(
                         let total_pushed: usize = results.iter().map(|r| r.rows_pushed).sum();
                         let total_pulled: usize = results.iter().map(|r| r.rows_pulled).sum();
 
-                        if total_pushed > 0 || total_pulled > 0 {
+                        if fmt == OutputFormat::Json {
+                            let out = WatchTickOutput::from_results(tick_count, &results);
+                            println!("{}", serde_json::to_string(&out).unwrap());
+                        } else if total_pushed > 0 || total_pulled > 0 {
                             info!(
                                 "Tick #{}: {} pushed, {} pulled across {} tables",
                                 tick_count, total_pushed, total_pulled, results.len()
@@ -282,8 +291,16 @@ pub async fn run_watch(
                     Err(e) => {
                         if is_transient_error(&e) {
                             warn!("Transient error on tick #{}: {}. Will retry next tick.", tick_count, e);
+                            if fmt == OutputFormat::Json {
+                                let out = WatchTickOutput::from_error(tick_count, &e.to_string());
+                                println!("{}", serde_json::to_string(&out).unwrap());
+                            }
                         } else {
                             error!("Fatal error on tick #{}: {}", tick_count, e);
+                            if fmt == OutputFormat::Json {
+                                let out = WatchTickOutput::from_error(tick_count, &e.to_string());
+                                println!("{}", serde_json::to_string(&out).unwrap());
+                            }
                             return Err(e);
                         }
                     }


### PR DESCRIPTION
## Summary

- Adds `--output json` (`-o json`) global flag across all 8 commands (push, pull, sync, diff, status, stash, retrieve, watch)
- Adds structured exit codes: 0=success, 2=config error, 3=network/transient, 4=conflict, 5=not-found, 1=general
- Watch daemon emits JSONL (one JSON line per tick) for stream parsing
- JSON mode routes tracing to stderr so stdout is clean machine-parseable output
- New `src/output.rs` module with typed structs: `CommandOutput`, `DiffOutput`, `StatusOutput`, `WatchTickOutput`, `ErrorOutput`
- Text output is unchanged (backward compatible)

## Example

```
$ smuggler --output json -c missing.toml status
{"command":"status","status":"error","error":"Config file not found: missing.toml","exit_code":2}
$ echo $?
2
```

## Test plan

- [x] 110 tests passing (13 new for output structs and exit codes)
- [x] cargo clippy clean
- [x] cargo fmt clean
- [x] Verified JSON error output with missing config (exit code 2)
- [x] Verified text mode backward compatibility

Closes #32, closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)