### PR TITLE
feat: XChaCha20-Poly1305 encryption for broadcast packets (#45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +164,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
+dependencies = [
+ "stream-cipher",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b0c90556d8e3fec7cf18d84a2f53d27b21288f2fe481b830fadcf809e48205"
+dependencies = [
+ "aead",
+ "chacha20",
+ "poly1305",
+ "stream-cipher",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +291,12 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crypto-common"
@@ -1174,6 +1212,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "poly1305"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
+dependencies = [
+ "cpuid-bool",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,11 +1719,13 @@ name = "smuggler"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "chacha20poly1305",
  "clap",
  "hex",
  "indicatif",
  "libc",
  "object_store",
+ "rand",
  "reqwest",
  "rusqlite",
  "serde",
@@ -1705,6 +1755,15 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stream-cipher"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "strsim"
@@ -2068,6 +2127,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ tempfile = "3"
 # Progress display
 indicatif = "0.17"
 
+# Encryption (broadcast packets)
+chacha20poly1305 = "0.5"
+rand = "0.9"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -8,6 +8,9 @@
 //! handling UDP size limits by splitting large deltas into multiple parts.
 
 use crate::error::{Result, SyncError};
+use chacha20poly1305::aead::{Aead, NewAead};
+use chacha20poly1305::{XChaCha20Poly1305, XNonce};
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -32,6 +35,9 @@ const PEER_TTL_MULTIPLIER: u64 = 3;
 /// Maximum size of a UDP announcement packet.
 const MAX_PACKET_SIZE: usize = 1024;
 
+/// Minimum encrypted packet size: 24-byte nonce + 16-byte Poly1305 tag.
+const ENCRYPTION_OVERHEAD: usize = 24 + 16;
+
 /// Configuration for LAN broadcast sync.
 #[derive(Debug, Clone, Deserialize)]
 pub struct BroadcastConfig {
@@ -45,6 +51,10 @@ pub struct BroadcastConfig {
 
     /// Instance identity (defaults to hostname)
     pub instance_id: Option<String>,
+
+    /// 256-bit pre-shared key, hex-encoded (64 hex chars).
+    /// When set, all broadcast traffic is encrypted with XChaCha20-Poly1305.
+    pub secret: Option<String>,
 }
 
 fn default_port() -> u16 {
@@ -61,6 +71,7 @@ impl Default for BroadcastConfig {
             port: DEFAULT_PORT,
             interval_secs: DEFAULT_INTERVAL_SECS,
             instance_id: None,
+            secret: None,
         }
     }
 }
@@ -76,6 +87,27 @@ impl BroadcastConfig {
     /// Peer TTL based on broadcast interval.
     pub fn peer_ttl(&self) -> Duration {
         Duration::from_secs(self.interval_secs * PEER_TTL_MULTIPLIER)
+    }
+
+    /// Parse the hex-encoded secret into a 256-bit key.
+    /// Returns None if no secret is configured.
+    pub fn encryption_key(&self) -> Result<Option<[u8; 32]>> {
+        match &self.secret {
+            None => Ok(None),
+            Some(hex_key) => {
+                let bytes = hex::decode(hex_key).map_err(|_| {
+                    SyncError::Config(
+                        "broadcast secret must be 64 hex characters (256-bit key)".to_string(),
+                    )
+                })?;
+                let key: [u8; 32] = bytes.try_into().map_err(|_| {
+                    SyncError::Config(
+                        "broadcast secret must be 64 hex characters (256-bit key)".to_string(),
+                    )
+                })?;
+                Ok(Some(key))
+            }
+        }
     }
 }
 
@@ -138,6 +170,81 @@ impl Announcement {
     }
 }
 
+/// Encrypt a serialized packet for broadcast.
+///
+/// Wire format: `[24-byte nonce][ciphertext + 16-byte Poly1305 tag]`
+fn encrypt_packet(plaintext: &[u8], key: &[u8; 32]) -> Result<Vec<u8>> {
+    let cipher = XChaCha20Poly1305::new(key.into());
+
+    let mut nonce_bytes = [0u8; 24];
+    rand::rng().fill_bytes(&mut nonce_bytes);
+    let nonce = XNonce::from_slice(&nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|_| SyncError::Broadcast("encryption failed".to_string()))?;
+
+    let mut packet = Vec::with_capacity(24 + ciphertext.len());
+    packet.extend_from_slice(&nonce_bytes);
+    packet.extend_from_slice(&ciphertext);
+    Ok(packet)
+}
+
+/// Decrypt a received packet.
+///
+/// Expects wire format: `[24-byte nonce][ciphertext + 16-byte Poly1305 tag]`
+fn decrypt_packet(data: &[u8], key: &[u8; 32]) -> Result<Vec<u8>> {
+    if data.len() < ENCRYPTION_OVERHEAD {
+        return Err(SyncError::Broadcast(format!(
+            "packet too short ({} bytes, minimum {})",
+            data.len(),
+            ENCRYPTION_OVERHEAD
+        )));
+    }
+
+    let (nonce_bytes, ciphertext) = data.split_at(24);
+    let nonce = XNonce::from_slice(nonce_bytes);
+    let cipher = XChaCha20Poly1305::new(key.into());
+
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| SyncError::Broadcast("authentication failed".to_string()))
+}
+
+/// Wrap plaintext in an encryption envelope if a key is provided.
+/// If no key, returns the plaintext as-is.
+pub fn maybe_encrypt(plaintext: &[u8], key: &Option<[u8; 32]>) -> Result<Vec<u8>> {
+    match key {
+        Some(k) => encrypt_packet(plaintext, k),
+        None => Ok(plaintext.to_vec()),
+    }
+}
+
+/// Unwrap a potentially encrypted packet.
+/// If a key is configured but the packet is too short to be encrypted, warns and drops.
+/// If no key is configured but the packet looks encrypted (not valid JSON), warns and drops.
+pub fn maybe_decrypt(data: &[u8], key: &Option<[u8; 32]>) -> Result<Option<Vec<u8>>> {
+    match key {
+        Some(k) => {
+            if data.len() < ENCRYPTION_OVERHEAD {
+                warn!(
+                    "Dropping packet: too short for encrypted mode ({} bytes)",
+                    data.len()
+                );
+                return Ok(None);
+            }
+            Ok(Some(decrypt_packet(data, k)?))
+        }
+        None => {
+            if data.first() != Some(&b'{') && data.first() != Some(&b'[') {
+                warn!("Dropping encrypted packet: no secret configured");
+                return Ok(None);
+            }
+            Ok(Some(data.to_vec()))
+        }
+    }
+}
+
 /// Manages peer discovery via UDP subnet broadcast.
 pub struct PeerDiscovery {
     config: BroadcastConfig,
@@ -184,7 +291,9 @@ impl PeerDiscovery {
 
     /// Send a broadcast announcement to all peers on the subnet.
     pub async fn announce(&self) -> Result<()> {
-        let data = self.announcement.to_bytes()?;
+        let plaintext = self.announcement.to_bytes()?;
+        let key = self.config.encryption_key()?;
+        let data = maybe_encrypt(&plaintext, &key)?;
         let broadcast_addr = SocketAddrV4::new(Ipv4Addr::BROADCAST, self.config.port);
 
         match self.socket.send_to(&data, broadcast_addr).await {
@@ -214,7 +323,13 @@ impl PeerDiscovery {
             .await
             .map_err(|e| SyncError::Broadcast(format!("recv: {}", e)))?;
 
-        let announcement = match Announcement::from_bytes(&buf[..n]) {
+        let key = self.config.encryption_key()?;
+        let plaintext = match maybe_decrypt(&buf[..n], &key)? {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let announcement = match Announcement::from_bytes(&plaintext) {
             Ok(a) => a,
             Err(e) => {
                 debug!("Ignoring malformed packet from {}: {}", addr, e);
@@ -677,11 +792,13 @@ mod tests {
             port: 0, // OS-assigned port
             interval_secs: 1,
             instance_id: Some("machine-a".to_string()),
+            secret: None,
         };
         let config_b = BroadcastConfig {
             port: 0,
             interval_secs: 1,
             instance_id: Some("machine-b".to_string()),
+            secret: None,
         };
 
         let hash = hash_db_path("/test/legion.db");
@@ -718,6 +835,7 @@ mod tests {
             port: 0,
             interval_secs: 1, // 1s interval = 3s TTL
             instance_id: Some("test-host".to_string()),
+            secret: None,
         };
 
         let hash = hash_db_path("/test/db.sqlite");
@@ -938,5 +1056,155 @@ mod tests {
         assert_eq!(reassembled.upserts.len(), original_count);
         assert_eq!(reassembled.deletes, vec!["del1".to_string()]);
         assert_eq!(reassembled.seq, 7);
+    }
+
+    // -----------------------------------------------------------------------
+    // Encryption tests
+    // -----------------------------------------------------------------------
+
+    fn test_key() -> [u8; 32] {
+        let mut key = [0u8; 32];
+        for (i, byte) in key.iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+        key
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let key = test_key();
+        let plaintext = b"hello smuggler broadcast";
+
+        let encrypted = encrypt_packet(plaintext, &key).unwrap();
+        let decrypted = decrypt_packet(&encrypted, &key).unwrap();
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_wrong_key_fails_authentication() {
+        let key_a = test_key();
+        let mut key_b = test_key();
+        key_b[0] = 0xFF;
+
+        let encrypted = encrypt_packet(b"secret data", &key_a).unwrap();
+        let result = decrypt_packet(&encrypted, &key_b);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("authentication failed"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_tampered_ciphertext_fails() {
+        let key = test_key();
+        let mut encrypted = encrypt_packet(b"important data", &key).unwrap();
+
+        // Flip a byte in the ciphertext (after the 24-byte nonce)
+        encrypted[30] ^= 0xFF;
+
+        let result = decrypt_packet(&encrypted, &key);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("authentication failed"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_nonce_uniqueness() {
+        let key = test_key();
+        let plaintext = b"same plaintext twice";
+
+        let encrypted_1 = encrypt_packet(plaintext, &key).unwrap();
+        let encrypted_2 = encrypt_packet(plaintext, &key).unwrap();
+
+        // Different nonces produce different ciphertext
+        assert_ne!(encrypted_1, encrypted_2);
+
+        // Both decrypt to the same plaintext
+        assert_eq!(decrypt_packet(&encrypted_1, &key).unwrap(), plaintext);
+        assert_eq!(decrypt_packet(&encrypted_2, &key).unwrap(), plaintext);
+    }
+
+    #[test]
+    fn test_packet_too_short() {
+        let key = test_key();
+
+        // Less than ENCRYPTION_OVERHEAD (40 bytes)
+        let short = vec![0u8; 20];
+        let result = decrypt_packet(&short, &key);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("packet too short"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_maybe_encrypt_decrypt_with_key() {
+        let key = Some(test_key());
+        let plaintext = b"broadcast payload";
+
+        let encrypted = maybe_encrypt(plaintext, &key).unwrap();
+        assert_ne!(&encrypted[..], &plaintext[..]);
+
+        let decrypted = maybe_decrypt(&encrypted, &key).unwrap();
+        assert_eq!(decrypted.unwrap(), plaintext);
+    }
+
+    #[test]
+    fn test_maybe_encrypt_decrypt_without_key() {
+        let key = None;
+        let plaintext = b"{\"version\":1}";
+
+        let output = maybe_encrypt(plaintext, &key).unwrap();
+        assert_eq!(&output[..], &plaintext[..]);
+
+        let decrypted = maybe_decrypt(&output, &key).unwrap();
+        assert_eq!(decrypted.unwrap(), plaintext);
+    }
+
+    #[test]
+    fn test_maybe_decrypt_rejects_plaintext_when_key_set() {
+        let key = Some(test_key());
+        let plaintext = b"{\"version\":1}";
+
+        let result = maybe_decrypt(plaintext, &key).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_maybe_decrypt_rejects_encrypted_when_no_key() {
+        let key_for_encrypt = test_key();
+        let encrypted = encrypt_packet(b"secret", &key_for_encrypt).unwrap();
+
+        let result = maybe_decrypt(&encrypted, &None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_encryption_key_parsing() {
+        // Valid 64-char hex
+        let config = BroadcastConfig {
+            secret: Some("a".repeat(64)),
+            ..Default::default()
+        };
+        assert!(config.encryption_key().unwrap().is_some());
+
+        // No secret
+        let config = BroadcastConfig::default();
+        assert!(config.encryption_key().unwrap().is_none());
+
+        // Invalid hex
+        let config = BroadcastConfig {
+            secret: Some("not-hex".to_string()),
+            ..Default::default()
+        };
+        assert!(config.encryption_key().is_err());
+
+        // Wrong length
+        let config = BroadcastConfig {
+            secret: Some("aa".to_string()),
+            ..Default::default()
+        };
+        assert!(config.encryption_key().is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Add optional XChaCha20-Poly1305 AEAD encryption for all broadcast sync traffic
- Pre-shared 256-bit key configured via `secret` field in `[broadcast]` config (hex-encoded)
- Wire format: `[24-byte nonce][ciphertext + 16-byte Poly1305 tag]`
- Integrated into `announce()` and `receive_one()` -- encryption is transparent when configured
- Mode mismatch detection: plaintext packets dropped when secret is set, encrypted packets dropped when no secret
- 10 new encryption tests (28 broadcast tests total, 125 full suite)

## Test plan

- [x] `cargo test` -- 125 tests pass
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo fmt -- --check` -- clean
- [ ] Manual test: two machines with matching secret see each other
- [ ] Manual test: mismatched secrets produce "authentication failed" warnings
- [ ] Wireshark: captured broadcast packets are opaque (no readable JSON)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)