### PR TITLE
feat: dry-run as structured data for agent approval gates (#49)

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -3,8 +3,20 @@
 use crate::config::ConflictResolution;
 use crate::datasource::DataSource;
 use crate::error::Result;
+use serde::Serialize;
 use std::collections::HashSet;
 use tracing::{debug, info, warn};
+
+/// Per-table diff statistics (counts only, no PK values).
+#[derive(Debug, Clone, Serialize)]
+pub struct DiffStats {
+    pub local_only: usize,
+    pub remote_only: usize,
+    pub local_newer: usize,
+    pub remote_newer: usize,
+    pub content_differs: usize,
+    pub identical: usize,
+}
 
 /// Represents the differences between local and remote for a table
 #[derive(Debug, Default)]
@@ -121,6 +133,18 @@ impl TableDiff {
         // Rows that only exist in local but not in remote
         // This is only for full sync mode, not incremental
         vec![]
+    }
+
+    /// Compute aggregate diff statistics (counts only).
+    pub fn stats(&self) -> DiffStats {
+        DiffStats {
+            local_only: self.local_only.len(),
+            remote_only: self.remote_only.len(),
+            local_newer: self.local_newer.len(),
+            remote_newer: self.remote_newer.len(),
+            content_differs: self.content_differs.len(),
+            identical: self.identical.len(),
+        }
     }
 
     /// Summary string for display

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,8 @@ use crate::datasource::DataSource;
 use crate::diff::diff_table;
 use crate::local::LocalDb;
 use crate::output::{
-    CommandOutput, DiffOutput, ErrorOutput, OutputFormat, StatusConfig, StatusDb, StatusOutput,
-    StatusTable,
+    CommandOutput, DiffOutput, DryRunOutput, DryRunTableOutput, DryRunVerboseTableOutput,
+    ErrorOutput, OutputFormat, StatusConfig, StatusDb, StatusOutput, StatusTable,
 };
 use crate::remote::D1Client;
 use crate::sync::{get_tables_to_sync, pull_all, push_all, sync_all};
@@ -251,18 +251,22 @@ async fn main() {
     // Execute command
     let result = match cli.command {
         Commands::Push { table, dry_run } => {
-            run_push(&config, target.unwrap(), table, dry_run, fmt).await
+            run_push(&config, target.unwrap(), table, dry_run, fmt, cli.verbose).await
         }
         Commands::Pull { table, dry_run } => {
-            run_pull(&config, target.unwrap(), table, dry_run, fmt).await
+            run_pull(&config, target.unwrap(), table, dry_run, fmt, cli.verbose).await
         }
         Commands::Sync { table, dry_run } => {
-            run_sync(&config, target.unwrap(), table, dry_run, fmt).await
+            run_sync(&config, target.unwrap(), table, dry_run, fmt, cli.verbose).await
         }
         Commands::Diff { table } => run_diff(&config, target.unwrap(), table, fmt).await,
         Commands::Status => run_status(&config, target.unwrap(), fmt).await,
-        Commands::Stash { table, dry_run } => run_stash(&config, table, dry_run, fmt).await,
-        Commands::Retrieve { table, dry_run } => run_retrieve(&config, table, dry_run, fmt).await,
+        Commands::Stash { table, dry_run } => {
+            run_stash(&config, table, dry_run, fmt, cli.verbose).await
+        }
+        Commands::Retrieve { table, dry_run } => {
+            run_retrieve(&config, table, dry_run, fmt, cli.verbose).await
+        }
         Commands::Watch { interval, dry_run } => {
             watch::run_watch(
                 &config,
@@ -303,6 +307,16 @@ async fn main() {
     }
 }
 
+fn print_dry_run_json(command: &'static str, results: &[sync::SyncResult], verbose: bool) {
+    if verbose {
+        let out = DryRunOutput::<DryRunVerboseTableOutput>::from_sync_results(command, results);
+        println!("{}", serde_json::to_string(&out).unwrap());
+    } else {
+        let out = DryRunOutput::<DryRunTableOutput>::from_sync_results(command, results);
+        println!("{}", serde_json::to_string(&out).unwrap());
+    }
+}
+
 /// Open a D1Client from resolved target fields.
 fn open_d1(account_id: &str, database_id: &str, api_token: &str, config: &Config) -> D1Client {
     D1Client::with_retry_config(
@@ -331,6 +345,7 @@ async fn run_push(
     table: Option<String>,
     dry_run: bool,
     fmt: OutputFormat,
+    verbose: bool,
 ) -> error::Result<()> {
     let local = LocalDb::open_readonly(config.local_db_path())?;
     let tables = resolve_tables(&local, table)?;
@@ -354,8 +369,9 @@ async fn run_push(
     };
 
     match fmt {
+        OutputFormat::Json if dry_run => print_dry_run_json("push", &results, verbose),
         OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("push", &results, dry_run);
+            let out = CommandOutput::from_sync_results("push", &results, false);
             println!("{}", serde_json::to_string(&out).unwrap());
         }
         OutputFormat::Text => {
@@ -371,8 +387,13 @@ async fn run_pull(
     table: Option<String>,
     dry_run: bool,
     fmt: OutputFormat,
+    verbose: bool,
 ) -> error::Result<()> {
-    let local = LocalDb::open(config.local_db_path())?;
+    let local = if dry_run {
+        LocalDb::open_readonly(config.local_db_path())?
+    } else {
+        LocalDb::open(config.local_db_path())?
+    };
     let tables = resolve_tables(&local, table)?;
 
     let results = match target {
@@ -394,8 +415,9 @@ async fn run_pull(
     };
 
     match fmt {
+        OutputFormat::Json if dry_run => print_dry_run_json("pull", &results, verbose),
         OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("pull", &results, dry_run);
+            let out = CommandOutput::from_sync_results("pull", &results, false);
             println!("{}", serde_json::to_string(&out).unwrap());
         }
         OutputFormat::Text => {
@@ -411,8 +433,13 @@ async fn run_sync(
     table: Option<String>,
     dry_run: bool,
     fmt: OutputFormat,
+    verbose: bool,
 ) -> error::Result<()> {
-    let local = LocalDb::open(config.local_db_path())?;
+    let local = if dry_run {
+        LocalDb::open_readonly(config.local_db_path())?
+    } else {
+        LocalDb::open(config.local_db_path())?
+    };
     let tables = resolve_tables(&local, table)?;
 
     let results = match target {
@@ -434,8 +461,9 @@ async fn run_sync(
     };
 
     match fmt {
+        OutputFormat::Json if dry_run => print_dry_run_json("sync", &results, verbose),
         OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("sync", &results, dry_run);
+            let out = CommandOutput::from_sync_results("sync", &results, false);
             println!("{}", serde_json::to_string(&out).unwrap());
         }
         OutputFormat::Text => {
@@ -817,6 +845,7 @@ async fn run_stash(
     table: Option<String>,
     dry_run: bool,
     fmt: OutputFormat,
+    verbose: bool,
 ) -> error::Result<()> {
     let stash_config = require_stash_config(config)?;
     info!("Stash mode: local -> S3 relay");
@@ -833,8 +862,9 @@ async fn run_stash(
     .await?;
 
     match fmt {
+        OutputFormat::Json if dry_run => print_dry_run_json("stash", &results, verbose),
         OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("stash", &results, dry_run);
+            let out = CommandOutput::from_sync_results("stash", &results, false);
             println!("{}", serde_json::to_string(&out).unwrap());
         }
         OutputFormat::Text => {
@@ -849,6 +879,7 @@ async fn run_retrieve(
     table: Option<String>,
     dry_run: bool,
     fmt: OutputFormat,
+    verbose: bool,
 ) -> error::Result<()> {
     let stash_config = require_stash_config(config)?;
     info!("Retrieve mode: S3 relay -> local");
@@ -865,8 +896,9 @@ async fn run_retrieve(
     .await?;
 
     match fmt {
+        OutputFormat::Json if dry_run => print_dry_run_json("retrieve", &results, verbose),
         OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("retrieve", &results, dry_run);
+            let out = CommandOutput::from_sync_results("retrieve", &results, false);
             println!("{}", serde_json::to_string(&out).unwrap());
         }
         OutputFormat::Text => {

--- a/src/output.rs
+++ b/src/output.rs
@@ -143,6 +143,115 @@ impl CommandOutput {
     }
 }
 
+/// Structured dry-run output with per-table diff breakdown.
+///
+/// Emitted by `--dry-run --output json`. Contains the same diff data
+/// used by the actual sync so agents can use it as an approval gate.
+/// Generic over the table detail type (compact counts vs verbose PK lists).
+#[derive(Serialize)]
+pub struct DryRunOutput<T: Serialize> {
+    pub command: &'static str,
+    pub status: &'static str,
+    pub tables: Vec<T>,
+    pub total_rows_to_push: usize,
+    pub total_rows_to_pull: usize,
+    pub exit_code: i32,
+}
+
+#[derive(Serialize)]
+pub struct DryRunTableOutput {
+    pub name: String,
+    pub local_only: usize,
+    pub remote_only: usize,
+    pub local_newer: usize,
+    pub remote_newer: usize,
+    pub content_differs: usize,
+    pub identical: usize,
+    pub rows_to_push: usize,
+    pub rows_to_pull: usize,
+}
+
+#[derive(Serialize)]
+pub struct DryRunVerboseTableOutput {
+    pub name: String,
+    pub local_only: Vec<String>,
+    pub remote_only: Vec<String>,
+    pub local_newer: Vec<String>,
+    pub remote_newer: Vec<String>,
+    pub content_differs: Vec<String>,
+    pub identical: usize,
+    pub rows_to_push: usize,
+    pub rows_to_pull: usize,
+}
+
+impl<T: Serialize> DryRunOutput<T> {
+    fn build(
+        command: &'static str,
+        results: &[SyncResult],
+        map_table: impl Fn(&SyncResult) -> T,
+    ) -> Self {
+        let mut total_push = 0;
+        let mut total_pull = 0;
+        let tables: Vec<_> = results
+            .iter()
+            .map(|r| {
+                total_push += r.rows_pushed;
+                total_pull += r.rows_pulled;
+                map_table(r)
+            })
+            .collect();
+
+        Self {
+            command,
+            status: "dry_run",
+            tables,
+            total_rows_to_push: total_push,
+            total_rows_to_pull: total_pull,
+            exit_code: 0,
+        }
+    }
+}
+
+impl DryRunOutput<DryRunTableOutput> {
+    pub fn from_sync_results(command: &'static str, results: &[SyncResult]) -> Self {
+        Self::build(command, results, |r| {
+            let stats = r.diff_stats.as_ref();
+            DryRunTableOutput {
+                name: r.table.clone(),
+                local_only: stats.map(|s| s.local_only).unwrap_or(0),
+                remote_only: stats.map(|s| s.remote_only).unwrap_or(0),
+                local_newer: stats.map(|s| s.local_newer).unwrap_or(0),
+                remote_newer: stats.map(|s| s.remote_newer).unwrap_or(0),
+                content_differs: stats.map(|s| s.content_differs).unwrap_or(0),
+                identical: stats.map(|s| s.identical).unwrap_or(0),
+                rows_to_push: r.rows_pushed,
+                rows_to_pull: r.rows_pulled,
+            }
+        })
+    }
+}
+
+impl DryRunOutput<DryRunVerboseTableOutput> {
+    pub fn from_sync_results(command: &'static str, results: &[SyncResult]) -> Self {
+        Self::build(command, results, |r| {
+            let detail = r.diff_detail.as_ref();
+            DryRunVerboseTableOutput {
+                name: r.table.clone(),
+                local_only: detail.map(|d| d.local_only.clone()).unwrap_or_default(),
+                remote_only: detail.map(|d| d.remote_only.clone()).unwrap_or_default(),
+                local_newer: detail.map(|d| d.local_newer.clone()).unwrap_or_default(),
+                remote_newer: detail.map(|d| d.remote_newer.clone()).unwrap_or_default(),
+                content_differs: detail
+                    .map(|d| d.content_differs.clone())
+                    .unwrap_or_default(),
+                identical: r.diff_stats.as_ref().map(|s| s.identical).unwrap_or(0),
+                rows_to_push: r.rows_pushed,
+                rows_to_pull: r.rows_pulled,
+            }
+        })
+    }
+}
+
 impl DiffOutput {
     pub fn from_diffs(diffs: Vec<(String, TableDiff)>) -> Self {
         Self {
@@ -214,11 +323,15 @@ mod tests {
                 table: "abilities".into(),
                 rows_pushed: 42,
                 rows_pulled: 0,
+                diff_stats: None,
+                diff_detail: None,
             },
             SyncResult {
                 table: "items".into(),
                 rows_pushed: 0,
                 rows_pulled: 0,
+                diff_stats: None,
+                diff_detail: None,
             },
         ];
 
@@ -243,6 +356,8 @@ mod tests {
             table: "t".into(),
             rows_pushed: 10,
             rows_pulled: 5,
+            diff_stats: None,
+            diff_detail: None,
         }];
 
         let out = CommandOutput::from_sync_results("sync", &results, true);
@@ -278,6 +393,8 @@ mod tests {
             table: "t".into(),
             rows_pushed: 3,
             rows_pulled: 7,
+            diff_stats: None,
+            diff_detail: None,
         }];
 
         let out = WatchTickOutput::from_results(5, &results);
@@ -355,5 +472,141 @@ mod tests {
         assert_eq!(v["local"]["connected"], true);
         assert_eq!(v["local"]["tables"][0]["rows"], 100);
         assert_eq!(v["target"]["tables"][0]["rows"], 95);
+    }
+
+    #[test]
+    fn test_dry_run_output_json_structure() {
+        use crate::diff::DiffStats;
+
+        let results = vec![
+            SyncResult {
+                table: "abilities".into(),
+                rows_pushed: 8,
+                rows_pulled: 3,
+                diff_stats: Some(DiffStats {
+                    local_only: 3,
+                    remote_only: 1,
+                    local_newer: 5,
+                    remote_newer: 2,
+                    content_differs: 0,
+                    identical: 142,
+                }),
+                diff_detail: None,
+            },
+            SyncResult {
+                table: "items".into(),
+                rows_pushed: 0,
+                rows_pulled: 0,
+                diff_stats: Some(DiffStats {
+                    local_only: 0,
+                    remote_only: 0,
+                    local_newer: 0,
+                    remote_newer: 0,
+                    content_differs: 0,
+                    identical: 50,
+                }),
+                diff_detail: None,
+            },
+        ];
+
+        let out = DryRunOutput::<DryRunTableOutput>::from_sync_results("sync", &results);
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["command"], "sync");
+        assert_eq!(v["status"], "dry_run");
+        assert_eq!(v["total_rows_to_push"], 8);
+        assert_eq!(v["total_rows_to_pull"], 3);
+        assert_eq!(v["exit_code"], 0);
+
+        let tables = v["tables"].as_array().unwrap();
+        assert_eq!(tables.len(), 2);
+
+        assert_eq!(tables[0]["name"], "abilities");
+        assert_eq!(tables[0]["local_only"], 3);
+        assert_eq!(tables[0]["remote_only"], 1);
+        assert_eq!(tables[0]["local_newer"], 5);
+        assert_eq!(tables[0]["remote_newer"], 2);
+        assert_eq!(tables[0]["content_differs"], 0);
+        assert_eq!(tables[0]["identical"], 142);
+        assert_eq!(tables[0]["rows_to_push"], 8);
+        assert_eq!(tables[0]["rows_to_pull"], 3);
+
+        assert_eq!(tables[1]["name"], "items");
+        assert_eq!(tables[1]["rows_to_push"], 0);
+        assert_eq!(tables[1]["rows_to_pull"], 0);
+        assert_eq!(tables[1]["identical"], 50);
+    }
+
+    #[test]
+    fn test_dry_run_no_side_effects_matches_structure() {
+        let results = vec![SyncResult {
+            table: "t".into(),
+            rows_pushed: 5,
+            rows_pulled: 2,
+            diff_stats: None,
+            diff_detail: None,
+        }];
+
+        let out = DryRunOutput::<DryRunTableOutput>::from_sync_results("push", &results);
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["status"], "dry_run");
+        assert_eq!(v["total_rows_to_push"], 5);
+        assert_eq!(v["total_rows_to_pull"], 2);
+        // Without diff_stats, zeros are used for breakdown
+        assert_eq!(v["tables"][0]["local_only"], 0);
+        assert_eq!(v["tables"][0]["identical"], 0);
+    }
+
+    #[test]
+    fn test_dry_run_verbose_output_includes_pk_values() {
+        use crate::diff::DiffStats;
+        use crate::sync::DiffDetail;
+
+        let results = vec![SyncResult {
+            table: "abilities".into(),
+            rows_pushed: 3,
+            rows_pulled: 1,
+            diff_stats: Some(DiffStats {
+                local_only: 2,
+                remote_only: 1,
+                local_newer: 1,
+                remote_newer: 0,
+                content_differs: 0,
+                identical: 10,
+            }),
+            diff_detail: Some(DiffDetail {
+                local_only: vec!["pk1".into(), "pk2".into()],
+                remote_only: vec!["pk3".into()],
+                local_newer: vec!["pk4".into()],
+                remote_newer: vec![],
+                content_differs: vec![],
+            }),
+        }];
+
+        let out = DryRunOutput::<DryRunVerboseTableOutput>::from_sync_results("push", &results);
+        let json = serde_json::to_string(&out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["command"], "push");
+        assert_eq!(v["status"], "dry_run");
+        assert_eq!(v["total_rows_to_push"], 3);
+        assert_eq!(v["total_rows_to_pull"], 1);
+
+        let t = &v["tables"][0];
+        assert_eq!(t["name"], "abilities");
+        assert_eq!(t["local_only"].as_array().unwrap().len(), 2);
+        assert_eq!(t["local_only"][0], "pk1");
+        assert_eq!(t["local_only"][1], "pk2");
+        assert_eq!(t["remote_only"].as_array().unwrap().len(), 1);
+        assert_eq!(t["remote_only"][0], "pk3");
+        assert_eq!(t["local_newer"].as_array().unwrap().len(), 1);
+        assert_eq!(t["remote_newer"].as_array().unwrap().len(), 0);
+        assert_eq!(t["content_differs"].as_array().unwrap().len(), 0);
+        assert_eq!(t["identical"], 10);
+        assert_eq!(t["rows_to_push"], 3);
+        assert_eq!(t["rows_to_pull"], 1);
     }
 }

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -215,6 +215,11 @@ async fn sync_table<S: DataSource, D: DataSource>(
     // applied by the higher-level sync engine that owns the SyncConfig.
     let diff = diff_table(source, dest, table, timestamp_column, &[]).await?;
 
+    if dry_run {
+        result.diff_stats = Some(diff.stats());
+        result.diff_detail = Some(crate::sync::DiffDetail::from_diff(&diff));
+    }
+
     if !diff.has_changes() {
         info!("Table {} is in sync", table);
         return Ok(result);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,8 +6,30 @@
 
 use crate::config::{column_excluded, BatchConfig, Config, ConflictResolution};
 use crate::datasource::DataSource;
-use crate::diff::{diff_table, TableDiff};
+use crate::diff::{diff_table, DiffStats, TableDiff};
 use crate::error::Result;
+
+/// Per-table primary key lists from the diff, for verbose dry-run output.
+#[derive(Debug, Clone)]
+pub struct DiffDetail {
+    pub local_only: Vec<String>,
+    pub remote_only: Vec<String>,
+    pub local_newer: Vec<String>,
+    pub remote_newer: Vec<String>,
+    pub content_differs: Vec<String>,
+}
+
+impl DiffDetail {
+    pub fn from_diff(diff: &TableDiff) -> Self {
+        Self {
+            local_only: diff.local_only.clone(),
+            remote_only: diff.remote_only.clone(),
+            local_newer: diff.local_newer.clone(),
+            remote_newer: diff.remote_newer.clone(),
+            content_differs: diff.content_differs.clone(),
+        }
+    }
+}
 use indicatif::{ProgressBar, ProgressStyle};
 use std::collections::HashMap;
 use tracing::{info, warn};
@@ -18,6 +40,10 @@ pub struct SyncResult {
     pub table: String,
     pub rows_pushed: usize,
     pub rows_pulled: usize,
+    /// Per-table diff breakdown, populated when diff was computed.
+    pub diff_stats: Option<DiffStats>,
+    /// Per-table PK lists from diff, populated for verbose dry-run output.
+    pub diff_detail: Option<DiffDetail>,
 }
 
 impl SyncResult {
@@ -26,6 +52,8 @@ impl SyncResult {
             table: table.to_string(),
             rows_pushed: 0,
             rows_pulled: 0,
+            diff_stats: None,
+            diff_detail: None,
         }
     }
 
@@ -204,10 +232,18 @@ pub async fn sync_table<A: DataSource, B: DataSource>(
     dry_run: bool,
 ) -> Result<SyncResult> {
     let diff = diff_table(a, b, table, timestamp_column, exclude_columns).await?;
+    let (stats, detail) = if dry_run {
+        (Some(diff.stats()), Some(DiffDetail::from_diff(&diff)))
+    } else {
+        (None, None)
+    };
 
     if !diff.has_changes() {
         info!("Table {} is in sync", table);
-        return Ok(SyncResult::new(table));
+        let mut r = SyncResult::new(table);
+        r.diff_stats = stats;
+        r.diff_detail = detail;
+        return Ok(r);
     }
 
     let push_result = push_table(
@@ -237,6 +273,8 @@ pub async fn sync_table<A: DataSource, B: DataSource>(
         table: table.to_string(),
         rows_pushed: push_result.rows_pushed,
         rows_pulled: pull_result.rows_pulled,
+        diff_stats: stats,
+        diff_detail: detail,
     })
 }
 
@@ -317,13 +355,22 @@ pub async fn push_all<Src: DataSource, Dst: DataSource>(
         )
         .await?;
 
+        let (stats, detail) = if dry_run {
+            (Some(diff.stats()), Some(DiffDetail::from_diff(&diff)))
+        } else {
+            (None, None)
+        };
+
         if !diff.has_changes() {
             info!("Table {} is in sync", table);
-            results.push(SyncResult::new(table));
+            let mut r = SyncResult::new(table);
+            r.diff_stats = stats;
+            r.diff_detail = detail;
+            results.push(r);
             continue;
         }
 
-        let result = push_table(
+        let mut result = push_table(
             source,
             dest,
             table,
@@ -334,6 +381,8 @@ pub async fn push_all<Src: DataSource, Dst: DataSource>(
             dry_run,
         )
         .await?;
+        result.diff_stats = stats;
+        result.diff_detail = detail;
         results.push(result);
     }
 
@@ -366,13 +415,22 @@ pub async fn pull_all<Src: DataSource, Dst: DataSource>(
         )
         .await?;
 
+        let (stats, detail) = if dry_run {
+            (Some(diff.stats()), Some(DiffDetail::from_diff(&diff)))
+        } else {
+            (None, None)
+        };
+
         if !diff.has_changes() {
             info!("Table {} is in sync", table);
-            results.push(SyncResult::new(table));
+            let mut r = SyncResult::new(table);
+            r.diff_stats = stats;
+            r.diff_detail = detail;
+            results.push(r);
             continue;
         }
 
-        let result = pull_table(
+        let mut result = pull_table(
             local,
             remote,
             table,
@@ -383,6 +441,8 @@ pub async fn pull_all<Src: DataSource, Dst: DataSource>(
             dry_run,
         )
         .await?;
+        result.diff_stats = stats;
+        result.diff_detail = detail;
         results.push(result);
     }
 


### PR DESCRIPTION
## Summary

- `--dry-run --output json` now emits per-table diff breakdown with counts (local_only, remote_only, local_newer, remote_newer, content_differs, identical) and row totals
- `--verbose` flag adds PK values per diff bucket for detailed agent inspection
- All 5 commands supported: push, pull, sync, stash, retrieve
- Same diff data used by actual sync -- not a separate code path, zero side effects

## Changes

- `src/diff.rs`: Add `DiffStats` struct and `TableDiff::stats()` method
- `src/sync.rs`: Add `DiffDetail` struct, populate stats/detail in SyncResult only during dry-run
- `src/output.rs`: Generic `DryRunOutput<T>` with compact (`DryRunTableOutput`) and verbose (`DryRunVerboseTableOutput`) variants
- `src/main.rs`: Route `--dry-run --output json` through new output structs, `--verbose` flag

## Simplify pass

- Unified `DryRunOutput` and `DryRunVerboseOutput` into generic `DryRunOutput<T>` with shared `build()` method
- Guarded stats/detail computation with `if dry_run` in all three sync paths (push_all, pull_all, sync_table) to avoid wasted clones on non-dry-run paths
- Replaced `.clone()` with `.as_ref()` for DiffStats access
- Fixed `identical_count` -> `identical` naming inconsistency in verbose output

## Test plan

- [x] `test_dry_run_output_json_structure` -- verifies JSON shape, field names, and values
- [x] `test_dry_run_no_side_effects_matches_structure` -- verifies structure with nil stats
- [x] `test_dry_run_verbose_output_includes_pk_values` -- verifies PK lists in verbose mode
- [x] All 177 tests pass, clippy clean, fmt clean

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)