### PR TITLE
feat: Turso/libSQL adapter for DataSource trait (#52)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy 0.8.42",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +42,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -86,6 +115,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,10 +160,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -130,16 +270,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -149,6 +316,15 @@ checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -193,9 +369,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -237,6 +436,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -297,6 +505,15 @@ name = "cpuid-bool"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crypto-common"
@@ -365,6 +582,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -546,9 +769,47 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -562,12 +823,28 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
- "indexmap",
+ "http 1.4.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -584,6 +861,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hashlink"
@@ -607,6 +893,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,12 +924,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -634,10 +951,16 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -646,10 +969,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -661,9 +1014,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -675,19 +1028,49 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.22.4",
+ "rustls-native-certs 0.7.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.23.36",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.32",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -698,7 +1081,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -712,18 +1095,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -837,6 +1220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,12 +1248,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -878,6 +1279,16 @@ dependencies = [
  "portable-atomic",
  "unicode-width",
  "web-time",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -901,6 +1312,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -934,10 +1354,168 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libsql"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30fe980ac5693ed1f3db490559fb578885e913a018df64af8a1a46e1959a78df"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "bincode",
+ "bitflags 2.10.0",
+ "bytes",
+ "chrono",
+ "crc32fast",
+ "fallible-iterator 0.3.0",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "hyper-rustls 0.25.0",
+ "libsql-hrana",
+ "libsql-sqlite3-parser",
+ "libsql-sys",
+ "libsql_replication",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-web",
+ "tower 0.4.13",
+ "tower-http 0.4.4",
+ "tracing",
+ "uuid",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "libsql-ffi"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "glob",
+]
+
+[[package]]
+name = "libsql-hrana"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3358538b52cfcf9af4fe7aeb57d6843aafed2e8af80807bd636fd1448e94ea7"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "prost",
+ "serde",
+]
+
+[[package]]
+name = "libsql-rusqlite"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b646f94fc1d266e481c38a2d44d6d9d1be3ad04b56b90457acfb310dc450030e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator 0.2.0",
+ "fallible-streaming-iterator",
+ "hashlink 0.8.4",
+ "libsql-ffi",
+ "smallvec",
+]
+
+[[package]]
+name = "libsql-sqlite3-parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a90128c708356af8f7d767c9ac2946692c9112b4f74f07b99a01a60680e413"
+dependencies = [
+ "bitflags 2.10.0",
+ "cc",
+ "fallible-iterator 0.3.0",
+ "indexmap 2.13.0",
+ "log",
+ "memchr",
+ "phf",
+ "phf_codegen",
+ "phf_shared",
+ "uncased",
+]
+
+[[package]]
+name = "libsql-sys"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90725458cc4461bc82f8f7983e80b002ea4f64b5184e1462f252d0dd74b122f5"
+dependencies = [
+ "bytes",
+ "libsql-ffi",
+ "libsql-rusqlite",
+ "once_cell",
+ "tracing",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "libsql_replication"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bba5c9b3a26aca06d70f6a3646ba341cf574a548355353fe135af524b1b77cc"
+dependencies = [
+ "aes",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "cbc",
+ "libsql-rusqlite",
+ "libsql-sys",
+ "parking_lot",
+ "prost",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tracing",
+ "uuid",
+ "zerocopy 0.7.35",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -949,6 +1527,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -993,6 +1577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1603,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1040,6 +1636,16 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1073,27 +1679,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "humantime",
- "hyper",
- "itertools",
+ "hyper 1.8.1",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "ring",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -1120,7 +1726,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1188,10 +1794,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+ "uncased",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1242,7 +1913,17 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.42",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1252,6 +1933,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1275,10 +1979,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.36",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1293,13 +1997,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
- "rustc-hash",
- "rustls",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1314,7 +2018,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1335,13 +2039,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1351,7 +2082,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1369,7 +2109,19 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1395,17 +2147,17 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -1415,19 +2167,19 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.23.36",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
- "tower",
- "tower-http",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1456,13 +2208,19 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
 dependencies = [
- "bitflags",
- "fallible-iterator",
+ "bitflags 2.10.0",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.10.0",
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -1472,15 +2230,42 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1492,9 +2277,22 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -1510,6 +2308,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +2324,17 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1572,7 +2390,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -1585,7 +2403,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1601,6 +2419,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1703,6 +2527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,20 +2554,31 @@ dependencies = [
  "hex",
  "indicatif",
  "libc",
+ "libsql",
  "object_store",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1790,6 +2631,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -1814,7 +2661,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -1838,8 +2685,17 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1848,7 +2704,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1908,9 +2775,19 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1936,11 +2813,33 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.36",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1984,7 +2883,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1999,6 +2898,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3b0e1cedbf19fdfb78ef3d672cb9928e0a91a9cb4629cc0c916e8cff8aaaa1"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "pin-project",
+ "tokio-stream",
+ "tonic",
+ "tower-http 0.4.4",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,10 +2973,30 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-range-header",
+ "pin-project-lite",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2019,14 +3005,14 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -2049,6 +3035,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2117,6 +3104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +3123,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -2167,6 +3169,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -2216,6 +3230,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2280,6 +3303,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,6 +3335,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -2310,6 +3367,36 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -2570,6 +3657,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -2602,11 +3771,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.42",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,19 @@ indicatif = "0.17"
 chacha20poly1305 = "0.5"
 rand = "0.9"
 
+# Turso/libSQL (optional)
+libsql = { version = "0.9", optional = true }
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Unix process checking (PID lock)
 libc = "0.2"
+
+[features]
+default = []
+turso = ["dep:libsql"]
 
 [profile.release]
 lto = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,9 @@ pub enum TargetConfig {
     },
     /// Local SQLite target
     Sqlite { database: String },
+    /// Turso/libSQL target
+    #[cfg(feature = "turso")]
+    Turso { url: String, auth_token: String },
 }
 
 /// Resolved target after merging legacy fields with [target] section
@@ -52,6 +55,11 @@ pub enum ResolvedTarget {
     },
     Sqlite {
         database: String,
+    },
+    #[cfg(feature = "turso")]
+    Turso {
+        url: String,
+        auth_token: String,
     },
 }
 
@@ -380,6 +388,11 @@ impl Config {
                 },
                 TargetConfig::Sqlite { database } => ResolvedTarget::Sqlite {
                     database: database.clone(),
+                },
+                #[cfg(feature = "turso")]
+                TargetConfig::Turso { url, auth_token } => ResolvedTarget::Turso {
+                    url: url.clone(),
+                    auth_token: auth_token.clone(),
                 },
             });
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,10 @@ pub enum SyncError {
 
     #[error("Broadcast error: {0}")]
     Broadcast(String),
+
+    #[cfg(feature = "turso")]
+    #[error("Turso error: {0}")]
+    Turso(String),
 }
 
 impl SyncError {
@@ -144,6 +148,9 @@ impl SyncError {
             | SyncError::ServerError { .. }
             | SyncError::ConnectionTimeout
             | SyncError::RetryExhausted { .. } => 3,
+
+            #[cfg(feature = "turso")]
+            SyncError::Turso(_) => 3,
 
             SyncError::ConcurrentWrite => 4,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,8 @@ mod remote;
 mod stash;
 mod sync;
 mod table;
+#[cfg(feature = "turso")]
+mod turso;
 mod watch;
 
 use crate::config::{Config, ResolvedTarget};
@@ -366,6 +368,13 @@ async fn run_push(
             let target_db = LocalDb::open(&database)?;
             push_all(&local, &target_db, config, tables, dry_run).await?
         }
+        #[cfg(feature = "turso")]
+        ResolvedTarget::Turso { url, auth_token } => {
+            info!("Push mode: local -> Turso");
+            let remote = turso::TursoClient::connect(&url, &auth_token).await?;
+            remote.test_connection().await?;
+            push_all(&local, &remote, config, tables, dry_run).await?
+        }
     };
 
     match fmt {
@@ -412,6 +421,13 @@ async fn run_pull(
             let source_db = LocalDb::open_readonly(&database)?;
             pull_all(&local, &source_db, config, tables, dry_run).await?
         }
+        #[cfg(feature = "turso")]
+        ResolvedTarget::Turso { url, auth_token } => {
+            info!("Pull mode: Turso -> local");
+            let remote = turso::TursoClient::connect(&url, &auth_token).await?;
+            remote.test_connection().await?;
+            pull_all(&local, &remote, config, tables, dry_run).await?
+        }
     };
 
     match fmt {
@@ -457,6 +473,13 @@ async fn run_sync(
             info!("Sync mode: bidirectional (local <-> SQLite {})", database);
             let target_db = LocalDb::open(&database)?;
             sync_all(&local, &target_db, config, tables, dry_run).await?
+        }
+        #[cfg(feature = "turso")]
+        ResolvedTarget::Turso { url, auth_token } => {
+            info!("Sync mode: bidirectional (local <-> Turso)");
+            let remote = turso::TursoClient::connect(&url, &auth_token).await?;
+            remote.test_connection().await?;
+            sync_all(&local, &remote, config, tables, dry_run).await?
         }
     };
 
@@ -539,6 +562,28 @@ async fn run_diff(
             output_diffs(
                 &local,
                 &target_db,
+                &tables,
+                &config.sync.timestamp_column,
+                &config.sync.exclude_columns,
+                fmt,
+            )
+            .await
+        }
+        #[cfg(feature = "turso")]
+        ResolvedTarget::Turso { url, auth_token } => {
+            let remote = turso::TursoClient::connect(&url, &auth_token).await?;
+            remote.test_connection().await?;
+            let tables = match table {
+                Some(t) => {
+                    let schema = local.get_schema()?;
+                    let _ = schema.validate(&t)?;
+                    vec![t]
+                }
+                None => get_tables_to_sync(&local, &remote, config).await?,
+            };
+            output_diffs(
+                &local,
+                &remote,
                 &tables,
                 &config.sync.timestamp_column,
                 &config.sync.exclude_columns,
@@ -645,6 +690,8 @@ async fn run_status(
     let target_type = match &target {
         ResolvedTarget::D1 { .. } => "d1",
         ResolvedTarget::Sqlite { .. } => "sqlite",
+        #[cfg(feature = "turso")]
+        ResolvedTarget::Turso { .. } => "turso",
     };
 
     // Gather local DB info
@@ -733,6 +780,41 @@ async fn run_status(
                 tables: vec![],
             },
         },
+        #[cfg(feature = "turso")]
+        ResolvedTarget::Turso { url, auth_token } => {
+            match turso::TursoClient::connect(url, auth_token).await {
+                Ok(remote) => match remote.test_connection().await {
+                    Ok(()) => {
+                        let tables = remote.list_tables().await?;
+                        let mut table_rows = Vec::new();
+                        for table in &tables {
+                            if config.should_sync_table(table) {
+                                let count = remote.row_count(table).await?;
+                                table_rows.push(StatusTable {
+                                    name: table.clone(),
+                                    rows: count,
+                                });
+                            }
+                        }
+                        StatusDb {
+                            connected: true,
+                            error: None,
+                            tables: table_rows,
+                        }
+                    }
+                    Err(e) => StatusDb {
+                        connected: false,
+                        error: Some(e.to_string()),
+                        tables: vec![],
+                    },
+                },
+                Err(e) => StatusDb {
+                    connected: false,
+                    error: Some(e.to_string()),
+                    tables: vec![],
+                },
+            }
+        }
     };
 
     match fmt {
@@ -777,6 +859,10 @@ async fn run_status(
                 ResolvedTarget::Sqlite { database } => {
                     println!("  Target: SQLite ({})", database);
                 }
+                #[cfg(feature = "turso")]
+                ResolvedTarget::Turso { url, .. } => {
+                    println!("  Target: Turso ({})", url);
+                }
             }
 
             println!("  Timestamp column: {}", config.sync.timestamp_column);
@@ -814,6 +900,8 @@ async fn run_status(
             match &target {
                 ResolvedTarget::D1 { .. } => println!("\n--- Remote D1 ---"),
                 ResolvedTarget::Sqlite { .. } => println!("\n--- Target SQLite ---"),
+                #[cfg(feature = "turso")]
+                ResolvedTarget::Turso { .. } => println!("\n--- Target Turso ---"),
             }
             if target_status.connected {
                 println!("  Connection: OK");

--- a/src/turso.rs
+++ b/src/turso.rs
@@ -1,0 +1,598 @@
+//! Turso/libSQL database adapter
+//!
+//! Implements the [`DataSource`] trait for Turso databases accessed via the
+//! libsql crate's HTTP protocol. This allows smuggler to sync data to and
+//! from Turso-hosted libSQL databases the same way it works with D1 or
+//! local SQLite targets.
+
+use crate::config::column_excluded;
+use crate::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
+use crate::error::{Result, SyncError};
+use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use tracing::{debug, info};
+
+/// Client for a Turso/libSQL database accessed over HTTP.
+pub struct TursoClient {
+    conn: libsql::Connection,
+}
+
+impl TursoClient {
+    /// Connect to a Turso database via the libsql HTTP protocol.
+    pub async fn connect(url: &str, auth_token: &str) -> Result<Self> {
+        let db = libsql::Builder::new_remote(url.to_string(), auth_token.to_string())
+            .build()
+            .await
+            .map_err(|e| SyncError::Turso(format!("failed to build database: {}", e)))?;
+
+        let conn = db
+            .connect()
+            .map_err(|e| SyncError::Turso(format!("failed to connect: {}", e)))?;
+
+        info!("Connected to Turso database at {}", url);
+        Ok(Self { conn })
+    }
+
+    /// Test the connection by running a simple query.
+    pub async fn test_connection(&self) -> Result<()> {
+        self.conn
+            .query("SELECT 1", ())
+            .await
+            .map_err(|e| SyncError::Turso(format!("connection test failed: {}", e)))?;
+        Ok(())
+    }
+}
+
+impl DataSource for TursoClient {
+    async fn list_tables(&self) -> Result<Vec<String>> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT name FROM sqlite_master \
+                 WHERE type = 'table' \
+                 AND name NOT LIKE 'sqlite_%' \
+                 ORDER BY name",
+                (),
+            )
+            .await
+            .map_err(|e| SyncError::Turso(format!("list_tables query failed: {}", e)))?;
+
+        let mut tables = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| SyncError::Turso(format!("list_tables row iteration: {}", e)))?
+        {
+            let name: String = row
+                .get(0)
+                .map_err(|e| SyncError::Turso(format!("list_tables get column: {}", e)))?;
+            tables.push(name);
+        }
+
+        debug!("Found {} tables", tables.len());
+        Ok(tables)
+    }
+
+    async fn table_info(&self, table: &str) -> Result<TableInfo> {
+        let sql = format!("PRAGMA table_info(\"{}\")", table);
+        let mut rows = self
+            .conn
+            .query(&sql, ())
+            .await
+            .map_err(|e| SyncError::Turso(format!("table_info query failed: {}", e)))?;
+
+        let mut columns = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| SyncError::Turso(format!("table_info row iteration: {}", e)))?
+        {
+            let name: String = row
+                .get(1)
+                .map_err(|e| SyncError::Turso(format!("table_info get name: {}", e)))?;
+            let col_type: String = row
+                .get(2)
+                .map_err(|e| SyncError::Turso(format!("table_info get type: {}", e)))?;
+            let notnull: i32 = row
+                .get(3)
+                .map_err(|e| SyncError::Turso(format!("table_info get notnull: {}", e)))?;
+            let pk: i32 = row
+                .get(5)
+                .map_err(|e| SyncError::Turso(format!("table_info get pk: {}", e)))?;
+
+            columns.push(ColumnInfo {
+                name,
+                col_type,
+                notnull: notnull != 0,
+                pk: pk != 0,
+            });
+        }
+
+        if columns.is_empty() {
+            return Err(SyncError::TableNotFound(table.to_string()));
+        }
+
+        let primary_key: Vec<String> = columns
+            .iter()
+            .filter(|c| c.pk)
+            .map(|c| c.name.clone())
+            .collect();
+
+        if primary_key.is_empty() {
+            return Err(SyncError::NoPrimaryKey(table.to_string()));
+        }
+
+        Ok(TableInfo {
+            name: table.to_string(),
+            columns,
+            primary_key,
+        })
+    }
+
+    async fn get_row_metadata(
+        &self,
+        table: &str,
+        timestamp_column: &str,
+        exclude_columns: &[String],
+    ) -> Result<HashMap<String, RowMeta>> {
+        let info = self.table_info(table).await?;
+        let pk_cols = &info.primary_key;
+        let has_timestamp = info.columns.iter().any(|c| c.name == timestamp_column);
+
+        let pk_select = pk_cols
+            .iter()
+            .map(|c| format!("\"{}\"", c))
+            .collect::<Vec<_>>()
+            .join(" || '|' || ");
+
+        let timestamp_select = if has_timestamp {
+            format!(", \"{}\"", timestamp_column)
+        } else {
+            String::new()
+        };
+
+        let timestamp_columns = ["updated_at", "created_at"];
+        let hash_cols: Vec<_> = info
+            .columns
+            .iter()
+            .filter(|c| {
+                !timestamp_columns.contains(&c.name.as_str())
+                    && !column_excluded(&c.name, exclude_columns)
+            })
+            .collect();
+
+        let all_cols = hash_cols
+            .iter()
+            .map(|c| format!("\"{}\"", c.name))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let sql = format!(
+            "SELECT {}, {} {} FROM \"{}\"",
+            pk_select, all_cols, timestamp_select, table
+        );
+
+        debug!("Executing: {}", sql);
+
+        let mut rows = self
+            .conn
+            .query(&sql, ())
+            .await
+            .map_err(|e| SyncError::Turso(format!("get_row_metadata query failed: {}", e)))?;
+
+        let hash_col_count = hash_cols.len();
+        let mut result = HashMap::new();
+
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| SyncError::Turso(format!("get_row_metadata row iteration: {}", e)))?
+        {
+            let pk_value = libsql_value_to_string(
+                &row.get_value(0)
+                    .map_err(|e| SyncError::Turso(format!("get_row_metadata get pk: {}", e)))?,
+            );
+
+            // Hash content columns
+            let mut hasher = Sha256::new();
+            for i in 0..hash_col_count {
+                let val = libsql_value_to_string(&row.get_value(i as i32 + 1).map_err(|e| {
+                    SyncError::Turso(format!("get_row_metadata get hash col: {}", e))
+                })?);
+                hasher.update(val.as_bytes());
+                hasher.update(b"|");
+            }
+            let content_hash = hex::encode(hasher.finalize());
+
+            let updated_at: Option<String> = if has_timestamp {
+                let ts_idx = hash_col_count as i32 + 1;
+                let val = row.get_value(ts_idx).map_err(|e| {
+                    SyncError::Turso(format!("get_row_metadata get timestamp: {}", e))
+                })?;
+                match val {
+                    libsql::Value::Null => None,
+                    other => Some(libsql_value_to_string(&other)),
+                }
+            } else {
+                None
+            };
+
+            result.insert(
+                pk_value.clone(),
+                RowMeta {
+                    pk_value,
+                    updated_at,
+                    content_hash,
+                },
+            );
+        }
+
+        debug!("Got {} rows from {}", result.len(), table);
+        Ok(result)
+    }
+
+    async fn get_rows(
+        &self,
+        table: &str,
+        pk_values: &[String],
+    ) -> Result<Vec<HashMap<String, JsonValue>>> {
+        if pk_values.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let info = self.table_info(table).await?;
+        let pk_cols = &info.primary_key;
+
+        let pk_expr = pk_cols
+            .iter()
+            .map(|c| format!("\"{}\"", c))
+            .collect::<Vec<_>>()
+            .join(" || '|' || ");
+
+        let cols = info
+            .columns
+            .iter()
+            .map(|c| format!("\"{}\"", c.name))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let placeholders = pk_values
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let sql = format!(
+            "SELECT {} FROM \"{}\" WHERE {} IN ({})",
+            cols, table, pk_expr, placeholders
+        );
+
+        debug!("Fetching {} rows from {}", pk_values.len(), table);
+
+        let params: Vec<libsql::Value> = pk_values
+            .iter()
+            .map(|v| libsql::Value::Text(v.clone()))
+            .collect();
+
+        let mut rows = self
+            .conn
+            .query(&sql, libsql::params::Params::Positional(params))
+            .await
+            .map_err(|e| SyncError::Turso(format!("get_rows query failed: {}", e)))?;
+
+        let mut result = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| SyncError::Turso(format!("get_rows row iteration: {}", e)))?
+        {
+            let mut row_data = HashMap::new();
+            for (i, col) in info.columns.iter().enumerate() {
+                let val = row.get_value(i as i32).map_err(|e| {
+                    SyncError::Turso(format!("get_rows get column {}: {}", col.name, e))
+                })?;
+                row_data.insert(col.name.clone(), libsql_value_to_json(&val));
+            }
+            result.push(row_data);
+        }
+
+        Ok(result)
+    }
+
+    async fn upsert_rows(&self, table: &str, rows: &[HashMap<String, JsonValue>]) -> Result<usize> {
+        if rows.is_empty() {
+            return Ok(0);
+        }
+
+        let info = self.table_info(table).await?;
+        let cols: Vec<&str> = info.columns.iter().map(|c| c.name.as_str()).collect();
+
+        let col_list = cols
+            .iter()
+            .map(|c| format!("\"{}\"", c))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let placeholders = cols
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let sql = format!(
+            "INSERT OR REPLACE INTO \"{}\" ({}) VALUES ({})",
+            table, col_list, placeholders
+        );
+
+        debug!("Upserting {} rows into {}", rows.len(), table);
+
+        let tx = self
+            .conn
+            .transaction()
+            .await
+            .map_err(|e| SyncError::Turso(format!("begin transaction failed: {}", e)))?;
+
+        let mut count = 0;
+        for row in rows {
+            let params: Vec<libsql::Value> = cols
+                .iter()
+                .map(|col| json_to_libsql_value(row.get(*col)))
+                .collect();
+
+            if let Err(e) = tx
+                .execute(&sql, libsql::params::Params::Positional(params))
+                .await
+            {
+                let _ = tx.rollback().await;
+                return Err(SyncError::Turso(format!(
+                    "upsert_rows execute failed: {}",
+                    e
+                )));
+            }
+
+            count += 1;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| SyncError::Turso(format!("commit transaction failed: {}", e)))?;
+
+        info!("Upserted {} rows into {}", count, table);
+        Ok(count)
+    }
+
+    async fn row_count(&self, table: &str) -> Result<usize> {
+        let sql = format!("SELECT COUNT(*) FROM \"{}\"", table);
+        let mut rows = self
+            .conn
+            .query(&sql, ())
+            .await
+            .map_err(|e| SyncError::Turso(format!("row_count query failed: {}", e)))?;
+
+        let row = rows
+            .next()
+            .await
+            .map_err(|e| SyncError::Turso(format!("row_count row iteration: {}", e)))?
+            .ok_or_else(|| SyncError::Turso("row_count returned no rows".to_string()))?;
+
+        let count: i64 = row
+            .get(0)
+            .map_err(|e| SyncError::Turso(format!("row_count get value: {}", e)))?;
+
+        Ok(count as usize)
+    }
+}
+
+/// Convert a libsql::Value to a string for hashing (mirrors local.rs get_value_as_string).
+fn libsql_value_to_string(val: &libsql::Value) -> String {
+    match val {
+        libsql::Value::Null => String::new(),
+        libsql::Value::Integer(i) => i.to_string(),
+        libsql::Value::Real(f) => f.to_string(),
+        libsql::Value::Text(s) => s.clone(),
+        libsql::Value::Blob(b) => hex::encode(b),
+    }
+}
+
+/// Convert a libsql::Value to a serde_json::Value (mirrors local.rs get_json_value).
+fn libsql_value_to_json(val: &libsql::Value) -> JsonValue {
+    match val {
+        libsql::Value::Null => JsonValue::Null,
+        libsql::Value::Integer(i) => JsonValue::from(*i),
+        libsql::Value::Real(f) => JsonValue::from(*f),
+        libsql::Value::Text(s) => JsonValue::from(s.clone()),
+        libsql::Value::Blob(b) => JsonValue::String(hex::encode(b)),
+    }
+}
+
+/// Convert a serde_json::Value to a libsql::Value for parameterized queries.
+fn json_to_libsql_value(val: Option<&JsonValue>) -> libsql::Value {
+    match val {
+        None | Some(JsonValue::Null) => libsql::Value::Null,
+        Some(JsonValue::Bool(b)) => libsql::Value::Integer(if *b { 1 } else { 0 }),
+        Some(JsonValue::Number(n)) => {
+            if let Some(i) = n.as_i64() {
+                libsql::Value::Integer(i)
+            } else if let Some(f) = n.as_f64() {
+                libsql::Value::Real(f)
+            } else {
+                libsql::Value::Text(n.to_string())
+            }
+        }
+        Some(JsonValue::String(s)) => libsql::Value::Text(s.clone()),
+        Some(JsonValue::Array(_)) | Some(JsonValue::Object(_)) => {
+            libsql::Value::Text(val.unwrap().to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_libsql_value_to_string_null() {
+        assert_eq!(libsql_value_to_string(&libsql::Value::Null), "");
+    }
+
+    #[test]
+    fn test_libsql_value_to_string_integer() {
+        assert_eq!(libsql_value_to_string(&libsql::Value::Integer(42)), "42");
+        assert_eq!(libsql_value_to_string(&libsql::Value::Integer(-1)), "-1");
+        assert_eq!(libsql_value_to_string(&libsql::Value::Integer(0)), "0");
+    }
+
+    #[test]
+    fn test_libsql_value_to_string_real() {
+        assert_eq!(libsql_value_to_string(&libsql::Value::Real(3.14)), "3.14");
+    }
+
+    #[test]
+    fn test_libsql_value_to_string_text() {
+        assert_eq!(
+            libsql_value_to_string(&libsql::Value::Text("hello".to_string())),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn test_libsql_value_to_string_blob() {
+        assert_eq!(
+            libsql_value_to_string(&libsql::Value::Blob(vec![0xde, 0xad, 0xbe, 0xef])),
+            "deadbeef"
+        );
+    }
+
+    #[test]
+    fn test_libsql_value_to_json_null() {
+        assert_eq!(libsql_value_to_json(&libsql::Value::Null), JsonValue::Null);
+    }
+
+    #[test]
+    fn test_libsql_value_to_json_integer() {
+        assert_eq!(
+            libsql_value_to_json(&libsql::Value::Integer(42)),
+            JsonValue::from(42)
+        );
+    }
+
+    #[test]
+    fn test_libsql_value_to_json_real() {
+        assert_eq!(
+            libsql_value_to_json(&libsql::Value::Real(3.14)),
+            JsonValue::from(3.14)
+        );
+    }
+
+    #[test]
+    fn test_libsql_value_to_json_text() {
+        assert_eq!(
+            libsql_value_to_json(&libsql::Value::Text("hello".to_string())),
+            JsonValue::from("hello")
+        );
+    }
+
+    #[test]
+    fn test_libsql_value_to_json_blob() {
+        assert_eq!(
+            libsql_value_to_json(&libsql::Value::Blob(vec![0xca, 0xfe])),
+            JsonValue::String("cafe".to_string())
+        );
+    }
+
+    #[test]
+    fn test_json_to_libsql_value_null() {
+        assert_eq!(json_to_libsql_value(None), libsql::Value::Null);
+        assert_eq!(
+            json_to_libsql_value(Some(&JsonValue::Null)),
+            libsql::Value::Null
+        );
+    }
+
+    #[test]
+    fn test_json_to_libsql_value_bool() {
+        assert_eq!(
+            json_to_libsql_value(Some(&JsonValue::Bool(true))),
+            libsql::Value::Integer(1)
+        );
+        assert_eq!(
+            json_to_libsql_value(Some(&JsonValue::Bool(false))),
+            libsql::Value::Integer(0)
+        );
+    }
+
+    #[test]
+    fn test_json_to_libsql_value_integer() {
+        let val = JsonValue::from(42);
+        assert_eq!(json_to_libsql_value(Some(&val)), libsql::Value::Integer(42));
+    }
+
+    #[test]
+    fn test_json_to_libsql_value_real() {
+        let val = JsonValue::from(3.14);
+        assert_eq!(json_to_libsql_value(Some(&val)), libsql::Value::Real(3.14));
+    }
+
+    #[test]
+    fn test_json_to_libsql_value_string() {
+        let val = JsonValue::from("hello");
+        assert_eq!(
+            json_to_libsql_value(Some(&val)),
+            libsql::Value::Text("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn test_json_to_libsql_value_array() {
+        let val = JsonValue::Array(vec![JsonValue::from(1), JsonValue::from(2)]);
+        assert_eq!(
+            json_to_libsql_value(Some(&val)),
+            libsql::Value::Text("[1,2]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_json_to_libsql_value_object() {
+        let mut map = serde_json::Map::new();
+        map.insert("key".to_string(), JsonValue::from("val"));
+        let val = JsonValue::Object(map);
+        assert_eq!(
+            json_to_libsql_value(Some(&val)),
+            libsql::Value::Text("{\"key\":\"val\"}".to_string())
+        );
+    }
+
+    // Content hash consistency: verify that the same column values produce
+    // identical SHA-256 hashes regardless of whether they go through the
+    // libsql or local (rusqlite) code path.
+    #[test]
+    fn test_content_hash_consistency() {
+        let values = vec![
+            libsql::Value::Integer(1),
+            libsql::Value::Text("hello".to_string()),
+            libsql::Value::Real(3.14),
+        ];
+
+        let mut hasher = Sha256::new();
+        for v in &values {
+            hasher.update(libsql_value_to_string(v).as_bytes());
+            hasher.update(b"|");
+        }
+        let hash = hex::encode(hasher.finalize());
+
+        // Same values through string conversion should match
+        let mut hasher2 = Sha256::new();
+        hasher2.update(b"1");
+        hasher2.update(b"|");
+        hasher2.update(b"hello");
+        hasher2.update(b"|");
+        hasher2.update(b"3.14");
+        hasher2.update(b"|");
+        let hash2 = hex::encode(hasher2.finalize());
+
+        assert_eq!(hash, hash2);
+    }
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -262,6 +262,20 @@ pub async fn run_watch(
                         let target_db = LocalDb::open(database)?;
                         sync_all(&local, &target_db, config, None, dry_run).await
                     }
+                    #[cfg(feature = "turso")]
+                    ResolvedTarget::Turso { url, auth_token } => {
+                        let local = LocalDb::open(config.local_db_path())?;
+                        let remote = crate::turso::TursoClient::connect(url, auth_token).await?;
+                        if let Err(e) = remote.test_connection().await {
+                            warn!("Connection test failed on tick #{}: {}. Will retry next tick.", tick_count, e);
+                            if fmt == OutputFormat::Json {
+                                let out = WatchTickOutput::from_error(tick_count, &e.to_string());
+                                println!("{}", serde_json::to_string(&out).unwrap());
+                            }
+                            continue;
+                        }
+                        sync_all(&local, &remote, config, None, dry_run).await
+                    }
                 };
 
                 match result {
@@ -319,14 +333,23 @@ pub async fn run_watch(
 
 /// Check if an error is transient (should retry on next tick) vs fatal (should exit).
 fn is_transient_error(err: &SyncError) -> bool {
-    matches!(
+    if matches!(
         err,
         SyncError::RateLimited { .. }
             | SyncError::ServerError { .. }
             | SyncError::ConnectionTimeout
             | SyncError::Http(_)
             | SyncError::ConcurrentWrite
-    )
+    ) {
+        return true;
+    }
+
+    #[cfg(feature = "turso")]
+    if matches!(err, SyncError::Turso(_)) {
+        return true;
+    }
+
+    false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- New `TursoClient` struct in `src/turso.rs` implementing `DataSource` trait via the libsql crate's HTTP protocol
- Gated behind optional `turso` feature flag (`cargo build --features turso`) to keep default binary lean
- All sync commands supported: push, pull, sync, diff, status, watch, stash, retrieve
- Config: `[target] type = "turso"` with `url` and `auth_token` fields

## Status: On Hold

**2026-04-03**: Sean reframed smuggler as a data lake manager for SQLite-like data with many sources (D1, DO, Turso, S3, etc.) and a runtime plugin architecture. Compile-time feature flags don't scale to N adapters. This PR's code is correct but will be refactored into a runtime-loadable adapter once #51 (library crate extraction) and the plugin architecture ship. Leaving open as reference implementation.

## Changes

- `src/turso.rs` (new) -- TursoClient with all 6 DataSource methods, value conversion helpers, 18 unit tests
- `src/error.rs` -- `SyncError::Turso(String)` variant (feature-gated)
- `src/config.rs` -- `TargetConfig::Turso` and `ResolvedTarget::Turso` variants (feature-gated)
- `src/main.rs` -- Turso arms in all command handlers (feature-gated)
- `src/watch.rs` -- Turso arm in watch tick loop (feature-gated)
- `Cargo.toml` -- libsql 0.9 optional dep, `turso` feature flag

## Test plan

- [x] 177 tests pass without turso feature
- [x] 195 tests pass with turso feature
- [x] Clippy clean both configs, fmt clean

Closes #52