### PR TITLE
chore: post-merge cleanup from simplify review

### DIFF
--- a/crates/smuggler-core/src/lib.rs
+++ b/crates/smuggler-core/src/lib.rs
@@ -23,4 +23,4 @@ pub use diff::{diff_table, DiffStats, TableDiff};
 pub use error::{Result, SyncError};
 pub use local::LocalDb;
 pub use remote::D1Client;
-pub use sync::{pull_all, push_all, sync_all, NoProgress, SyncProgress, SyncResult};
+pub use sync::{pull_all, push_all, sync_all, DiffDetail, NoProgress, SyncProgress, SyncResult};

--- a/crates/smuggler/src/main.rs
+++ b/crates/smuggler/src/main.rs
@@ -66,6 +66,14 @@ impl SyncProgress for IndicatifProgress {
     }
 }
 
+fn make_progress(fmt: OutputFormat) -> Box<dyn SyncProgress> {
+    if fmt == OutputFormat::Text {
+        Box::new(IndicatifProgress::new())
+    } else {
+        Box::new(NoProgress)
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "smuggler")]
 #[command(
@@ -402,11 +410,7 @@ async fn run_push(
     let local = LocalDb::open_readonly(config.local_db_path())?;
     let tables = resolve_tables(&local, table)?;
 
-    let progress: Box<dyn SyncProgress> = if fmt == OutputFormat::Text {
-        Box::new(IndicatifProgress::new())
-    } else {
-        Box::new(NoProgress)
-    };
+    let progress = make_progress(fmt);
 
     let results = match target {
         ResolvedTarget::D1 {
@@ -465,11 +469,7 @@ async fn run_pull(
     };
     let tables = resolve_tables(&local, table)?;
 
-    let progress: Box<dyn SyncProgress> = if fmt == OutputFormat::Text {
-        Box::new(IndicatifProgress::new())
-    } else {
-        Box::new(NoProgress)
-    };
+    let progress = make_progress(fmt);
 
     let results = match target {
         ResolvedTarget::D1 {
@@ -528,11 +528,7 @@ async fn run_sync(
     };
     let tables = resolve_tables(&local, table)?;
 
-    let progress: Box<dyn SyncProgress> = if fmt == OutputFormat::Text {
-        Box::new(IndicatifProgress::new())
-    } else {
-        Box::new(NoProgress)
-    };
+    let progress = make_progress(fmt);
 
     let results = match target {
         ResolvedTarget::D1 {

--- a/crates/smuggler/src/watch.rs
+++ b/crates/smuggler/src/watch.rs
@@ -58,7 +58,7 @@ pub async fn run_watch(
                             warn!("Connection test failed on tick #{}: {}. Will retry next tick.", tick_count, e);
                             if fmt == OutputFormat::Json {
                                 let out = WatchTickOutput::from_error(tick_count, &e.to_string());
-                                println!("{}", serde_json::to_string(&out).unwrap());
+                                println!("{}", serde_json::to_string(&out).expect("WatchTickOutput is always serializable"));
                             }
                             continue;
                         }
@@ -78,7 +78,7 @@ pub async fn run_watch(
 
                         if fmt == OutputFormat::Json {
                             let out = WatchTickOutput::from_results(tick_count, &results);
-                            println!("{}", serde_json::to_string(&out).unwrap());
+                            println!("{}", serde_json::to_string(&out).expect("WatchTickOutput is always serializable"));
                         } else if total_pushed > 0 || total_pulled > 0 {
                             info!(
                                 "Tick #{}: {} pushed, {} pulled across {} tables",
@@ -100,13 +100,13 @@ pub async fn run_watch(
                             warn!("Transient error on tick #{}: {}. Will retry next tick.", tick_count, e);
                             if fmt == OutputFormat::Json {
                                 let out = WatchTickOutput::from_error(tick_count, &e.to_string());
-                                println!("{}", serde_json::to_string(&out).unwrap());
+                                println!("{}", serde_json::to_string(&out).expect("WatchTickOutput is always serializable"));
                             }
                         } else {
                             error!("Fatal error on tick #{}: {}", tick_count, e);
                             if fmt == OutputFormat::Json {
                                 let out = WatchTickOutput::from_error(tick_count, &e.to_string());
-                                println!("{}", serde_json::to_string(&out).unwrap());
+                                println!("{}", serde_json::to_string(&out).expect("WatchTickOutput is always serializable"));
                             }
                             return Err(e);
                         }


### PR DESCRIPTION
## Summary

Post-merge simplify review on #51 (library crate extraction). Fixes found by the three-agent review that should have run before merge.

- Add `DiffDetail` to smuggler-core re-exports (was missing from public API)
- Extract `make_progress()` helper (identical block was duplicated 3x in main.rs)
- Replace `.unwrap()` with `.expect()` on watch daemon JSON serialization

## Test plan

- [x] 177 tests pass (166 core + 11 CLI)
- [x] Clippy and fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)