### PR TITLE
feat: feature-gate native deps for WASM compilation

### DIFF
--- a/crates/smugglr-core/Cargo.toml
+++ b/crates/smugglr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smugglr-core"
-description = "Sync engine for smugglr -- bidirectional SQLite/D1 synchronization"
+description = "SQLite replication engine -- content-hash diffing, delta sync, any target"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -8,42 +8,58 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[features]
+default = ["native"]
+native = [
+    "dep:rusqlite",
+    "dep:reqwest",
+    "dep:tokio",
+    "dep:object_store",
+    "dep:url",
+    "dep:tempfile",
+    "dep:chacha20poly1305",
+    "dep:rand",
+    "dep:libc",
+]
+
 [dependencies]
-# SQLite
-rusqlite = { version = "0.34", features = ["bundled"] }
-
-# HTTP client
-reqwest = { version = "0.12", features = ["json"] }
-
-# Async runtime
-tokio = { version = "1", features = ["full"] }
-
-# Serialization
+# Serialization (always needed)
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-# Config
+# Config (always needed)
 toml = "0.8"
 
-# Error handling
+# Error handling (always needed)
 thiserror = "2"
 anyhow = "1"
 
-# Hashing for change detection
+# Hashing for change detection (always needed, WASM-compatible)
 sha2 = "0.10"
 hex = "0.4"
 
-# Object storage (S3, R2, GCS, local filesystem)
-object_store = { version = "0.12", features = ["aws"] }
-url = "2"
-tempfile = "3"
-
-# Encryption (broadcast packets)
-chacha20poly1305 = "0.5"
-rand = "0.9"
-
-# Logging
+# Logging (always needed)
 tracing = "0.1"
 
+# -- Native-only dependencies --
+
+# SQLite
+rusqlite = { version = "0.34", features = ["bundled"], optional = true }
+
+# HTTP client
+reqwest = { version = "0.12", features = ["json"], optional = true }
+
+# Async runtime
+tokio = { version = "1", features = ["full"], optional = true }
+
+# Object storage (S3, R2, GCS, local filesystem)
+object_store = { version = "0.12", features = ["aws"], optional = true }
+url = { version = "2", optional = true }
+tempfile = { version = "3", optional = true }
+
+# Encryption (broadcast packets)
+chacha20poly1305 = { version = "0.5", optional = true }
+rand = { version = "0.9", optional = true }
+
 # Unix process checking (PID lock)
-libc = "0.2"
+libc = { version = "0.2", optional = true }

--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub target: Option<TargetConfig>,
 
     /// LAN broadcast sync configuration
+    #[cfg(feature = "native")]
     pub broadcast: Option<crate::broadcast::BroadcastConfig>,
 }
 
@@ -407,9 +408,18 @@ impl Config {
                                 .unwrap_or_else(|| p.clone());
                             (pb, n)
                         }
-                        (Some(n), None) => {
-                            let pb = crate::plugin::resolve_plugin_path(n)?;
-                            (pb, n.clone())
+                        (Some(_n), None) => {
+                            #[cfg(feature = "native")]
+                            {
+                                let pb = crate::plugin::resolve_plugin_path(_n)?;
+                                (pb, _n.clone())
+                            }
+                            #[cfg(not(feature = "native"))]
+                            {
+                                return Err(SyncError::Config(
+                                    "Plugin targets require the 'native' feature".into(),
+                                ));
+                            }
                         }
                         (None, None) => {
                             return Err(SyncError::Config(

--- a/crates/smugglr-core/src/error.rs
+++ b/crates/smugglr-core/src/error.rs
@@ -7,12 +7,14 @@ pub enum SyncError {
     #[error("Configuration error: {0}")]
     Config(String),
 
+    #[cfg(feature = "native")]
     #[error("Local database error: {0}")]
     LocalDb(#[from] rusqlite::Error),
 
     #[error("Remote API error: {0}")]
     Remote(String),
 
+    #[cfg(feature = "native")]
     #[error("HTTP request error: {0}")]
     Http(#[from] reqwest::Error),
 
@@ -57,6 +59,7 @@ pub enum SyncError {
     #[error("Invalid table name '{name}'. Available tables: [{available}]")]
     InvalidTableName { name: String, available: String },
 
+    #[cfg(feature = "native")]
     #[error("Object store error: {0}")]
     ObjectStore(#[from] object_store::Error),
 
@@ -109,6 +112,7 @@ impl SyncError {
             SyncError::RateLimited { .. } => true,
             SyncError::ServerError { status, .. } if *status >= 500 => true,
             SyncError::ConnectionTimeout => true,
+            #[cfg(feature = "native")]
             SyncError::Http(e) => e.is_timeout() || e.is_connect(),
             _ => false,
         }
@@ -142,8 +146,9 @@ impl SyncError {
             SyncError::InvalidTableName { .. } | SyncError::NoPrimaryKey(_) => 2,
             SyncError::ParamLimitExceeded { .. } => 2,
 
-            SyncError::Http(_)
-            | SyncError::RateLimited { .. }
+            #[cfg(feature = "native")]
+            SyncError::Http(_) => 3,
+            SyncError::RateLimited { .. }
             | SyncError::ServerError { .. }
             | SyncError::ConnectionTimeout
             | SyncError::RetryExhausted { .. } => 3,

--- a/crates/smugglr-core/src/lib.rs
+++ b/crates/smugglr-core/src/lib.rs
@@ -1,28 +1,42 @@
-//! smugglr-core: sync engine for bidirectional SQLite/D1 synchronization.
+//! smugglr: SQLite replication across platforms.
 //!
-//! This crate contains the core sync logic without any CLI dependencies.
-//! It can be used as a library by other Rust applications that need
-//! SQLite <-> D1 synchronization.
+//! Core sync engine: content-hash diffing, delta computation, bidirectional
+//! replication. Use as a library from Rust or compile to WASM for browser use.
+//!
+//! The `native` feature (default) enables platform-specific backends:
+//! LocalDb (rusqlite), D1Client, PluginDataSource, broadcast, stash, daemon.
+//! Without it, only the diff/sync engine and trait definitions are available.
 
 pub mod batch;
-pub mod broadcast;
 pub mod config;
-pub mod daemon;
 pub mod datasource;
 pub mod diff;
 pub mod error;
-pub mod local;
-pub mod plugin;
-pub mod remote;
-pub mod stash;
 pub mod sync;
 pub mod table;
+
+#[cfg(feature = "native")]
+pub mod broadcast;
+#[cfg(feature = "native")]
+pub mod daemon;
+#[cfg(feature = "native")]
+pub mod local;
+#[cfg(feature = "native")]
+pub mod plugin;
+#[cfg(feature = "native")]
+pub mod remote;
+#[cfg(feature = "native")]
+pub mod stash;
 
 pub use config::Config;
 pub use datasource::DataSource;
 pub use diff::{diff_table, DiffStats, TableDiff};
 pub use error::{Result, SyncError};
-pub use local::LocalDb;
-pub use plugin::PluginDataSource;
-pub use remote::D1Client;
 pub use sync::{pull_all, push_all, sync_all, DiffDetail, NoProgress, SyncProgress, SyncResult};
+
+#[cfg(feature = "native")]
+pub use local::LocalDb;
+#[cfg(feature = "native")]
+pub use plugin::PluginDataSource;
+#[cfg(feature = "native")]
+pub use remote::D1Client;


### PR DESCRIPTION
## Summary

- Feature-gate native-only dependencies in smugglr-core behind a `native` feature (default on)
- `rusqlite`, `reqwest`, `tokio`, `object_store`, `chacha20poly1305`, `rand`, `libc` gated behind `native`
- Modules `local`, `remote`, `plugin`, `broadcast`, `daemon`, `stash` conditionally compiled
- With `--no-default-features`, smugglr-core compiles to `wasm32-unknown-unknown`
- WASM-compatible surface: diff engine, sync logic, config parsing, DataSource trait, batch splitting

Cherry-picked from the rename branch where this was developed but not included in the rename PR merge.

Closes #68 (first acceptance criterion: smugglr-core compiles to wasm32-unknown-unknown)

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p smugglr-core --no-default-features` passes
- [x] `cargo check -p smugglr-core` (native, default features) passes
- [ ] CI confirms both targets compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)