### PR TITLE
fix: enable WAL mode in LocalDb::open

### DIFF
--- a/crates/smugglr-core/src/local.rs
+++ b/crates/smugglr-core/src/local.rs
@@ -28,6 +28,14 @@ impl LocalDb {
 
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
 
+        let mode: String = conn.query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))?;
+        if mode != "wal" {
+            tracing::warn!(
+                journal_mode = %mode,
+                "WAL mode unavailable (network filesystem?). Concurrent write access may deadlock."
+            );
+        }
+
         Ok(Self {
             conn: Mutex::new(conn),
         })


### PR DESCRIPTION
## Problem

`LocalDb::open` opened the connection in the default journal mode (DELETE/rollback). When a concurrent reader holds the file open — specifically legion daemon polling `data_version` — SQLite's default serialization causes write latency and deadlock risk under contention.

## Fix

Execute `PRAGMA journal_mode=WAL` immediately after opening the connection. WAL allows one writer and any number of readers to proceed concurrently without blocking each other.

The result is checked: if SQLite returns anything other than `"wal"` (happens on network filesystems where WAL is unavailable), a structured warning is logged rather than hard-failing.

Read-only connections (`open_readonly`) are unaffected — WAL mode is a file-level property set by the writer.

## Test plan

- [ ] `cargo check -p smugglr-core` passes
- [ ] Open a DB with `LocalDb::open`, verify `PRAGMA journal_mode` returns `wal`
- [ ] Concurrent read connection no longer blocks writes under WAL

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)