### PR TITLE
refactor(#82): route D1 config to http-sql plugin

### DIFF
--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -713,6 +713,37 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_target_d1_with_url() {
+        // Covers the `if let Some(u) = url` branch in resolve_d1_plugin_target.
+        // A D1 config with an explicit url (e.g. for a self-hosted HTTP bridge
+        // via the Durable Objects template) must round-trip through the plugin
+        // config map so the http-sql adapter can pick it up.
+        let config = Config {
+            cloudflare_account_id: None,
+            cloudflare_api_token: None,
+            database_id: None,
+            local_db: Some("test.db".into()),
+            sync: SyncConfig::default(),
+            stash: None,
+            target: Some(TargetConfig::D1 {
+                account_id: "acct".into(),
+                database_id: "db".into(),
+                api_token: "tok".into(),
+                url: Some("https://bridge.example.com".into()),
+            }),
+            broadcast: None,
+        };
+        let target = config.resolve_target().unwrap();
+        assert_d1_plugin(
+            &target,
+            "acct",
+            "db",
+            "tok",
+            Some("https://bridge.example.com"),
+        );
+    }
+
+    #[test]
     fn test_resolve_target_explicit_overrides_legacy() {
         let config = Config {
             cloudflare_account_id: Some("old_acct".into()),

--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -403,12 +403,7 @@ impl Config {
                     database_id,
                     api_token,
                     url,
-                } => ResolvedTarget::D1 {
-                    account_id: account_id.clone(),
-                    database_id: database_id.clone(),
-                    api_token: api_token.clone(),
-                    url: url.clone(),
-                },
+                } => resolve_d1_plugin_target(account_id, database_id, api_token, url.as_deref())?,
                 TargetConfig::Sqlite { database } => ResolvedTarget::Sqlite {
                     database: database.clone(),
                 },
@@ -456,12 +451,9 @@ impl Config {
             &self.database_id,
             &self.cloudflare_api_token,
         ) {
-            (Some(account_id), Some(database_id), Some(api_token)) => Ok(ResolvedTarget::D1 {
-                account_id: account_id.clone(),
-                database_id: database_id.clone(),
-                api_token: api_token.clone(),
-                url: None,
-            }),
+            (Some(account_id), Some(database_id), Some(api_token)) => {
+                resolve_d1_plugin_target(account_id, database_id, api_token, None)
+            }
             _ => Err(SyncError::Config(
                 "No target configured. Add a [target] section or set cloudflare_account_id, database_id, and cloudflare_api_token.".to_string()
             )),
@@ -496,6 +488,60 @@ impl Config {
     pub fn retry_config(&self) -> RetryConfig {
         RetryConfig::from_sync_config(&self.sync)
     }
+}
+
+/// Build a `ResolvedTarget::Plugin` for the http-sql plugin with a d1 profile.
+///
+/// Both the explicit `[target] type = "d1"` branch and the legacy flat-fields branch
+/// funnel through here. The `ResolvedTarget::D1` variant is preserved in the enum for
+/// issue #83 which removes it entirely; at runtime, D1 config always resolves to a plugin.
+fn resolve_d1_plugin_target(
+    account_id: &str,
+    database_id: &str,
+    api_token: &str,
+    url: Option<&str>,
+) -> Result<ResolvedTarget> {
+    let mut plugin_config = HashMap::new();
+    plugin_config.insert("profile".to_string(), "d1".to_string());
+    plugin_config.insert("account_id".to_string(), account_id.to_string());
+    plugin_config.insert("database_id".to_string(), database_id.to_string());
+    plugin_config.insert("api_token".to_string(), api_token.to_string());
+    if let Some(u) = url {
+        plugin_config.insert("url".to_string(), u.to_string());
+    }
+
+    let plugin_path = resolve_http_sql_plugin_path()?;
+
+    Ok(ResolvedTarget::Plugin {
+        path: plugin_path,
+        name: "smugglr-http-sql".to_string(),
+        config: plugin_config,
+    })
+}
+
+/// Resolve the path to the smugglr-http-sql plugin binary.
+///
+/// Under `cfg(test)` a placeholder path is returned so unit tests can assert on
+/// config synthesis without requiring the binary to be installed.
+#[cfg(test)]
+fn resolve_http_sql_plugin_path() -> Result<PathBuf> {
+    Ok(PathBuf::from("/fake/smugglr-http-sql"))
+}
+
+#[cfg(all(not(test), feature = "native"))]
+fn resolve_http_sql_plugin_path() -> Result<PathBuf> {
+    crate::plugin::resolve_plugin_path("http-sql").map_err(|_| {
+        SyncError::Config(
+            "D1 target requires the smugglr-http-sql plugin. Install it with: cargo install smugglr-http-sql".into(),
+        )
+    })
+}
+
+#[cfg(all(not(test), not(feature = "native")))]
+fn resolve_http_sql_plugin_path() -> Result<PathBuf> {
+    Err(SyncError::Config(
+        "D1 target requires the 'native' feature".into(),
+    ))
 }
 
 /// Auto-detect the local D1 database from wrangler's state directory
@@ -606,7 +652,26 @@ mod tests {
     fn test_resolve_target_legacy_d1() {
         let config = test_config_d1();
         let target = config.resolve_target().unwrap();
-        assert!(matches!(target, ResolvedTarget::D1 { .. }));
+        match target {
+            ResolvedTarget::Plugin { name, config, .. } => {
+                assert_eq!(name, "smugglr-http-sql");
+                assert_eq!(config.get("profile").map(String::as_str), Some("d1"));
+                assert_eq!(
+                    config.get("account_id").map(String::as_str),
+                    Some("test_acct")
+                );
+                assert_eq!(
+                    config.get("database_id").map(String::as_str),
+                    Some("test_db")
+                );
+                assert_eq!(
+                    config.get("api_token").map(String::as_str),
+                    Some("test_token")
+                );
+                assert!(config.get("url").is_none());
+            }
+            _ => panic!("expected plugin target for legacy d1 config"),
+        }
     }
 
     #[test]
@@ -637,7 +702,17 @@ mod tests {
             broadcast: None,
         };
         let target = config.resolve_target().unwrap();
-        assert!(matches!(target, ResolvedTarget::D1 { .. }));
+        match target {
+            ResolvedTarget::Plugin { name, config, .. } => {
+                assert_eq!(name, "smugglr-http-sql");
+                assert_eq!(config.get("profile").map(String::as_str), Some("d1"));
+                assert_eq!(config.get("account_id").map(String::as_str), Some("acct"));
+                assert_eq!(config.get("database_id").map(String::as_str), Some("db"));
+                assert_eq!(config.get("api_token").map(String::as_str), Some("tok"));
+                assert!(config.get("url").is_none());
+            }
+            _ => panic!("expected plugin target for explicit d1 config"),
+        }
     }
 
     #[test]
@@ -796,17 +871,17 @@ api_token = "tok789"
         let config: Config = toml::from_str(toml_str).unwrap();
         let target = config.resolve_target().unwrap();
         match target {
-            ResolvedTarget::D1 {
-                account_id,
-                database_id,
-                api_token,
-                ..
-            } => {
-                assert_eq!(account_id, "acct123");
-                assert_eq!(database_id, "db456");
-                assert_eq!(api_token, "tok789");
+            ResolvedTarget::Plugin { name, config, .. } => {
+                assert_eq!(name, "smugglr-http-sql");
+                assert_eq!(config.get("profile").map(String::as_str), Some("d1"));
+                assert_eq!(
+                    config.get("account_id").map(String::as_str),
+                    Some("acct123")
+                );
+                assert_eq!(config.get("database_id").map(String::as_str), Some("db456"));
+                assert_eq!(config.get("api_token").map(String::as_str), Some("tok789"));
             }
-            _ => panic!("expected d1"),
+            _ => panic!("expected plugin target for d1 toml config"),
         }
     }
 
@@ -821,7 +896,16 @@ local_db = "game.db"
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.target.is_none());
         let target = config.resolve_target().unwrap();
-        assert!(matches!(target, ResolvedTarget::D1 { .. }));
+        match target {
+            ResolvedTarget::Plugin { name, config, .. } => {
+                assert_eq!(name, "smugglr-http-sql");
+                assert_eq!(config.get("profile").map(String::as_str), Some("d1"));
+                assert_eq!(config.get("account_id").map(String::as_str), Some("acct"));
+                assert_eq!(config.get("api_token").map(String::as_str), Some("tok"));
+                assert_eq!(config.get("database_id").map(String::as_str), Some("db"));
+            }
+            _ => panic!("expected plugin target for legacy d1 toml config"),
+        }
     }
 
     // -- Column exclusion tests --

--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -388,9 +388,11 @@ impl Config {
             }
         }
 
-        // Validate that we have a resolvable target
-        config.resolve_target()?;
-
+        // Target resolution is deferred to command dispatch: some commands
+        // (broadcast, stash, retrieve, snapshot, restore) never touch the
+        // target and must not fail at load time if the plugin binary is
+        // missing. See crates/smugglr/src/main.rs for where target resolution
+        // actually runs.
         Ok(config)
     }
 
@@ -523,25 +525,22 @@ fn resolve_d1_plugin_target(
 ///
 /// Under `cfg(test)` a placeholder path is returned so unit tests can assert on
 /// config synthesis without requiring the binary to be installed.
-#[cfg(test)]
 fn resolve_http_sql_plugin_path() -> Result<PathBuf> {
-    Ok(PathBuf::from("/fake/smugglr-http-sql"))
-}
-
-#[cfg(all(not(test), feature = "native"))]
-fn resolve_http_sql_plugin_path() -> Result<PathBuf> {
-    crate::plugin::resolve_plugin_path("http-sql").map_err(|_| {
-        SyncError::Config(
-            "D1 target requires the smugglr-http-sql plugin. Install it with: cargo install smugglr-http-sql".into(),
-        )
-    })
-}
-
-#[cfg(all(not(test), not(feature = "native")))]
-fn resolve_http_sql_plugin_path() -> Result<PathBuf> {
-    Err(SyncError::Config(
-        "D1 target requires the 'native' feature".into(),
-    ))
+    #[cfg(test)]
+    {
+        Ok(PathBuf::from("/fake/smugglr-http-sql"))
+    }
+    #[cfg(all(not(test), feature = "native"))]
+    {
+        crate::plugin::resolve_plugin_path("http-sql")
+            .map_err(|_| SyncError::Config("d1 target requires the smugglr-http-sql plugin".into()))
+    }
+    #[cfg(all(not(test), not(feature = "native")))]
+    {
+        Err(SyncError::Config(
+            "d1 target requires the 'native' feature".into(),
+        ))
+    }
 }
 
 /// Auto-detect the local D1 database from wrangler's state directory
@@ -629,6 +628,33 @@ mod tests {
         }
     }
 
+    /// Assert that `target` is a `ResolvedTarget::Plugin` pointing at the
+    /// http-sql plugin with a synthesized d1 profile config. Used by every
+    /// test that exercises the D1-to-plugin routing in `resolve_target`.
+    fn assert_d1_plugin(
+        target: &ResolvedTarget,
+        account_id: &str,
+        database_id: &str,
+        api_token: &str,
+        url: Option<&str>,
+    ) {
+        let ResolvedTarget::Plugin { name, config, .. } = target else {
+            panic!("expected plugin target, got {:?}", target);
+        };
+        assert_eq!(name, "smugglr-http-sql");
+        assert_eq!(config.get("profile").map(String::as_str), Some("d1"));
+        assert_eq!(
+            config.get("account_id").map(String::as_str),
+            Some(account_id)
+        );
+        assert_eq!(
+            config.get("database_id").map(String::as_str),
+            Some(database_id)
+        );
+        assert_eq!(config.get("api_token").map(String::as_str), Some(api_token));
+        assert_eq!(config.get("url").map(String::as_str), url);
+    }
+
     #[test]
     fn test_default_excludes() {
         let config = test_config_d1();
@@ -652,26 +678,7 @@ mod tests {
     fn test_resolve_target_legacy_d1() {
         let config = test_config_d1();
         let target = config.resolve_target().unwrap();
-        match target {
-            ResolvedTarget::Plugin { name, config, .. } => {
-                assert_eq!(name, "smugglr-http-sql");
-                assert_eq!(config.get("profile").map(String::as_str), Some("d1"));
-                assert_eq!(
-                    config.get("account_id").map(String::as_str),
-                    Some("test_acct")
-                );
-                assert_eq!(
-                    config.get("database_id").map(String::as_str),
-                    Some("test_db")
-                );
-                assert_eq!(
-                    config.get("api_token").map(String::as_str),
-                    Some("test_token")
-                );
-                assert!(config.get("url").is_none());
-            }
-            _ => panic!("expected plugin target for legacy d1 config"),
-        }
+        assert_d1_plugin(&target, "test_acct", "test_db", "test_token", None);
     }
 
     #[test]
@@ -702,17 +709,7 @@ mod tests {
             broadcast: None,
         };
         let target = config.resolve_target().unwrap();
-        match target {
-            ResolvedTarget::Plugin { name, config, .. } => {
-                assert_eq!(name, "smugglr-http-sql");
-                assert_eq!(config.get("profile").map(String::as_str), Some("d1"));
-                assert_eq!(config.get("account_id").map(String::as_str), Some("acct"));
-                assert_eq!(config.get("database_id").map(String::as_str), Some("db"));
-                assert_eq!(config.get("api_token").map(String::as_str), Some("tok"));
-                assert!(config.get("url").is_none());
-            }
-            _ => panic!("expected plugin target for explicit d1 config"),
-        }
+        assert_d1_plugin(&target, "acct", "db", "tok", None);
     }
 
     #[test]
@@ -870,19 +867,7 @@ api_token = "tok789"
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         let target = config.resolve_target().unwrap();
-        match target {
-            ResolvedTarget::Plugin { name, config, .. } => {
-                assert_eq!(name, "smugglr-http-sql");
-                assert_eq!(config.get("profile").map(String::as_str), Some("d1"));
-                assert_eq!(
-                    config.get("account_id").map(String::as_str),
-                    Some("acct123")
-                );
-                assert_eq!(config.get("database_id").map(String::as_str), Some("db456"));
-                assert_eq!(config.get("api_token").map(String::as_str), Some("tok789"));
-            }
-            _ => panic!("expected plugin target for d1 toml config"),
-        }
+        assert_d1_plugin(&target, "acct123", "db456", "tok789", None);
     }
 
     #[test]
@@ -896,16 +881,7 @@ local_db = "game.db"
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.target.is_none());
         let target = config.resolve_target().unwrap();
-        match target {
-            ResolvedTarget::Plugin { name, config, .. } => {
-                assert_eq!(name, "smugglr-http-sql");
-                assert_eq!(config.get("profile").map(String::as_str), Some("d1"));
-                assert_eq!(config.get("account_id").map(String::as_str), Some("acct"));
-                assert_eq!(config.get("api_token").map(String::as_str), Some("tok"));
-                assert_eq!(config.get("database_id").map(String::as_str), Some("db"));
-            }
-            _ => panic!("expected plugin target for legacy d1 toml config"),
-        }
+        assert_d1_plugin(&target, "acct", "db", "tok", None);
     }
 
     // -- Column exclusion tests --


### PR DESCRIPTION
## Summary

Routes `TargetConfig::D1` and legacy flat D1 fields (`cloudflare_account_id`, `database_id`, `cloudflare_api_token`) through `ResolvedTarget::Plugin` with the http-sql plugin and a synthesized `d1` profile config, instead of the hardcoded `ResolvedTarget::D1` variant. Middle step of the D1 extraction trilogy (#80 parent, #81/#84 batch upsert merged, #82 this PR, #83 removes `ResolvedTarget::D1` and `D1Client` entirely).

Both old and new config formats keep working. The `ResolvedTarget::D1` variant is intentionally preserved -- removing it is #83's job. All existing D1 match arms in `main.rs` and `watch.rs` continue to compile; they just become dead at runtime.

## Changes

Single file: `crates/smugglr-core/src/config.rs` (+122 / -31 net vs main, three commits).

- New private helper `resolve_d1_plugin_target(account_id, database_id, api_token, url)` builds a `ResolvedTarget::Plugin` with name `"smugglr-http-sql"` and a `HashMap<String, String>` containing `profile=d1` + credentials + optional `url`.
- New private helper `resolve_http_sql_plugin_path()` with inline `#[cfg]` branches for `test` / `native` / `not(native)`.
- Both `TargetConfig::D1` and the legacy flat-fields branch in `resolve_target` funnel through the new helper.
- **`Config::load` no longer eagerly calls `resolve_target()` for validation.** Pre-#82 this was free for D1 configs (no I/O); post-routing it would hit the filesystem to locate the plugin binary. Commands that never touch the target (`broadcast`, `stash`, `retrieve`, `snapshot`, `restore`) must not fail at config load time if the plugin is missing -- `main.rs` already resolves lazily at dispatch for commands that need it.
- Test helper `assert_d1_plugin(target, account, db, token, url)` DRYs four near-identical assertion blocks.
- New test `test_resolve_target_d1_with_url` covers the `Some(url)` branch (uncovered in the first pass; caught by inspector review).

## Scope compliance

- Only `config.rs` touched
- `ResolvedTarget::D1` variant preserved (removed in #83)
- `main.rs` / `watch.rs` D1 match arms untouched
- `remote.rs` / `D1Client` unchanged
- `TargetConfig::D1` TOML parsing unchanged (kept as config sugar)

## Gates

- `cargo test --workspace --exclude smugglr-wasm`: **237 tests passing** (198 smugglr-core, 11 smugglr, 13 smugglr-http-sql, 15 smugglr-plugin-sdk)
- `cargo clippy --workspace --exclude smugglr-wasm -- -D warnings`: clean
- `cargo fmt -- --check`: clean
- `legion quality-gate record` (legion-simplify): clean, no findings (gate ID 019d7c42-cc13-77f0-b3ae-a62388213a84)

**Note on smugglr-wasm exclusion:** `crates/smugglr-wasm` has 23 pre-existing type inference errors in `fetch_adapter.rs` and `lib.rs` on main -- verified by checking out main and running `cargo check -p smugglr-wasm`. Not introduced by this PR. Should be tracked as a separate issue; this PR should not be blocked on it.

## Commits

1. `c629259` feat(#82): route D1 config to http-sql plugin -- main implementation by cargo agent
2. `81aa3c7` refactor(#82): simplify pass -- drop eager validation, collapse cfg variants, DRY tests, lowercase error messages
3. `896dd8a` test(#82): cover D1 url round-trip through plugin config map -- closes inspector-flagged coverage gap

## Test plan

- [x] `cargo test -p smugglr-core` passes (198 tests, +1 new url coverage)
- [x] Legacy flat D1 config resolves to Plugin variant with synthesized d1 profile
- [x] Explicit `[target] type = "d1"` resolves to Plugin variant
- [x] D1 config with explicit `url` field round-trips through plugin config map
- [x] Sqlite target still resolves to Sqlite variant (no regression)
- [x] Missing config still errors at `resolve_target` time
- [ ] **Manual smoke test before merge**: run `smugglr push` against a real D1 target with `smugglr-http-sql` installed on PATH
- [ ] **Manual smoke test**: run `smugglr broadcast` with a D1 config and `smugglr-http-sql` NOT installed -- should succeed (verifies the Config::load deferred-resolution fix)

Closes #82.