### PR TITLE
fix(#93): gate smugglr-wasm on target_arch=wasm32

### DIFF
--- a/crates/smugglr-wasm/src/lib.rs
+++ b/crates/smugglr-wasm/src/lib.rs
@@ -7,6 +7,14 @@
 //! requires Send futures for tokio) and drives the diff engine directly against
 //! FetchDataSource. The diff algorithm, conflict resolution, and batch planning
 //! are all from smugglr-core.
+//!
+//! Compilation gate: this crate requires `target_arch = "wasm32"`. FetchDataSource
+//! uses `!Send` types (JsFuture, Rc, RefCell) which are incompatible with the
+//! `Send` futures that smugglr-core's DataSource trait requires on multi-threaded
+//! targets. Under `wasm32-unknown-unknown` the single-threaded target relaxes
+//! `Send` bounds and the crate builds cleanly. See issue #93 for details.
+
+#![cfg(target_arch = "wasm32")]
 
 mod fetch_adapter;
 


### PR DESCRIPTION
## Summary

Closes #93. Adds `#![cfg(target_arch = "wasm32")]` at the top of `crates/smugglr-wasm/src/lib.rs` so the crate compiles to an empty library on host targets while keeping full functionality under `wasm32-unknown-unknown`.

## Why

From a clean checkout on main:

```
$ cargo check -p smugglr-wasm
error[E0282]: type annotations needed ... 23 errors
```

`FetchDataSource` uses `!Send` types (`JsFuture`, `Rc`, `RefCell`) that conflict with the `Send` futures `smugglr-core::DataSource` requires on multi-threaded targets. Under wasm32 the single-threaded target relaxes the `Send` bound so the crate builds. Under host target the 23 errors break every `--workspace` gate, including the three documented in CLAUDE.md.

The workspace root already excludes `smugglr-wasm` from `default-members`, so `cargo test` (no flags) works. But the gates use `--workspace`, which overrides `default-members`. Either the gates needed to change or the crate needed to gate itself. Gating the crate localizes the fix and makes the constraint self-documenting.

## Changes

- `crates/smugglr-wasm/src/lib.rs`: 1 new crate-level attribute + doc comment explaining the constraint and pointing at #93

## Verification

```
cargo test --workspace          -> 237 tests passing
cargo clippy --workspace        -> -D warnings clean
cargo fmt -- --check            -> clean
cargo check -p smugglr-wasm --target wasm32-unknown-unknown -> clean
wasm-pack build --target web --dev -> produces pkg/ with same shape as before
```

Unblocks #87 (incremental diff for WASM). Zero behavior change under the wasm target — the crate still compiles the same code and exports the same `Smugglr` type.

## Test plan

- [x] All CLAUDE.md-documented gates pass (`cargo test --workspace`, `cargo clippy --workspace -- -D warnings`, `cargo fmt -- --check`)
- [x] wasm target still compiles (`cargo check -p smugglr-wasm --target wasm32-unknown-unknown`)
- [x] wasm-pack produces usable output (`wasm-pack build --target web --dev`)
- [x] legion-simplify gate clean on HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)