### PR TITLE
chore: clean up npm package exports and dead branch

### DIFF
--- a/packages/smugglr/package.json
+++ b/packages/smugglr/package.json
@@ -7,12 +7,12 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./wasm": {
-      "import": "./dist/wasm/smugglr_wasm.js",
-      "types": "./dist/wasm/smugglr_wasm.d.ts"
+      "types": "./dist/wasm/smugglr_wasm.d.ts",
+      "import": "./dist/wasm/smugglr_wasm.js"
     }
   },
   "files": [

--- a/packages/smugglr/src/index.ts
+++ b/packages/smugglr/src/index.ts
@@ -23,9 +23,6 @@ export type {
 };
 export { SmugglrError };
 
-// Re-export setWasm for advanced use (custom bundlers, SSR, etc.)
-export { setWasm };
-
 // WASM module state -- loaded lazily or set explicitly via setWasm().
 let wasmModule: WasmModule | null = null;
 let wasmReady: Promise<WasmModule> | null = null;
@@ -72,7 +69,7 @@ interface WasmSmugglr {
  * setWasm(mod);
  * ```
  */
-function setWasm(mod: WasmModule): void {
+export function setWasm(mod: WasmModule): void {
   wasmModule = mod;
   wasmReady = Promise.resolve(mod);
 }
@@ -81,8 +78,6 @@ async function loadWasm(options?: InitOptions): Promise<WasmModule> {
   if (wasmReady) return wasmReady;
 
   wasmReady = (async () => {
-    if (wasmModule) return wasmModule;
-
     // If the consumer passed a module directly, use it.
     if (options?.wasmModule) {
       const mod = options.wasmModule as WasmModule;
@@ -94,8 +89,7 @@ async function loadWasm(options?: InitOptions): Promise<WasmModule> {
     // Default: dynamic import of the co-located wasm-bindgen output.
     // This path is rewritten by the build script to point at the bundled copy.
     const mod = await import("./wasm/smugglr_wasm.js") as WasmModule;
-    const initArg = options?.wasmUrl ?? undefined;
-    await mod.default(initArg);
+    await mod.default(options?.wasmUrl);
     wasmModule = mod;
     return mod;
   })();


### PR DESCRIPTION
## Summary

Three small fixes in the recently-shipped \`packages/smugglr\` npm package (PR #88):

1. **\`package.json\`**: reorder conditional exports so \`types\` comes before \`import\`. TypeScript resolves conditions in order, so \`types\` must be first or consumers may resolve to the JS file when looking up declarations.

2. **\`src/index.ts\`**: remove unreachable \`if (wasmModule) return wasmModule\` check inside the \`loadWasm\` IIFE. \`wasmModule\` is only set in \`setWasm\` (which also sets \`wasmReady\`) and inside \`loadWasm\` itself, so by the time the IIFE runs, the early \`if (wasmReady)\` return has already covered any case where \`wasmModule\` was set externally.

3. **\`src/index.ts\`**: collapse \`function setWasm\` + separate \`export { setWasm }\` into a direct \`export function setWasm\`. Also drop the \`?? undefined\` on \`wasmUrl\` since the optional chain already returns undefined.

No behavioral changes. Diff is +6/-12.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] No public API changes (\`setWasm\` is still exported with the same signature)
- [ ] Sean should verify the package still builds end-to-end with \`pnpm build\` (requires \`wasm-pack\`)