### PR TITLE
chore: bump to 0.3.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.3.0 (2026-04-11)
+
+The core engine no longer knows about any specific remote backend. `D1Client` and `ResolvedTarget::D1` are gone from `smugglr-core`; every remote is a plugin. The same release ships the sync engine to the browser via WebAssembly and npm.
+
+### Added
+
+- **Durable Objects HTTP bridge template** (`templates/do-bridge/`): Cloudflare Worker that exposes a Durable Object's SQLite storage as a D1-compatible HTTP endpoint, reachable via the http-sql plugin. (#79)
+- **Point-in-time snapshots**: `smugglr snapshot` / `smugglr snapshots` / `smugglr restore <timestamp>` for disaster recovery using existing stash storage. Snapshots land at `<stash-path>/snapshots/<timestamp>.sqlite`. (#78)
+- **Batch upsert support in the http-sql plugin**: bulk row writes over a single HTTP SQL call respecting per-backend parameter limits. (#84)
+- **`smugglr-wasm` crate**: compiles the http-sql client path to WebAssembly so browsers can run delta sync against remote SQL endpoints directly. (#86)
+- **`smugglr` npm package** (initial): TypeScript wrapper over wasm-bindgen output. Exports `Smugglr.init(config)`, `.push()`, `.pull()`, `.sync()`, `.diff()`, and explicit `.dispose()`. Package subpath export `./wasm` for consumers who control WASM loading directly. (#88)
+- **Incremental diff with per-table hash cache for WASM**: subsequent syncs only rehash tables whose source data has actually changed. (#96)
+
+### Changed
+
+- **D1 config routed through http-sql plugin internally**: `[target] type = "d1"` still works as a user-facing config shape; the runtime now synthesizes a plugin profile and launches the http-sql plugin to carry the traffic. No user-visible change. (#92)
+- **`native` feature gate on platform-specific deps**: tokio, reqwest, and rusqlite are gated behind the `native` feature in `smugglr-core`, allowing the diff/sync engine to build for wasm32 without incompatible dependencies. (#77)
+- **`smugglr` npm package cleanup**: fixed conditional exports ordering, removed redundant re-exports and dead initialization branches. (#98)
+- **Broadcast TCP encryption spec** (`docs/plans/broadcast-tcp-encryption.md`): design document for encryption and TCP framing for cross-process broadcast sync. Spec only; no implementation yet. (#95)
+
+### Removed
+
+- **`D1Client` and `ResolvedTarget::D1` removed from `smugglr-core`**: `crates/smugglr-core/src/remote.rs` deleted (904 lines). The sync engine has no hardcoded knowledge of any remote backend. D1, Turso, rqlite, and every other HTTP SQL target are plugin concerns. (#99)
+
+### Fixed
+
+- Gate `smugglr-wasm` crate on `target_arch = "wasm32"` so `cargo test --workspace` on native does not attempt to compile WASM-only code. (#94)
+
 ## 0.2.1 (2026-04-02)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smugglr"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "indicatif",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-http-sql"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "hex",
  "reqwest",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-plugin-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-wasm"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "hex",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Smuggler is a universal SQLite sync engine. It started as a way to sync local de
 - **Pluggable backends** - `DataSource` trait abstracts any database backend
 - **Watch daemon** - Background sync on a configurable interval
 - **Column exclusion** - Skip embedding BLOBs and other large columns with glob patterns
-- **Automatic retries** - Exponential backoff with configurable limits for transient D1 failures
-- **Batched writes** - Respects D1's 100-parameter bind limit, splits large upserts automatically
+- **Automatic retries** - Exponential backoff with configurable limits for transient HTTP failures
+- **Batched writes** - Respects per-backend HTTP SQL parameter limits, splits large upserts automatically
 - **Table validation** - `--table` input validated against live schema before any SQL runs
 
 ## Installation
@@ -104,15 +104,18 @@ smugglr push
 ## Commands
 
 ```
-smugglr status      # Can we phone home?
-smugglr diff        # What's different?
-smugglr push        # Local -> D1 (YOLO)
-smugglr pull        # D1 -> Local (safer YOLO)
-smugglr sync        # Bidirectional (push + pull in one shot)
-smugglr stash       # Local -> S3 relay (cross-machine sync)
-smugglr retrieve    # S3 relay -> Local (cross-machine sync)
-smugglr watch       # Daemon mode (sync on interval)
-smugglr broadcast   # LAN sync (peer discovery + encrypted deltas)
+smugglr status              # Can we phone home?
+smugglr diff                # What's different?
+smugglr push                # Local -> remote (YOLO)
+smugglr pull                # Remote -> local (safer YOLO)
+smugglr sync                # Bidirectional (push + pull in one shot)
+smugglr stash               # Local -> S3 relay (cross-machine sync)
+smugglr retrieve            # S3 relay -> Local (cross-machine sync)
+smugglr watch               # Daemon mode (sync on interval)
+smugglr broadcast           # LAN sync (peer discovery + encrypted deltas)
+smugglr snapshot            # Point-in-time full backup to stash storage
+smugglr snapshots           # List available snapshots
+smugglr restore <timestamp> # Disaster recovery from a snapshot
 ```
 
 ### Options
@@ -160,11 +163,11 @@ Smuggler's sync engine is built on the `DataSource` trait, which abstracts any d
 
 ```
 DataSource (trait)
-  |-- LocalDb    (rusqlite, synchronous)
-  |-- D1Client   (reqwest HTTP, async with retries)
+  |-- LocalDb          (rusqlite, synchronous)
+  |-- PluginDataSource (runtime-loaded external adapter, stdio protocol)
 ```
 
-The diff engine (`diff_table`) and table resolution (`get_tables_to_sync`) are generic over any two `DataSource` implementations. This means the same comparison logic works whether you're syncing local-to-D1, local-to-local, or any future backend.
+The diff engine (`diff_table`) and table resolution (`get_tables_to_sync`) are generic over any two `DataSource` implementations. Every remote backend -- D1, Turso, rqlite, Datasette, SQLiteCloud, StarbaseDB -- is reached through the `smugglr-http-sql` plugin. One plugin, profile-driven: adding a new remote target is a TOML config change, not a core recompile.
 
 ## Cross-Machine Sync (Stash/Retrieve)
 
@@ -218,6 +221,27 @@ smugglr retrieve && legion reindex
 # SessionStop hook
 smugglr stash
 ```
+
+## Browser Sync (npm)
+
+The sync engine compiles to WebAssembly and ships via the `smugglr` package on npm. Browser apps can run content-hashed delta sync against any http-sql-reachable target without a server in the middle.
+
+```ts
+import { Smugglr } from "smugglr";
+
+const s = await Smugglr.init({
+  source: { url: "https://my-db.turso.io", authToken: "tok", profile: "turso" },
+  dest:   { url: "https://api.cloudflare.com/...", authToken: "cf-tok", profile: "d1" },
+  sync:   { tables: ["users", "posts"], conflictResolution: "local_wins" },
+});
+
+await s.sync();
+s.dispose();
+```
+
+The package exports `Smugglr.init(config)` and the same verbs as the CLI: `.push()`, `.pull()`, `.sync()`, `.diff()`. All return typed results. The `./wasm` subpath export is available for consumers who need to control WASM binary loading directly (CDN URL, pre-fetched buffer, bundler import).
+
+This is the current browser story: sync between two remote HTTP SQL endpoints from the browser. Local SQLite storage in the browser is a separate track, not yet shipped.
 
 ## LAN Broadcast Sync
 
@@ -344,7 +368,7 @@ Check that column order and types match. NULL vs empty string will cause hash mi
 ## Development
 
 ```bash
-cargo test                       # Run the tests (165 and counting)
+cargo test                       # Run the tests (224 and counting)
 cargo fmt                        # Format code
 cargo clippy --all-targets       # Lint (including tests)
 RUST_LOG=debug cargo run -- diff # Debug output

--- a/crates/smugglr-core/src/datasource.rs
+++ b/crates/smugglr-core/src/datasource.rs
@@ -50,9 +50,10 @@ impl<T> MaybeSend for T {}
 
 /// Abstraction over a database that can be used as a sync source or destination.
 ///
-/// Both local SQLite databases and remote Cloudflare D1 instances implement
-/// this trait, allowing the diff and sync engines to work generically with
-/// any pair of data sources.
+/// `LocalDb` and `PluginDataSource` implement this trait, letting the diff
+/// and sync engines work generically with any pair of data sources. Remote
+/// backends (D1, Turso, rqlite, Datasette, SQLiteCloud, StarbaseDB) are
+/// reached through the http-sql plugin via `PluginDataSource`.
 pub trait DataSource: Sync {
     /// List all user tables (excluding internal/system tables).
     fn list_tables(&self) -> impl std::future::Future<Output = Result<Vec<String>>> + MaybeSend;

--- a/crates/smugglr/src/main.rs
+++ b/crates/smugglr/src/main.rs
@@ -80,7 +80,7 @@ fn make_progress(fmt: OutputFormat) -> Box<dyn SyncProgress> {
 #[command(
     author,
     version,
-    about = "Smuggle data between SQLite and Cloudflare D1"
+    about = "Smuggle data between SQLite-shaped things"
 )]
 struct Cli {
     /// Path to config file
@@ -101,7 +101,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Push local changes to D1 (local -> remote)
+    /// Push local changes to the remote target (local -> remote)
     Push {
         /// Specific table to push (default: all configured tables)
         #[arg(short, long)]
@@ -112,7 +112,7 @@ enum Commands {
         dry_run: bool,
     },
 
-    /// Pull remote changes to local (D1 -> local)
+    /// Pull changes from the remote target to local (remote -> local)
     Pull {
         /// Specific table to pull (default: all configured tables)
         #[arg(short, long)]

--- a/crates/smugglr/src/main.rs
+++ b/crates/smugglr/src/main.rs
@@ -77,11 +77,7 @@ fn make_progress(fmt: OutputFormat) -> Box<dyn SyncProgress> {
 
 #[derive(Parser)]
 #[command(name = "smugglr")]
-#[command(
-    author,
-    version,
-    about = "Smuggle data between SQLite-shaped things"
-)]
+#[command(author, version, about = "Smuggle data between SQLite-shaped things")]
 struct Cli {
     /// Path to config file
     #[arg(short, long, default_value = "config.toml")]

--- a/packages/smugglr/package.json
+++ b/packages/smugglr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smugglr",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Content-hashed delta sync for SQLite, in the browser",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Workspace crates and npm package bumped to 0.3.0 to match the 0.3.0 docs/CHANGELOG already on this branch.

## Changes
- Cargo.toml workspace.package.version: 0.2.1 -> 0.3.0 (all 5 crates inherit)
- packages/smugglr/package.json: 0.1.0 -> 0.3.0
- Cargo.lock regenerated

## Release plan (post-merge, manual first time to set up OIDC)
1. cargo publish in dep order: smugglr-plugin-sdk -> smugglr-core -> smugglr-http-sql -> smugglr (skip smugglr-wasm)
2. packages/smugglr: pnpm build && npm login && npm publish --access=public
3. Configure GitHub Actions trusted publishers on crates.io + npmjs for 0.4.0+

## Test plan
- [x] cargo check --workspace clean at 0.3.0