### PR TITLE
chore: pin internal crate dep versions for publishing

### DIFF
--- a/crates/smugglr/Cargo.toml
+++ b/crates/smugglr/Cargo.toml
@@ -22,7 +22,7 @@ name = "smugglr"
 path = "src/main.rs"
 
 [dependencies]
-smugglr-core = { path = "../smugglr-core" }
+smugglr-core = { path = "../smugglr-core", version = "0.3.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/plugins/smugglr-http-sql/Cargo.toml
+++ b/plugins/smugglr-http-sql/Cargo.toml
@@ -13,8 +13,8 @@ name = "smugglr-http-sql"
 path = "src/main.rs"
 
 [dependencies]
-smugglr-core = { path = "../../crates/smugglr-core", default-features = false }
-smugglr-plugin-sdk = { path = "../../crates/smugglr-plugin-sdk" }
+smugglr-core = { path = "../../crates/smugglr-core", version = "0.3.0", default-features = false }
+smugglr-plugin-sdk = { path = "../../crates/smugglr-plugin-sdk", version = "0.3.0" }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
cargo publish rejects path-only deps with: `all dependencies must have a version requirement specified when publishing`.

Adds `version = "0.3.0"` alongside `path = ...` for the workspace-internal deps:
- crates/smugglr -> smugglr-core
- plugins/smugglr-http-sql -> smugglr-core, smugglr-plugin-sdk

Without this, the plugin and CLI fail manifest verification at publish time. Caught while publishing 0.3.0 to crates.io (after smugglr-plugin-sdk and smugglr-core were already up). Cherry-fixed locally with --allow-dirty to complete the release; this PR makes it permanent.

## Test plan
- [x] cargo check --workspace clean
- [x] All four crates published to crates.io at 0.3.0