### PR TITLE
chore(0.3.1): crate metadata + npm README, point to smugglr.dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,78 @@ jobs:
           files: |
             artifacts/**/*
             checksums.txt
+
+  publish-crates:
+    name: Publish to crates.io
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Authenticate to crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish smugglr-plugin-sdk
+        run: cargo publish -p smugglr-plugin-sdk
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Publish smugglr-core
+        run: cargo publish -p smugglr-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Publish smugglr-http-sql
+        run: cargo publish -p smugglr-http-sql
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Publish smugglr (CLI)
+        run: cargo publish -p smugglr
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  publish-npm:
+    name: Publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+        working-directory: packages/smugglr
+
+      - name: Build
+        run: pnpm build
+        working-directory: packages/smugglr
+
+      - name: Publish
+        run: npm publish --access=public --provenance
+        working-directory: packages/smugglr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smugglr"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "indicatif",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-http-sql"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "hex",
  "reqwest",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-plugin-sdk"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-wasm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "hex",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"
 repository = "https://github.com/rafters-studio/smugglr"
+homepage = "https://smugglr.dev"
+documentation = "https://smugglr.dev/docs"
 authors = ["Sean Silvius"]
 
 [profile.release]

--- a/crates/smugglr-core/Cargo.toml
+++ b/crates/smugglr-core/Cargo.toml
@@ -6,7 +6,12 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 authors.workspace = true
+readme = "../../README.md"
+keywords = ["sqlite", "sync", "replication", "delta", "content-hash"]
+categories = ["database", "wasm"]
 
 [features]
 default = ["native"]

--- a/crates/smugglr-plugin-sdk/Cargo.toml
+++ b/crates/smugglr-plugin-sdk/Cargo.toml
@@ -5,8 +5,13 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 authors.workspace = true
 description = "SDK for building smugglr adapter plugins"
+readme = "../../README.md"
+keywords = ["smugglr", "plugin", "sqlite", "sync", "sdk"]
+categories = ["database", "development-tools"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/smugglr/Cargo.toml
+++ b/crates/smugglr/Cargo.toml
@@ -22,7 +22,7 @@ name = "smugglr"
 path = "src/main.rs"
 
 [dependencies]
-smugglr-core = { path = "../smugglr-core" }
+smugglr-core = { path = "../smugglr-core", version = "0.3.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/smugglr/Cargo.toml
+++ b/crates/smugglr/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "smugglr"
-description = "Smuggle data between SQLite and Cloudflare D1"
+description = "Content-hashed delta sync for SQLite -- push, pull, and bidirectional sync to any pluggable target"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 authors.workspace = true
-homepage = "https://github.com/rafters-studio/smugglr"
-documentation = "https://github.com/rafters-studio/smugglr#readme"
 readme = "../../README.md"
-keywords = ["cloudflare", "d1", "sqlite", "sync", "database"]
+keywords = ["sqlite", "sync", "replication", "delta", "cli"]
 categories = ["command-line-utilities", "database"]
 exclude = [
     "config.toml",

--- a/packages/smugglr/README.md
+++ b/packages/smugglr/README.md
@@ -1,0 +1,58 @@
+# smugglr
+
+Content-hashed delta sync for SQLite, in the browser.
+
+The smugglr sync engine compiled to WebAssembly with a small typed wrapper. Push, pull, or bidirectionally sync between any two HTTP-SQL endpoints (Turso, rqlite, Cloudflare D1, custom) directly from the browser or Node. Only rows that actually changed are sent.
+
+Homepage: [smugglr.dev](https://smugglr.dev)
+
+## Install
+
+```sh
+pnpm add smugglr
+```
+
+## Usage
+
+```ts
+import { Smugglr } from "smugglr";
+
+const s = await Smugglr.init({
+  source: { url: "https://my-db.turso.io", authToken: "tok", profile: "turso" },
+  dest:   { url: "https://api.cloudflare.com/...", authToken: "cf", profile: "d1" },
+  sync:   { tables: ["users", "posts"], conflictResolution: "local_wins" },
+});
+
+await s.sync();          // bidirectional
+await s.push();          // source -> dest
+await s.pull();          // dest -> source
+const plan = await s.diff(); // dry-run plan, no writes
+
+s.dispose();
+```
+
+`using` is supported:
+
+```ts
+using s = await Smugglr.init(config);
+await s.sync();
+// freed at scope exit
+```
+
+## Custom WASM loading
+
+If your bundler resolves `.wasm` imports differently or you serve the binary from a CDN:
+
+```ts
+import { Smugglr, setWasm } from "smugglr";
+import * as wasm from "smugglr/wasm";
+
+await wasm.default("https://cdn.example.com/smugglr_wasm_bg.wasm");
+setWasm(wasm);
+
+const s = await Smugglr.init(config);
+```
+
+## License
+
+MIT

--- a/packages/smugglr/package.json
+++ b/packages/smugglr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smugglr",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Content-hashed delta sync for SQLite, in the browser",
   "type": "module",
   "main": "dist/index.js",
@@ -16,8 +16,13 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
+  "homepage": "https://smugglr.dev",
+  "bugs": {
+    "url": "https://github.com/rafters-studio/smugglr/issues"
+  },
   "scripts": {
     "build:wasm": "cd ../../crates/smugglr-wasm && wasm-pack build --target web --dev",
     "build:copy-wasm": "mkdir -p dist/wasm && cp ../../crates/smugglr-wasm/pkg/smugglr_wasm.js dist/wasm/ && cp ../../crates/smugglr-wasm/pkg/smugglr_wasm.d.ts dist/wasm/ && cp ../../crates/smugglr-wasm/pkg/smugglr_wasm_bg.wasm dist/wasm/ && cp ../../crates/smugglr-wasm/pkg/smugglr_wasm_bg.wasm.d.ts dist/wasm/",

--- a/plugins/smugglr-http-sql/Cargo.toml
+++ b/plugins/smugglr-http-sql/Cargo.toml
@@ -13,8 +13,8 @@ name = "smugglr-http-sql"
 path = "src/main.rs"
 
 [dependencies]
-smugglr-core = { path = "../../crates/smugglr-core", default-features = false }
-smugglr-plugin-sdk = { path = "../../crates/smugglr-plugin-sdk" }
+smugglr-core = { path = "../../crates/smugglr-core", version = "0.3.0", default-features = false }
+smugglr-plugin-sdk = { path = "../../crates/smugglr-plugin-sdk", version = "0.3.0" }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/plugins/smugglr-http-sql/Cargo.toml
+++ b/plugins/smugglr-http-sql/Cargo.toml
@@ -5,8 +5,13 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 authors.workspace = true
 description = "HTTP SQL adapter plugin for smugglr -- supports Turso, rqlite, SQLite Cloud, and custom endpoints"
+readme = "../../README.md"
+keywords = ["smugglr", "plugin", "turso", "rqlite", "d1"]
+categories = ["database"]
 
 [[bin]]
 name = "smugglr-http-sql"


### PR DESCRIPTION
Patch release. 0.3.0 shipped to crates.io and npm with thin metadata; this fills it in.

## crates.io
- workspace.package: `homepage = https://smugglr.dev`, `documentation = https://smugglr.dev/docs`
- All four published crates inherit those + add per-crate `readme = ../../README.md`, keywords, categories
- smugglr CLI description rewritten -- no longer says 'Smuggle data between SQLite and Cloudflare D1' since D1 is now a plugin like any other backend in 0.3.x

## npm
- packages/smugglr: new README.md, `homepage: https://smugglr.dev`, bugs link
- 0.3.0 was published without a README; 0.3.1 fixes it

## Versions
- Workspace: 0.3.0 -> 0.3.1
- npm: 0.3.0 -> 0.3.1

## Test plan
- [x] cargo check --workspace clean at 0.3.1
- [ ] After merge: republish crates and npm at 0.3.1