### PR TITLE
ci: pin pnpm version in publish-npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,8 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smugglr"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "indicatif",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-http-sql"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "reqwest",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-plugin-sdk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-wasm"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/packages/smugglr/package.json
+++ b/packages/smugglr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smugglr",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Content-hashed delta sync for SQLite, in the browser",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
publish-npm failed in v0.3.1 release: `No pnpm version is specified. Please specify it`. pnpm/action-setup@v4 needs either a version arg or a packageManager field somewhere; we have neither.

Pin to pnpm 10 to match local dev (pnpm 10.33.0).

After merge, retag to retrigger publish:
```
git tag -d v0.3.1
git push origin :v0.3.1
git tag v0.3.1
git push origin v0.3.1
```

Or bump to v0.3.2 if you'd rather not move a tag.