### PR TITLE
ci: point pnpm cache at packages/smugglr lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+          cache-dependency-path: packages/smugglr/pnpm-lock.yaml
           registry-url: https://registry.npmjs.org
 
       - name: Install deps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smugglr"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "indicatif",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-http-sql"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hex",
  "reqwest",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-plugin-sdk"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-wasm"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hex",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/packages/smugglr/package.json
+++ b/packages/smugglr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smugglr",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Content-hashed delta sync for SQLite, in the browser",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
v0.3.2 publish-npm failed: `Dependencies lock file is not found in /home/runner/work/smugglr/smugglr`. setup-node looks for pnpm-lock.yaml at repo root; ours lives at packages/smugglr/pnpm-lock.yaml.

After merge: `git tag v0.3.3 && git push origin v0.3.3` (need a workspace+npm bump first -- I'll fold that in if you want, or you can decide whether to skip a version).