### PR TITLE
feat(#97): LocalSqlDataSource + AnyDataSource dispatch (PR 1/3)

### DIFF
--- a/crates/smugglr-wasm/src/lib.rs
+++ b/crates/smugglr-wasm/src/lib.rs
@@ -17,11 +17,14 @@
 #![cfg(target_arch = "wasm32")]
 
 mod fetch_adapter;
+mod local_adapter;
 
 use fetch_adapter::FetchDataSource;
+use local_adapter::LocalSqlDataSource;
 use smugglr_core::config::{column_excluded, ConflictResolution, SyncConfig};
-use smugglr_core::datasource::{DataSource, RowMeta};
+use smugglr_core::datasource::{DataSource, RowMeta, TableInfo};
 use smugglr_core::diff::{classify_diff, TableDiff};
+use smugglr_core::error::Result as SmugglrResult;
 use smugglr_core::profile::Profile;
 
 use serde::{Deserialize, Serialize};
@@ -83,8 +86,104 @@ impl CachedMeta {
     }
 }
 
+/// Either a remote HTTP SQL endpoint or a local SQLite executor.
+///
+/// Both implement `DataSource`; lib.rs holds an `AnyDataSource` for source
+/// and dest and dispatches at the trait surface so the diff/sync paths
+/// don't care which side is local vs remote.
+pub(crate) enum AnyDataSource {
+    Fetch(FetchDataSource),
+    Local(LocalSqlDataSource),
+}
+
+impl AnyDataSource {
+    /// Incremental row metadata query, delegated to the underlying adapter.
+    /// Mirrors the inherent method on each adapter.
+    pub async fn get_row_metadata_since(
+        &self,
+        table: &str,
+        timestamp_column: &str,
+        exclude_columns: &[String],
+        since_timestamp: &str,
+    ) -> SmugglrResult<HashMap<String, RowMeta>> {
+        match self {
+            Self::Fetch(d) => {
+                d.get_row_metadata_since(table, timestamp_column, exclude_columns, since_timestamp)
+                    .await
+            }
+            Self::Local(d) => {
+                d.get_row_metadata_since(table, timestamp_column, exclude_columns, since_timestamp)
+                    .await
+            }
+        }
+    }
+}
+
+impl DataSource for AnyDataSource {
+    async fn list_tables(&self) -> SmugglrResult<Vec<String>> {
+        match self {
+            Self::Fetch(d) => d.list_tables().await,
+            Self::Local(d) => d.list_tables().await,
+        }
+    }
+
+    async fn table_info(&self, table: &str) -> SmugglrResult<TableInfo> {
+        match self {
+            Self::Fetch(d) => d.table_info(table).await,
+            Self::Local(d) => d.table_info(table).await,
+        }
+    }
+
+    async fn get_row_metadata(
+        &self,
+        table: &str,
+        timestamp_column: &str,
+        exclude_columns: &[String],
+    ) -> SmugglrResult<HashMap<String, RowMeta>> {
+        match self {
+            Self::Fetch(d) => {
+                d.get_row_metadata(table, timestamp_column, exclude_columns)
+                    .await
+            }
+            Self::Local(d) => {
+                d.get_row_metadata(table, timestamp_column, exclude_columns)
+                    .await
+            }
+        }
+    }
+
+    async fn get_rows(
+        &self,
+        table: &str,
+        pk_values: &[String],
+    ) -> SmugglrResult<Vec<HashMap<String, serde_json::Value>>> {
+        match self {
+            Self::Fetch(d) => d.get_rows(table, pk_values).await,
+            Self::Local(d) => d.get_rows(table, pk_values).await,
+        }
+    }
+
+    async fn upsert_rows(
+        &self,
+        table: &str,
+        rows: &[HashMap<String, serde_json::Value>],
+    ) -> SmugglrResult<usize> {
+        match self {
+            Self::Fetch(d) => d.upsert_rows(table, rows).await,
+            Self::Local(d) => d.upsert_rows(table, rows).await,
+        }
+    }
+
+    async fn row_count(&self, table: &str) -> SmugglrResult<usize> {
+        match self {
+            Self::Fetch(d) => d.row_count(table).await,
+            Self::Local(d) => d.row_count(table).await,
+        }
+    }
+}
+
 #[derive(Deserialize)]
-struct JsEndpointConfig {
+struct JsHttpEndpoint {
     url: String,
     #[serde(default, alias = "authToken")]
     auth_token: String,
@@ -94,14 +193,6 @@ struct JsEndpointConfig {
 
 fn default_profile() -> String {
     "generic".to_string()
-}
-
-#[derive(Deserialize)]
-struct JsSmugglrConfig {
-    source: JsEndpointConfig,
-    dest: JsEndpointConfig,
-    #[serde(default)]
-    sync: JsSyncConfig,
 }
 
 #[derive(Deserialize, Default)]
@@ -183,21 +274,43 @@ fn build_sync_config(js: &JsSyncConfig) -> SyncConfig {
     sync
 }
 
-fn build_datasource(endpoint: &JsEndpointConfig) -> Result<FetchDataSource, JsValue> {
-    let profile = Profile::from_name(&endpoint.profile)
-        .ok_or_else(|| JsValue::from_str(&format!("unknown profile: {}", endpoint.profile)))?;
-    Ok(FetchDataSource::new(
-        endpoint.url.clone(),
-        endpoint.auth_token.clone(),
-        profile,
-    ))
+/// Dispatch endpoint config -> adapter.
+///
+/// Local endpoint shape: `{ type: "local", executor: SqlExecutor }` where
+/// the executor is any JS object with a `run(sql, params): Promise<{columns, rows}>` method.
+/// Anything else is treated as a remote HTTP endpoint and parsed as `JsHttpEndpoint`.
+fn build_datasource(endpoint_js: &JsValue) -> Result<AnyDataSource, JsValue> {
+    let kind = js_sys::Reflect::get(endpoint_js, &JsValue::from_str("type"))
+        .ok()
+        .and_then(|v| v.as_string());
+
+    if kind.as_deref() == Some("local") {
+        let executor = js_sys::Reflect::get(endpoint_js, &JsValue::from_str("executor"))
+            .map_err(|e| JsValue::from_str(&format!("local endpoint missing executor: {:?}", e)))?;
+        if executor.is_undefined() || executor.is_null() {
+            return Err(JsValue::from_str(
+                "local endpoint missing executor: must be an object with a run(sql, params) method",
+            ));
+        }
+        Ok(AnyDataSource::Local(LocalSqlDataSource::new(executor)))
+    } else {
+        let http: JsHttpEndpoint = serde_wasm_bindgen::from_value(endpoint_js.clone())
+            .map_err(|e| JsValue::from_str(&format!("invalid endpoint config: {}", e)))?;
+        let profile = Profile::from_name(&http.profile)
+            .ok_or_else(|| JsValue::from_str(&format!("unknown profile: {}", http.profile)))?;
+        Ok(AnyDataSource::Fetch(FetchDataSource::new(
+            http.url,
+            http.auth_token,
+            profile,
+        )))
+    }
 }
 
 /// Get tables to sync by finding the intersection of both sides,
 /// filtering by config, and requiring a primary key.
 async fn get_sync_tables(
-    source: &FetchDataSource,
-    dest: &FetchDataSource,
+    source: &AnyDataSource,
+    dest: &AnyDataSource,
     sync_config: &SyncConfig,
 ) -> Result<Vec<String>, JsValue> {
     let source_tables: HashSet<String> = source
@@ -252,8 +365,8 @@ fn strip_excluded(
 
 /// Transfer rows from source to dest in batches.
 async fn transfer_rows(
-    source: &FetchDataSource,
-    dest: &FetchDataSource,
+    source: &AnyDataSource,
+    dest: &AnyDataSource,
     table: &str,
     pk_values: &[String],
     batch_size: usize,
@@ -294,7 +407,7 @@ async fn transfer_rows(
 /// for `table`. The caller borrows the cache to access the metadata,
 /// avoiding a full clone of the hash map on the sync hot path.
 async fn ensure_cached_metadata(
-    ds: &FetchDataSource,
+    ds: &AnyDataSource,
     cache: &RefCell<HashMap<String, CachedMeta>>,
     table: &str,
     timestamp_column: &str,
@@ -345,8 +458,8 @@ async fn ensure_cached_metadata(
 /// fetch only changed rows, and the diff classification is delegated to the
 /// shared `classify_diff` helper in core.
 async fn diff_table_cached(
-    source: &FetchDataSource,
-    dest: &FetchDataSource,
+    source: &AnyDataSource,
+    dest: &AnyDataSource,
     source_cache: &RefCell<HashMap<String, CachedMeta>>,
     dest_cache: &RefCell<HashMap<String, CachedMeta>>,
     table: &str,
@@ -378,8 +491,8 @@ async fn diff_table_cached(
 #[wasm_bindgen]
 pub struct Smugglr {
     sync_config: SyncConfig,
-    source: FetchDataSource,
-    dest: FetchDataSource,
+    source: AnyDataSource,
+    dest: AnyDataSource,
     /// Per-table metadata cache for the source endpoint.
     source_cache: RefCell<HashMap<String, CachedMeta>>,
     /// Per-table metadata cache for the dest endpoint.
@@ -395,12 +508,23 @@ impl Smugglr {
     /// caches because the old instance is discarded.
     #[wasm_bindgen]
     pub fn init(config_js: JsValue) -> Result<Smugglr, JsValue> {
-        let js_config: JsSmugglrConfig = serde_wasm_bindgen::from_value(config_js)
-            .map_err(|e| JsValue::from_str(&format!("invalid config: {}", e)))?;
+        let source_js = js_sys::Reflect::get(&config_js, &JsValue::from_str("source"))
+            .map_err(|e| JsValue::from_str(&format!("config.source missing: {:?}", e)))?;
+        let dest_js = js_sys::Reflect::get(&config_js, &JsValue::from_str("dest"))
+            .map_err(|e| JsValue::from_str(&format!("config.dest missing: {:?}", e)))?;
+        let sync_js = js_sys::Reflect::get(&config_js, &JsValue::from_str("sync"))
+            .unwrap_or(JsValue::UNDEFINED);
 
-        let sync_config = build_sync_config(&js_config.sync);
-        let source = build_datasource(&js_config.source)?;
-        let dest = build_datasource(&js_config.dest)?;
+        let js_sync: JsSyncConfig = if sync_js.is_undefined() || sync_js.is_null() {
+            JsSyncConfig::default()
+        } else {
+            serde_wasm_bindgen::from_value(sync_js)
+                .map_err(|e| JsValue::from_str(&format!("invalid sync config: {}", e)))?
+        };
+
+        let sync_config = build_sync_config(&js_sync);
+        let source = build_datasource(&source_js)?;
+        let dest = build_datasource(&dest_js)?;
 
         Ok(Smugglr {
             sync_config,

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -1,0 +1,379 @@
+//! Local SQLite adapter -- runs SQL against a JS-provided executor.
+//!
+//! Rust speaks SQL strings + parameter arrays; the JS side provides any
+//! object satisfying `{ run(sql, params): Promise<{columns, rows}> }`.
+//! First shipped executor is wa-sqlite + OPFS; the same adapter accepts
+//! better-sqlite3 (Node), official sqlite-wasm, or sql.js without
+//! changes here.
+
+use sha2::{Digest, Sha256};
+use smugglr_core::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
+use smugglr_core::error::{Result, SyncError};
+use std::collections::HashMap;
+
+use serde_json::Value;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+
+pub struct LocalSqlDataSource {
+    executor: JsValue,
+    table_info_cache: std::sync::Mutex<HashMap<String, TableInfo>>,
+}
+
+// wasm32 is single-threaded; the !Sync of JsValue would be load-bearing on
+// multi-threaded targets, but here no cross-thread sharing is possible.
+// Same pattern the rest of the wasm-bindgen ecosystem uses for storing
+// JsValues in long-lived structs.
+unsafe impl Send for LocalSqlDataSource {}
+unsafe impl Sync for LocalSqlDataSource {}
+
+impl LocalSqlDataSource {
+    pub fn new(executor: JsValue) -> Self {
+        Self {
+            executor,
+            table_info_cache: std::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn run(&self, sql: &str, params: &[Value]) -> Result<RunResult> {
+        let run_fn = js_sys::Reflect::get(&self.executor, &JsValue::from_str("run"))
+            .map_err(|e| SyncError::Remote(format!("executor.run missing: {:?}", e)))?
+            .dyn_into::<js_sys::Function>()
+            .map_err(|_| SyncError::Remote("executor.run is not a function".into()))?;
+
+        let params_js = serde_wasm_bindgen::to_value(params)
+            .map_err(|e| SyncError::Remote(format!("failed to serialize params: {}", e)))?;
+
+        let promise = run_fn
+            .call2(&self.executor, &JsValue::from_str(sql), &params_js)
+            .map_err(|e| SyncError::Remote(format!("executor.run threw: {:?}", e)))?
+            .dyn_into::<js_sys::Promise>()
+            .map_err(|_| SyncError::Remote("executor.run did not return a Promise".into()))?;
+
+        let result_js = JsFuture::from(promise)
+            .await
+            .map_err(|e| SyncError::Remote(format!("executor.run rejected: {:?}", e)))?;
+
+        serde_wasm_bindgen::from_value(result_js)
+            .map_err(|e| SyncError::Remote(format!("invalid executor result shape: {}", e)))
+    }
+
+    fn rows_to_maps(&self, columns: &[String], rows: &[Vec<Value>]) -> Vec<HashMap<String, Value>> {
+        rows.iter()
+            .map(|row| {
+                columns
+                    .iter()
+                    .zip(row.iter())
+                    .map(|(col, val)| (col.clone(), val.clone()))
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn build_pk_text_expr(primary_key: &[String]) -> String {
+        if primary_key.len() == 1 {
+            format!("CAST(\"{}\" AS TEXT)", primary_key[0])
+        } else {
+            primary_key
+                .iter()
+                .map(|k| format!("CAST(\"{}\" AS TEXT)", k))
+                .collect::<Vec<_>>()
+                .join(" || '|' || ")
+        }
+    }
+
+    fn row_maps_to_metadata(
+        maps: &[HashMap<String, Value>],
+        column_order: &[String],
+        timestamp_column: &str,
+        exclude_columns: &[String],
+    ) -> HashMap<String, RowMeta> {
+        let mut result = HashMap::with_capacity(maps.len());
+        for row in maps {
+            let pk = row
+                .get("__pk")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let updated_at = row
+                .get(timestamp_column)
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let content_hash =
+                Self::content_hash(row, column_order, exclude_columns, timestamp_column);
+            result.insert(
+                pk.clone(),
+                RowMeta {
+                    pk_value: pk,
+                    updated_at,
+                    content_hash,
+                },
+            );
+        }
+        result
+    }
+
+    fn content_hash(
+        row: &HashMap<String, Value>,
+        columns_in_order: &[String],
+        exclude: &[String],
+        timestamp_column: &str,
+    ) -> String {
+        let timestamp_columns = ["updated_at", "created_at"];
+        let mut hasher = Sha256::new();
+        for col in columns_in_order {
+            if timestamp_columns.contains(&col.as_str())
+                || exclude.iter().any(|e| e == col)
+                || col == timestamp_column
+            {
+                continue;
+            }
+            if let Some(val) = row.get(col) {
+                match val {
+                    Value::Null => {}
+                    Value::String(s) => hasher.update(s.as_bytes()),
+                    Value::Number(n) => hasher.update(n.to_string().as_bytes()),
+                    Value::Bool(b) => hasher.update(if *b { "1" } else { "0" }.as_bytes()),
+                    other => hasher.update(other.to_string().as_bytes()),
+                }
+            }
+            hasher.update(b"|");
+        }
+        hex::encode(hasher.finalize())
+    }
+
+    pub async fn get_row_metadata_since(
+        &self,
+        table: &str,
+        timestamp_column: &str,
+        exclude_columns: &[String],
+        since_timestamp: &str,
+    ) -> Result<HashMap<String, RowMeta>> {
+        let info = self.cached_table_info(table).await?;
+        if info.primary_key.is_empty() {
+            return Err(SyncError::Config(format!(
+                "no primary key for table: {}",
+                table
+            )));
+        }
+
+        let pk_expr = Self::build_pk_text_expr(&info.primary_key);
+        let column_order: Vec<String> = info.columns.iter().map(|c| c.name.clone()).collect();
+        let sql = format!(
+            "SELECT *, {} AS __pk FROM \"{}\" WHERE \"{}\" > ?",
+            pk_expr, table, timestamp_column
+        );
+        let params = vec![Value::String(since_timestamp.to_string())];
+        let result = self.run(&sql, &params).await?;
+        let maps = self.rows_to_maps(&result.columns, &result.rows);
+
+        Ok(Self::row_maps_to_metadata(
+            &maps,
+            &column_order,
+            timestamp_column,
+            exclude_columns,
+        ))
+    }
+
+    async fn cached_table_info(&self, table: &str) -> Result<TableInfo> {
+        if let Some(info) = self.table_info_cache.lock().unwrap().get(table) {
+            return Ok(info.clone());
+        }
+        let info = self.table_info(table).await?;
+        self.table_info_cache
+            .lock()
+            .unwrap()
+            .insert(table.to_string(), info.clone());
+        Ok(info)
+    }
+
+    fn generate_batch_sql(
+        table: &str,
+        columns: &[String],
+        rows: &[HashMap<String, Value>],
+    ) -> (String, Vec<Value>) {
+        let col_list = columns
+            .iter()
+            .map(|c| format!("\"{}\"", c))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let row_placeholder = format!("({})", vec!["?"; columns.len()].join(", "));
+        let all_placeholders = vec![row_placeholder.as_str(); rows.len()].join(", ");
+
+        let sql = format!(
+            "INSERT OR REPLACE INTO \"{}\" ({}) VALUES {}",
+            table, col_list, all_placeholders
+        );
+
+        let params: Vec<Value> = rows
+            .iter()
+            .flat_map(|row| {
+                columns
+                    .iter()
+                    .map(|c| row.get(c).cloned().unwrap_or(Value::Null))
+            })
+            .collect();
+
+        (sql, params)
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct RunResult {
+    #[serde(default)]
+    columns: Vec<String>,
+    #[serde(default)]
+    rows: Vec<Vec<Value>>,
+}
+
+impl DataSource for LocalSqlDataSource {
+    async fn list_tables(&self) -> Result<Vec<String>> {
+        let result = self
+            .run(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+                &[],
+            )
+            .await?;
+
+        let name_idx = result.columns.iter().position(|c| c == "name").unwrap_or(0);
+        Ok(result
+            .rows
+            .iter()
+            .filter_map(|row| row.get(name_idx).and_then(|v| v.as_str()).map(String::from))
+            .collect())
+    }
+
+    async fn table_info(&self, table: &str) -> Result<TableInfo> {
+        let result = self
+            .run(&format!("PRAGMA table_info('{}')", table), &[])
+            .await?;
+
+        let name_idx = result.columns.iter().position(|c| c == "name").unwrap_or(1);
+        let type_idx = result.columns.iter().position(|c| c == "type").unwrap_or(2);
+        let notnull_idx = result
+            .columns
+            .iter()
+            .position(|c| c == "notnull")
+            .unwrap_or(3);
+        let pk_idx = result.columns.iter().position(|c| c == "pk").unwrap_or(5);
+
+        let mut col_infos = Vec::new();
+        let mut primary_key = Vec::new();
+
+        for row in &result.rows {
+            let name = row
+                .get(name_idx)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let col_type = row
+                .get(type_idx)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let notnull = row.get(notnull_idx).and_then(|v| v.as_i64()).unwrap_or(0) != 0;
+            let pk = row.get(pk_idx).and_then(|v| v.as_i64()).unwrap_or(0) != 0;
+
+            if pk {
+                primary_key.push(name.clone());
+            }
+
+            col_infos.push(ColumnInfo {
+                name,
+                col_type,
+                notnull,
+                pk,
+            });
+        }
+
+        Ok(TableInfo {
+            name: table.to_string(),
+            columns: col_infos,
+            primary_key,
+        })
+    }
+
+    async fn get_row_metadata(
+        &self,
+        table: &str,
+        timestamp_column: &str,
+        exclude_columns: &[String],
+    ) -> Result<HashMap<String, RowMeta>> {
+        let info = self.cached_table_info(table).await?;
+        if info.primary_key.is_empty() {
+            return Err(SyncError::Config(format!(
+                "no primary key for table: {}",
+                table
+            )));
+        }
+
+        let pk_expr = Self::build_pk_text_expr(&info.primary_key);
+        let column_order: Vec<String> = info.columns.iter().map(|c| c.name.clone()).collect();
+        let sql = format!("SELECT *, {} AS __pk FROM \"{}\"", pk_expr, table);
+        let result = self.run(&sql, &[]).await?;
+        let maps = self.rows_to_maps(&result.columns, &result.rows);
+
+        Ok(Self::row_maps_to_metadata(
+            &maps,
+            &column_order,
+            timestamp_column,
+            exclude_columns,
+        ))
+    }
+
+    async fn get_rows(
+        &self,
+        table: &str,
+        pk_values: &[String],
+    ) -> Result<Vec<HashMap<String, Value>>> {
+        if pk_values.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let info = self.cached_table_info(table).await?;
+        let pk_expr = Self::build_pk_text_expr(&info.primary_key);
+
+        let placeholders: Vec<String> = pk_values.iter().map(|_| "?".to_string()).collect();
+        let params: Vec<Value> = pk_values.iter().map(|v| Value::String(v.clone())).collect();
+        let sql = format!(
+            "SELECT * FROM \"{}\" WHERE {} IN ({})",
+            table,
+            pk_expr,
+            placeholders.join(", ")
+        );
+
+        let result = self.run(&sql, &params).await?;
+        Ok(self.rows_to_maps(&result.columns, &result.rows))
+    }
+
+    async fn upsert_rows(&self, table: &str, rows: &[HashMap<String, Value>]) -> Result<usize> {
+        if rows.is_empty() {
+            return Ok(0);
+        }
+        let columns: Vec<String> = rows[0].keys().cloned().collect();
+        let (sql, params) = Self::generate_batch_sql(table, &columns, rows);
+        self.run(&sql, &params).await.map_err(|e| {
+            SyncError::Remote(format!(
+                "batch upsert failed for table '{}' ({} rows): {}",
+                table,
+                rows.len(),
+                e
+            ))
+        })?;
+        Ok(rows.len())
+    }
+
+    async fn row_count(&self, table: &str) -> Result<usize> {
+        let sql = format!("SELECT COUNT(*) AS cnt FROM \"{}\"", table);
+        let result = self.run(&sql, &[]).await?;
+        let count = result
+            .rows
+            .first()
+            .and_then(|r| r.first())
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        Ok(count as usize)
+    }
+}


### PR DESCRIPTION
PR 1 of 3 for #97. Adds the Rust-side local SQLite adapter for the WASM npm package.

## Architecture choice

Rather than hardcoding wa-sqlite, the adapter speaks to a JS-provided **SqlExecutor**:

```ts
interface SqlExecutor {
  run(sql: string, params: unknown[]): Promise<{
    columns: string[];
    rows: unknown[][];
  }>;
}
```

First shipped executor (PR 2) wraps wa-sqlite + OPFS. The same Rust adapter accepts better-sqlite3 (Node), official sqlite-wasm, sql.js, or any future runtime. Smugglr stays SQLite-runtime-agnostic the way smugglr-core stays remote-backend-agnostic via plugins.

## Changes

- **crates/smugglr-wasm/src/local_adapter.rs** (new): `LocalSqlDataSource` implementing all 6 DataSource trait methods + `get_row_metadata_since` for the cached-diff path. Mirrors FetchDataSource SQL exactly so PK encoding and content hashes are identical end-to-end.
- **crates/smugglr-wasm/src/lib.rs**: `AnyDataSource` enum dispatches between Fetch and Local. Smugglr struct holds AnyDataSource for source/dest. Endpoint config is now a tagged union: `{type:'local', executor}` -> Local, otherwise HTTP.

## What's not in this PR

- TS wrapper changes (PR 2)
- wa-sqlite default executor adapter (PR 2)
- packages/smugglr/src/types.ts updates (PR 2)
- Playwright browser integration test (PR 3)

## Test plan

- [x] `cargo check -p smugglr-wasm --target wasm32-unknown-unknown` clean
- [x] `cargo check --workspace` clean (host)
- [ ] PR 2 wires through; PR 3 round-trips against real OPFS