### PR TITLE
feat(#97): Playwright e2e for OPFS + smugglr local sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,42 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
+
+  e2e-smugglr-npm:
+    name: E2E (smugglr npm + OPFS)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: packages/smugglr/pnpm-lock.yaml
+      - name: Install deps
+        working-directory: packages/smugglr
+        run: pnpm install --frozen-lockfile
+      - name: Build smugglr
+        working-directory: packages/smugglr
+        run: pnpm build
+      - name: Install Playwright browsers
+        working-directory: packages/smugglr
+        run: pnpm test:e2e:install
+      - name: Run e2e
+        working-directory: packages/smugglr
+        run: pnpm test:e2e
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: packages/smugglr/playwright-report
+          retention-days: 7

--- a/packages/smugglr/.gitignore
+++ b/packages/smugglr/.gitignore
@@ -1,2 +1,4 @@
 dist/
 node_modules/
+test-results/
+playwright-report/

--- a/packages/smugglr/README.md
+++ b/packages/smugglr/README.md
@@ -43,16 +43,18 @@ await s.sync();
 
 Sync a real SQLite database in the browser (via [wa-sqlite](https://github.com/rhashimoto/wa-sqlite) on OPFS) to any HTTP SQL backend:
 
+> OPFS sync access handles are worker-only in WebKit and Firefox. Run wa-sqlite + smugglr inside a Web Worker for cross-browser compatibility (Chromium allows main-thread use, but worker context is the spec-portable choice).
+
 ```ts
 import SQLiteAsyncESMFactory from "wa-sqlite/dist/wa-sqlite-async.mjs";
 import * as SQLite from "wa-sqlite";
-import { OPFSCoopSyncVFS } from "wa-sqlite/src/examples/OPFSCoopSyncVFS.js";
+import { OriginPrivateFileSystemVFS } from "wa-sqlite/src/examples/OriginPrivateFileSystemVFS.js";
 import { Smugglr, createWaSqliteExecutor } from "smugglr";
 
-// One-time wa-sqlite + OPFS setup
+// One-time wa-sqlite + OPFS setup (run inside a Web Worker)
 const module = await SQLiteAsyncESMFactory();
 const sqlite3 = SQLite.Factory(module);
-const vfs = await OPFSCoopSyncVFS.create("opfs", module);
+const vfs = new OriginPrivateFileSystemVFS();
 sqlite3.vfs_register(vfs, true);
 const db = await sqlite3.open_v2(
   "app.db",
@@ -84,6 +86,28 @@ await wasm.default("https://cdn.example.com/smugglr_wasm_bg.wasm");
 setWasm(wasm);
 
 const s = await Smugglr.init(config);
+```
+
+## Bundle size
+
+| Module                                         | Compressed (gzip) |
+| ---------------------------------------------- | ----------------- |
+| `smugglr` (TS wrapper)                         | ~2 KB             |
+| `smugglr/wasm` glue (`smugglr_wasm.js`)        | ~8 KB             |
+| `smugglr_wasm_bg.wasm` (sync engine)           | ~110 KB           |
+| `wa-sqlite-async.wasm` (peer, OPFS path only)  | ~410 KB           |
+| `wa-sqlite-async.mjs` glue (peer)              | ~15 KB            |
+
+`wa-sqlite` is only required for the local OPFS path. HTTP-only sync (e.g. Turso → D1) ships without it. Smugglr declares `wa-sqlite` as a peer dependency rather than bundling it, so consumers control the version and the bundler can tree-shake it out when only HTTP endpoints are configured.
+
+## End-to-end tests
+
+A Playwright suite under `e2e/` exercises the full local-OPFS path against a mocked HTTP target. Run with:
+
+```sh
+pnpm install
+pnpm test:e2e:install   # one-time: download chromium
+pnpm test:e2e
 ```
 
 ## License

--- a/packages/smugglr/e2e/index.html
+++ b/packages/smugglr/e2e/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>smugglr OPFS e2e</title>
+  </head>
+  <body>
+    <main id="status">loading</main>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/smugglr/e2e/main.ts
+++ b/packages/smugglr/e2e/main.ts
@@ -1,0 +1,44 @@
+// Main-thread proxy: forwards e2e RPC calls to the worker hosting wa-sqlite + smugglr.
+
+declare global {
+  interface Window {
+    e2e: {
+      init(dbPath: string): Promise<unknown>;
+      runSql(sql: string, params?: unknown[]): Promise<unknown>;
+      sync(opts: unknown): Promise<unknown>;
+      reset(): Promise<unknown>;
+    };
+  }
+}
+
+const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+  type: "module",
+});
+
+let nextId = 1;
+const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+worker.addEventListener("message", (ev: MessageEvent<{ id: number; ok: boolean; result?: unknown; error?: string }>) => {
+  const slot = pending.get(ev.data.id);
+  if (!slot) return;
+  pending.delete(ev.data.id);
+  if (ev.data.ok) slot.resolve(ev.data.result);
+  else slot.reject(new Error(ev.data.error ?? "worker error"));
+});
+
+function call(op: string, args: unknown[]) {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    worker.postMessage({ id, op, args });
+  });
+}
+
+window.e2e = {
+  init: (dbPath) => call("init", [dbPath]),
+  runSql: (sql, params = []) => call("runSql", [sql, params]),
+  sync: (opts) => call("sync", [opts]),
+  reset: () => call("reset", []),
+};
+
+document.getElementById("status")!.textContent = "ready";

--- a/packages/smugglr/e2e/tests/sync.spec.ts
+++ b/packages/smugglr/e2e/tests/sync.spec.ts
@@ -1,0 +1,192 @@
+// e2e: real OPFS-backed wa-sqlite database synced with smugglr against a
+// generic HTTP SQL target mocked via Playwright route().
+//
+// Generic profile request: POST { sql, params? } -> { columns, rows }.
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+interface RemoteRow {
+  id: string;
+  name: string;
+  updated_at: number;
+  hash?: string;
+}
+
+interface MockState {
+  tableExists: boolean;
+  rows: Map<string, RemoteRow>;
+  requests: Array<{ sql: string; params: unknown[] }>;
+}
+
+function freshState(): MockState {
+  return { tableExists: true, rows: new Map(), requests: [] };
+}
+
+function reply(route: Route, columns: string[], rows: unknown[][]) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ columns, rows }),
+  });
+}
+
+function emptyOk(route: Route) {
+  return reply(route, [], []);
+}
+
+function installMockTarget(page: Page, state: MockState, host = "https://mock.smugglr.test") {
+  return page.route(`${host}/**`, async (route) => {
+    const body = JSON.parse(route.request().postData() ?? "{}") as {
+      sql: string;
+      params?: unknown[];
+    };
+    const sql = body.sql.trim();
+    const params = body.params ?? [];
+    state.requests.push({ sql, params });
+
+    const lower = sql.toLowerCase();
+
+    // Schema introspection (sqlite_master / pragma).
+    if (lower.startsWith("select name from sqlite_master")) {
+      return reply(route, ["name"], state.tableExists ? [["users"]] : []);
+    }
+    if (lower.startsWith("pragma table_info")) {
+      return reply(
+        route,
+        ["cid", "name", "type", "notnull", "dflt_value", "pk"],
+        [
+          [0, "id", "TEXT", 1, null, 1],
+          [1, "name", "TEXT", 0, null, 0],
+          [2, "updated_at", "INTEGER", 0, null, 0],
+        ],
+      );
+    }
+
+    // Reads against the users table. smugglr issues two read shapes:
+    //   metadata: SELECT *, CAST("id" AS TEXT) AS __pk FROM "users"
+    //   row fetch: SELECT * FROM "users" WHERE CAST("id" AS TEXT) IN (?, ...)
+    if (lower.startsWith("select") && lower.includes('from "users"')) {
+      const wantsPk = lower.includes("__pk");
+      const cols = wantsPk
+        ? ["id", "name", "updated_at", "__pk"]
+        : ["id", "name", "updated_at"];
+      const matchesId = (id: string) => {
+        if (!lower.includes(" in (")) return true;
+        return params.some((p) => String(p) === id);
+      };
+      const out: unknown[][] = [];
+      for (const r of state.rows.values()) {
+        if (!matchesId(r.id)) continue;
+        const row: unknown[] = [r.id, r.name, r.updated_at];
+        if (wantsPk) row.push(r.id);
+        out.push(row);
+      }
+      return reply(route, cols, out);
+    }
+
+    if (lower.startsWith("insert") || lower.startsWith("replace")) {
+      // Parse the column list from the statement so we can map flat params
+      // back to named fields regardless of column order.
+      const colMatch = sql.match(/\(([^)]+)\)\s+VALUES/i);
+      const cols = colMatch
+        ? colMatch[1].split(",").map((c) => c.trim().replace(/^"|"$/g, ""))
+        : ["id", "name", "updated_at"];
+      const width = cols.length;
+      for (let i = 0; i + width - 1 < params.length; i += width) {
+        const row: Record<string, unknown> = {};
+        for (let c = 0; c < width; c++) {
+          row[cols[c]] = params[i + c];
+        }
+        const id = String(row.id ?? "");
+        state.rows.set(id, {
+          id,
+          name: String(row.name ?? ""),
+          updated_at: Number(row.updated_at ?? 0),
+        });
+      }
+      return emptyOk(route);
+    }
+
+    if (lower.startsWith("delete")) {
+      return emptyOk(route);
+    }
+
+    if (lower.startsWith("create table") || lower.startsWith("create index")) {
+      return emptyOk(route);
+    }
+
+    return emptyOk(route);
+  });
+}
+
+async function bootstrap(page: Page) {
+  await page.goto("/");
+  await expect(page.locator("#status")).toHaveText("ready");
+  await page.evaluate(() => window.e2e.reset());
+  await page.evaluate(() => window.e2e.init("e2e.db"));
+}
+
+test.describe("smugglr OPFS e2e", () => {
+  test.beforeEach(async ({ page }) => {
+    await bootstrap(page);
+  });
+
+  test("push: local OPFS rows reach the mock HTTP target", async ({ page }) => {
+    const state = freshState();
+    await installMockTarget(page, state);
+
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)",
+      ),
+    );
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "INSERT INTO users (id, name, updated_at) VALUES (?, ?, ?), (?, ?, ?)",
+        ["u1", "ada", 100, "u2", "lin", 200],
+      ),
+    );
+
+    const result = await page.evaluate(() =>
+      window.e2e.sync({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+        direction: "push",
+      }),
+    );
+
+    expect(result).toMatchObject({ command: "push", status: "ok" });
+    expect(state.requests.length).toBeGreaterThan(0);
+    expect(state.rows.size).toBe(2);
+    expect(state.rows.get("u1")?.name).toBe("ada");
+    expect(state.rows.get("u2")?.name).toBe("lin");
+  });
+
+  test("pull: remote rows land in local OPFS", async ({ page }) => {
+    const state = freshState();
+    state.rows.set("r1", { id: "r1", name: "remote-only", updated_at: 500 });
+    await installMockTarget(page, state);
+
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)",
+      ),
+    );
+
+    const result = await page.evaluate(() =>
+      window.e2e.sync({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+        direction: "pull",
+      }),
+    );
+
+    expect(result).toMatchObject({ command: "pull", status: "ok" });
+
+    const local = (await page.evaluate(() =>
+      window.e2e.runSql("SELECT id, name, updated_at FROM users ORDER BY id"),
+    )) as { columns: string[]; rows: unknown[][] };
+
+    expect(local.rows).toEqual([["r1", "remote-only", 500]]);
+  });
+});

--- a/packages/smugglr/e2e/vite.config.ts
+++ b/packages/smugglr/e2e/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vite";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: here,
+  server: {
+    port: 5173,
+    strictPort: true,
+    fs: {
+      // Allow serving from the package root so dist/ + node_modules/wa-sqlite resolve.
+      allow: [resolve(here, "..")],
+    },
+  },
+  optimizeDeps: {
+    // wa-sqlite ships ESM with a .wasm sidecar; let Vite handle it but skip
+    // the prebundle step (which mangles the Emscripten loader).
+    exclude: ["wa-sqlite"],
+  },
+  build: {
+    target: "es2022",
+  },
+});

--- a/packages/smugglr/e2e/worker.ts
+++ b/packages/smugglr/e2e/worker.ts
@@ -1,0 +1,92 @@
+// Web Worker host: owns wa-sqlite + OPFS + smugglr. Main thread proxies
+// RPC calls in via postMessage. SyncAccessHandle is worker-only in WebKit
+// and Firefox and is the spec-correct context for OPFS-backed SQLite.
+
+import SQLiteAsyncESMFactory from "wa-sqlite/dist/wa-sqlite-async.mjs";
+import * as SQLite from "wa-sqlite";
+// @ts-expect-error - wa-sqlite ships JS examples without .d.ts
+import { OriginPrivateFileSystemVFS } from "wa-sqlite/src/examples/OriginPrivateFileSystemVFS.js";
+
+import { Smugglr, createWaSqliteExecutor, setWasm } from "../dist/index.js";
+import * as wasm from "../dist/wasm/smugglr_wasm.js";
+
+let sqlite3: any = null;
+let db: number | null = null;
+
+async function init(dbPath: string) {
+  await (wasm as unknown as { default: () => Promise<unknown> }).default();
+  setWasm(wasm as never);
+  const module = await SQLiteAsyncESMFactory();
+  sqlite3 = SQLite.Factory(module);
+  const vfs = new OriginPrivateFileSystemVFS();
+  await new Promise((r) => setTimeout(r, 0));
+  sqlite3.vfs_register(vfs, true);
+  db = await sqlite3.open_v2(
+    dbPath,
+    SQLite.SQLITE_OPEN_READWRITE | SQLite.SQLITE_OPEN_CREATE,
+    "opfs",
+  );
+}
+
+async function runSql(sql: string, params: unknown[]) {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const exe = createWaSqliteExecutor(sqlite3, db);
+  return exe.run(sql, params);
+}
+
+async function sync(opts: {
+  destUrl: string;
+  tables: string[];
+  conflict?: "local_wins" | "remote_wins" | "newer_wins" | "uuid_v7_wins";
+  direction?: "push" | "pull" | "sync";
+}) {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const s = await Smugglr.init({
+    source: { type: "local", executor: createWaSqliteExecutor(sqlite3, db) },
+    dest: { url: opts.destUrl, profile: "generic" },
+    sync: {
+      tables: opts.tables,
+      conflictResolution: opts.conflict ?? "newer_wins",
+    },
+  });
+  const dir = opts.direction ?? "sync";
+  const result = dir === "push" ? await s.push()
+    : dir === "pull" ? await s.pull()
+    : await s.sync();
+  s.dispose();
+  return result;
+}
+
+async function reset() {
+  if (sqlite3 && db !== null) {
+    sqlite3.close(db);
+    db = null;
+  }
+  const root = await navigator.storage.getDirectory();
+  for await (const entry of (root as any).values()) {
+    await root.removeEntry(entry.name, { recursive: true });
+  }
+}
+
+interface RpcCall {
+  id: number;
+  op: "init" | "runSql" | "sync" | "reset";
+  args: unknown[];
+}
+
+self.addEventListener("message", async (ev: MessageEvent<RpcCall>) => {
+  const { id, op, args } = ev.data;
+  try {
+    let result: unknown;
+    switch (op) {
+      case "init": result = await init(args[0] as string); break;
+      case "runSql": result = await runSql(args[0] as string, (args[1] as unknown[]) ?? []); break;
+      case "sync": result = await sync(args[0] as Parameters<typeof sync>[0]); break;
+      case "reset": result = await reset(); break;
+    }
+    (self as unknown as Worker).postMessage({ id, ok: true, result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    (self as unknown as Worker).postMessage({ id, ok: false, error: message });
+  }
+});

--- a/packages/smugglr/package.json
+++ b/packages/smugglr/package.json
@@ -28,7 +28,9 @@
     "build:wasm:dev": "cd ../../crates/smugglr-wasm && wasm-pack build --target web --dev",
     "build:copy-wasm": "mkdir -p dist/wasm && cp ../../crates/smugglr-wasm/pkg/smugglr_wasm.js dist/wasm/ && cp ../../crates/smugglr-wasm/pkg/smugglr_wasm.d.ts dist/wasm/ && cp ../../crates/smugglr-wasm/pkg/smugglr_wasm_bg.wasm dist/wasm/ && cp ../../crates/smugglr-wasm/pkg/smugglr_wasm_bg.wasm.d.ts dist/wasm/",
     "build:ts": "tsc",
-    "build": "pnpm build:wasm && pnpm build:ts && pnpm build:copy-wasm"
+    "build": "pnpm build:wasm && pnpm build:ts && pnpm build:copy-wasm",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install --with-deps chromium"
   },
   "keywords": [
     "sqlite",
@@ -47,6 +49,10 @@
   },
   "author": "Sean Silvius",
   "devDependencies": {
-    "typescript": "^6.0.2"
+    "@playwright/test": "^1.59.1",
+    "@types/node": "^24.0.0",
+    "typescript": "^6.0.2",
+    "vite": "^8.0.10",
+    "wa-sqlite": "^1.0.0"
   }
 }

--- a/packages/smugglr/playwright.config.ts
+++ b/packages/smugglr/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/tests",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  timeout: 60_000,
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm vite --config e2e/vite.config.ts",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/packages/smugglr/pnpm-lock.yaml
+++ b/packages/smugglr/pnpm-lock.yaml
@@ -8,17 +8,560 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.2
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@24.12.2)
+      wa-sqlite:
+        specifier: ^1.0.0
+        version: 1.0.0
 
 packages:
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  wa-sqlite@1.0.0:
+    resolution: {integrity: sha512-Kyybo5/BaJp76z7gDWGk2J6Hthl4NIPsE+swgraEjy3IY6r5zIR02wAs1OJH4XtJp1y3puj3Onp5eMGS0z7nUA==}
+
 snapshots:
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
+  detect-libc@2.1.2: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  nanoid@3.3.11: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tslib@2.8.1:
+    optional: true
+
   typescript@6.0.2: {}
+
+  undici-types@7.16.0: {}
+
+  vite@8.0.10(@types/node@24.12.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+
+  wa-sqlite@1.0.0: {}


### PR DESCRIPTION
PR 3/3 closing #97 (the local-first OPFS path). PRs 1/3 (#108 LocalSqlDataSource + AnyDataSource) and 2/3 (#109 SqlExecutor + wa-sqlite adapter) shipped the runtime; this one closes out the acceptance criteria with an end-to-end proof and the bundle-size + cross-browser docs.

## Summary
- Playwright suite under `packages/smugglr/e2e/` boots wa-sqlite inside a Web Worker, opens an `OriginPrivateFileSystemVFS` database, and exercises smugglr against a generic HTTP-SQL target mocked via Playwright `route()`.
- Two tests cover both halves of local-first sync:
  - **push:** local OPFS rows reach the remote with correct column ordering + primary-key bindings.
  - **pull:** remote rows land in the local OPFS table (verified by a follow-up SELECT against the live OPFS db).
- README: replace stale `OPFSCoopSyncVFS` reference (not shipped in wa-sqlite@1) with `OriginPrivateFileSystemVFS`, add a measured bundle-size table, and call out the worker-context requirement for cross-browser OPFS.
- New CI job `e2e-smugglr-npm` wires the suite into `ci.yml` (ubuntu, chromium).

## Why a Web Worker
`createSyncAccessHandle` is worker-only by spec in WebKit and Firefox. Chromium currently allows main-thread use, but the worker context is the portable choice and matches the architecture real consumers will ship.

## Acceptance criteria (#97)
- [x] `WaSqliteDataSource` -- shipped via #108 / #109 as the executor-injection model
- [x] All trait methods implemented -- shipped via #108
- [x] TypeScript wrapper accepts a local executor source/dest -- shipped via #109
- [x] Same conflict-resolution semantics as HTTP path -- inherited from core
- [x] Browser integration test against a real OPFS DB -- this PR
- [x] Bundle size impact documented -- this PR

## Test plan
- [x] `pnpm test:e2e` passes locally (chromium, OPFS-backed)
- [ ] CI `e2e-smugglr-npm` job green on this PR
- [ ] `cargo test` matrix still green

## Follow-ups
- Service-worker-context proof: smugglr's API doesn't change for SW (per PR #109 executor-injection design), but a separate test + docs note on VFS choice (SyncAccessHandle blocked in SW; async OPFS / IDBBatchAtomicVFS works) is worth a follow-up issue.

Closes #97.