### PR TITLE
feat(#114): post-sync table-changed events

### DIFF
--- a/crates/smugglr-wasm/src/lib.rs
+++ b/crates/smugglr-wasm/src/lib.rs
@@ -30,7 +30,35 @@ use smugglr_core::profile::Profile;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+/// Build the `TableChangedEvent` JS object for a single table.
+fn build_table_changed_event(
+    table: &str,
+    changed_pks: &[String],
+    origin: &str,
+) -> Result<JsValue, JsValue> {
+    let obj = js_sys::Object::new();
+    js_sys::Reflect::set(&obj, &JsValue::from_str("table"), &JsValue::from_str(table))?;
+    let arr = js_sys::Array::new();
+    for pk in changed_pks {
+        arr.push(&JsValue::from_str(pk));
+    }
+    js_sys::Reflect::set(&obj, &JsValue::from_str("changedPks"), &arr)?;
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("removedPks"),
+        &js_sys::Array::new(),
+    )?;
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("source"),
+        &JsValue::from_str(origin),
+    )?;
+    Ok(obj.into())
+}
 
 /// Per-table cached row metadata used for incremental diff.
 ///
@@ -497,6 +525,10 @@ pub struct Smugglr {
     source_cache: RefCell<HashMap<String, CachedMeta>>,
     /// Per-table metadata cache for the dest endpoint.
     dest_cache: RefCell<HashMap<String, CachedMeta>>,
+    /// Registered `table-changed` listeners. Each entry is (id, callback);
+    /// the id lets the JS-side unsubscribe closure remove its own slot.
+    listeners: RefCell<Vec<(u64, js_sys::Function)>>,
+    next_listener_id: RefCell<u64>,
 }
 
 #[wasm_bindgen]
@@ -532,7 +564,77 @@ impl Smugglr {
             dest,
             source_cache: RefCell::new(HashMap::new()),
             dest_cache: RefCell::new(HashMap::new()),
+            listeners: RefCell::new(Vec::new()),
+            next_listener_id: RefCell::new(0),
         })
+    }
+
+    /// Subscribe to events emitted by this instance.
+    ///
+    /// Currently the only supported event is `"table-changed"`, which fires
+    /// once per affected table after a `pull` or `sync` operation completes
+    /// the local write. The handler receives a `TableChangedEvent`:
+    ///
+    /// ```ts
+    /// interface TableChangedEvent {
+    ///   table: string;
+    ///   changedPks: string[];
+    ///   removedPks: string[];   // reserved; always [] until delete propagation lands
+    ///   source: 'pull' | 'sync';
+    /// }
+    /// ```
+    ///
+    /// Returns an unsubscribe function. Calling it removes the listener;
+    /// subsequent invocations are no-ops.
+    #[wasm_bindgen]
+    pub fn on(&self, event: &str, callback: js_sys::Function) -> Result<js_sys::Function, JsValue> {
+        if event != "table-changed" {
+            return Err(JsValue::from_str(&format!(
+                "unknown event '{}': only 'table-changed' is supported",
+                event
+            )));
+        }
+        let id = {
+            let mut next = self.next_listener_id.borrow_mut();
+            let v = *next;
+            *next = next.wrapping_add(1);
+            v
+        };
+        self.listeners.borrow_mut().push((id, callback));
+
+        // Build the unsubscribe closure. We reach back into the same Smugglr
+        // via a raw pointer because wasm-bindgen cannot capture `&self` into
+        // a JS-callable closure with a non-'static lifetime. This is safe in
+        // single-threaded WASM as long as the Smugglr instance outlives the
+        // unsubscribe call -- which it must, since the JS-side wrapper holds
+        // it and dispose() consumes it explicitly.
+        let self_ptr: *const Smugglr = self;
+        let cb = Closure::wrap(Box::new(move || {
+            // Safety: see comment above.
+            let s = unsafe { &*self_ptr };
+            s.listeners.borrow_mut().retain(|(other, _)| *other != id);
+        }) as Box<dyn Fn()>);
+        let func: js_sys::Function = cb.as_ref().unchecked_ref::<js_sys::Function>().clone();
+        cb.forget();
+        Ok(func)
+    }
+
+    fn emit_table_changed(&self, table: &str, changed_pks: &[String], origin: &str) {
+        if changed_pks.is_empty() {
+            return;
+        }
+        let listeners = self.listeners.borrow().clone();
+        if listeners.is_empty() {
+            return;
+        }
+        let event = match build_table_changed_event(table, changed_pks, origin) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let this = JsValue::NULL;
+        for (_id, cb) in listeners.iter() {
+            let _ = cb.call1(&this, &event);
+        }
     }
 
     /// Clear all cached row metadata for both endpoints.
@@ -624,7 +726,7 @@ impl Smugglr {
             let pulled = if dry_run || to_pull.is_empty() {
                 to_pull.len()
             } else {
-                transfer_rows(
+                let n = transfer_rows(
                     &self.dest,
                     &self.source,
                     table,
@@ -632,7 +734,11 @@ impl Smugglr {
                     batch_size,
                     &self.sync_config.exclude_columns,
                 )
-                .await?
+                .await?;
+                if n > 0 {
+                    self.emit_table_changed(table, &to_pull, "pull");
+                }
+                n
             };
 
             results.push(JsTableResult {
@@ -692,7 +798,7 @@ impl Smugglr {
             let pulled = if dry_run || to_pull.is_empty() {
                 to_pull.len()
             } else {
-                transfer_rows(
+                let n = transfer_rows(
                     &self.dest,
                     &self.source,
                     table,
@@ -700,7 +806,11 @@ impl Smugglr {
                     batch_size,
                     &self.sync_config.exclude_columns,
                 )
-                .await?
+                .await?;
+                if n > 0 {
+                    self.emit_table_changed(table, &to_pull, "sync");
+                }
+                n
             };
 
             results.push(JsTableResult {

--- a/packages/smugglr/README.md
+++ b/packages/smugglr/README.md
@@ -88,6 +88,25 @@ setWasm(wasm);
 const s = await Smugglr.init(config);
 ```
 
+## Reactive events
+
+Subscribe to `table-changed` to react to sync writes without polling. Fires once per affected table after `pull` or `sync` completes the local write; `push` and `diff` never emit.
+
+```ts
+const unsub = s.on("table-changed", (e) => {
+  // e.table          -- which table was modified
+  // e.changedPks     -- primary keys of inserted/updated rows
+  // e.removedPks     -- reserved; always [] until delete propagation lands
+  // e.source         -- "pull" | "sync"
+  console.log(`${e.table} +${e.changedPks.length} via ${e.source}`);
+});
+
+await s.sync();
+unsub(); // remove this listener
+```
+
+This is the primitive the framework binding plugins (`@smugglr/zustand`, `@smugglr/nanostores`, etc.) are built on.
+
 ## Bundle size
 
 | Module                                         | Compressed (gzip) |

--- a/packages/smugglr/e2e/tests/sync.spec.ts
+++ b/packages/smugglr/e2e/tests/sync.spec.ts
@@ -189,4 +189,42 @@ test.describe("smugglr OPFS e2e", () => {
 
     expect(local.rows).toEqual([["r1", "remote-only", 500]]);
   });
+
+  test("on('table-changed'): fires once per pulled table with the right pks", async ({ page }) => {
+    const state = freshState();
+    state.rows.set("r1", { id: "r1", name: "alpha", updated_at: 100 });
+    state.rows.set("r2", { id: "r2", name: "beta", updated_at: 200 });
+    await installMockTarget(page, state);
+
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)",
+      ),
+    );
+
+    const out = (await page.evaluate(() =>
+      window.e2e.sync({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+        direction: "pull",
+        captureEvents: true,
+        testUnsubscribe: true,
+      }),
+    )) as {
+      result: { command: string; status: string };
+      events: Array<{ table: string; changedPks: string[]; removedPks: string[]; source: string }>;
+      postUnsubEvents: unknown[];
+    };
+
+    expect(out.result).toMatchObject({ command: "pull", status: "ok" });
+    expect(out.events).toHaveLength(1);
+    expect(out.events[0].table).toBe("users");
+    expect(out.events[0].source).toBe("pull");
+    expect(out.events[0].removedPks).toEqual([]);
+    expect(out.events[0].changedPks.sort()).toEqual(["r1", "r2"]);
+
+    // Unsubscribed listener should be silent; second listener that registered
+    // after unsubscribe sees zero events because the second pull had no diff.
+    expect(out.postUnsubEvents).toEqual([]);
+  });
 });

--- a/packages/smugglr/e2e/worker.ts
+++ b/packages/smugglr/e2e/worker.ts
@@ -39,6 +39,10 @@ async function sync(opts: {
   tables: string[];
   conflict?: "local_wins" | "remote_wins" | "newer_wins" | "uuid_v7_wins";
   direction?: "push" | "pull" | "sync";
+  /** When set, subscribes to "table-changed" before sync and returns captured events. */
+  captureEvents?: boolean;
+  /** When set, also test that the unsubscribe function silences subsequent events. */
+  testUnsubscribe?: boolean;
 }) {
   if (!sqlite3 || db === null) throw new Error("init() first");
   const s = await Smugglr.init({
@@ -49,12 +53,31 @@ async function sync(opts: {
       conflictResolution: opts.conflict ?? "newer_wins",
     },
   });
+
+  const events: unknown[] = [];
+  let unsub: (() => void) | null = null;
+  if (opts.captureEvents) {
+    unsub = s.on("table-changed", (e) => events.push(e));
+  }
+
   const dir = opts.direction ?? "sync";
   const result = dir === "push" ? await s.push()
     : dir === "pull" ? await s.pull()
     : await s.sync();
+
+  let postUnsubEvents: unknown[] = [];
+  if (opts.testUnsubscribe && unsub) {
+    unsub();
+    const after: unknown[] = [];
+    s.on("table-changed", (e) => after.push(e));
+    // Trigger a no-op pull -- since the rows already match, no event should fire.
+    await s.pull();
+    postUnsubEvents = after;
+  }
+
   s.dispose();
-  return result;
+  if (!opts.captureEvents) return result;
+  return { result, events, postUnsubEvents };
 }
 
 async function reset() {

--- a/packages/smugglr/src/index.ts
+++ b/packages/smugglr/src/index.ts
@@ -13,6 +13,9 @@ import type {
   LocalEndpointConfig,
   SqlExecutor,
   InitOptions,
+  TableChangedEvent,
+  SmugglrEventMap,
+  Unsubscribe,
 } from "./types.js";
 import { SmugglrError } from "./types.js";
 
@@ -26,6 +29,9 @@ export type {
   LocalEndpointConfig,
   SqlExecutor,
   InitOptions,
+  TableChangedEvent,
+  SmugglrEventMap,
+  Unsubscribe,
 };
 export { SmugglrError };
 export { createWaSqliteExecutor } from "./opfs.js";
@@ -50,6 +56,7 @@ interface WasmSmugglr {
   pull(dry_run?: boolean | null): Promise<unknown>;
   sync(dry_run?: boolean | null): Promise<unknown>;
   diff(): Promise<unknown>;
+  on(event: string, callback: (e: unknown) => void): () => void;
   [Symbol.dispose]?: () => void;
 }
 
@@ -189,6 +196,30 @@ export class Smugglr {
     } catch (e) {
       throw parseError(e);
     }
+  }
+
+  /**
+   * Subscribe to events emitted by this Smugglr instance.
+   *
+   * The `table-changed` event fires once per affected table after a `pull`
+   * or `sync` completes the local write. The handler receives a
+   * {@link TableChangedEvent}. Returns an unsubscribe function.
+   *
+   * @example
+   * ```ts
+   * const unsub = s.on("table-changed", (e) => {
+   *   console.log(`${e.table} changed`, e.changedPks, "via", e.source);
+   * });
+   * await s.sync();
+   * unsub();
+   * ```
+   */
+  on<K extends keyof SmugglrEventMap>(
+    event: K,
+    handler: (e: SmugglrEventMap[K]) => void,
+  ): Unsubscribe {
+    const wrapped = (raw: unknown) => handler(raw as SmugglrEventMap[K]);
+    return this.inner.on(event, wrapped);
   }
 
   /** Release WASM resources. Called automatically if using `using` syntax. */

--- a/packages/smugglr/src/types.ts
+++ b/packages/smugglr/src/types.ts
@@ -100,6 +100,26 @@ export interface DiffResult {
   tables: TableDiff[];
 }
 
+/** Event payload for the `table-changed` event. */
+export interface TableChangedEvent {
+  /** Name of the table whose local rows were modified. */
+  table: string;
+  /** Primary keys of rows that were inserted or updated. */
+  changedPks: string[];
+  /** Primary keys of rows that were removed. Reserved -- always empty until delete propagation lands. */
+  removedPks: string[];
+  /** Which operation produced the change. */
+  source: "pull" | "sync";
+}
+
+/** Subscribable events emitted by a Smugglr instance. */
+export type SmugglrEventMap = {
+  "table-changed": TableChangedEvent;
+};
+
+/** Function returned by `Smugglr.on(...)`; call it to remove the listener. */
+export type Unsubscribe = () => void;
+
 /** Options for WASM initialization */
 export interface InitOptions {
   /** URL to the .wasm binary (overrides the default co-located path) */


### PR DESCRIPTION
Adds an event surface to the WASM Smugglr instance so reactive consumers (state-management plugins like @smugglr/zustand and @smugglr/nanostores) can react to sync writes without polling. This is the primitive issues #115 and #116 are blocked on.

## API
\`\`\`ts
class Smugglr {
  on(event: 'table-changed', handler: (e: TableChangedEvent) => void): Unsubscribe;
}

interface TableChangedEvent {
  table: string;
  changedPks: string[];
  removedPks: string[];   // reserved -- always [] until delete propagation lands
  source: 'pull' | 'sync';
}
\`\`\`

## Behavior
- Fires once per affected table after pull / sync completes the local write
- \`push\` and \`diff\` never emit (push is local→remote; diff is read-only)
- Returns an unsubscribe function that removes only its own listener

## Implementation
- Listener registry on the Rust Smugglr struct (id-keyed so each unsubscribe closure removes only its own slot).
- \`emit_table_changed\` invoked from the WASM-side pull and sync flows after \`transfer_rows\` returns \`n > 0\`. The diff's \`rows_to_pull\` list provides \`changedPks\` directly without a re-query.
- \`removedPks\` reserved as \`[]\` so the event shape stays stable when delete propagation eventually lands; deferring would mean a breaking change for plugin consumers.

## Acceptance criteria (#114)
- [x] \`on('table-changed', cb)\` API on the WASM Smugglr struct
- [x] Returns an unsubscribe function
- [x] Fires after pull / sync with the right table + pk lists
- [x] No event for unchanged tables
- [x] Tests: subscribe, run pull, verify event with expected pks

## Test plan
- [x] \`pnpm test:e2e\` (3/3 passing) -- including unsubscribe verification
- [x] \`cargo test --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [ ] CI green

## Unblocks
- #115 (@smugglr/zustand)
- #116 (@smugglr/nanostores)

Closes #114.