### PR TITLE
docs(#119): runnable examples for CLI, Node, Rust, and browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,21 @@ cargo clippy --all-targets       # Lint (including tests)
 RUST_LOG=debug cargo run -- diff # Debug output
 ```
 
+## Examples
+
+Runnable examples covering CLI, Node, Rust, and browser use cases live in [`docs/examples/`](docs/examples/). Each subdir has its own README, prerequisites, and source.
+
+| Surface | Example | What it shows |
+| ------- | ------- | ------------- |
+| CLI     | [cli-d1-sync](docs/examples/cli-d1-sync) | `smugglr push/pull/sync` against Cloudflare D1. |
+| CLI     | [cli-lan-broadcast](docs/examples/cli-lan-broadcast) | Two laptops auto-syncing via UDP on the same subnet. |
+| Node    | [node-server-to-d1](docs/examples/node-server-to-d1) | `Smugglr.init({source: local, dest: D1}).push()` from Node. |
+| Node    | [node-auto-sync](docs/examples/node-auto-sync) | Long-running sync loop with backoff and graceful shutdown. |
+| Rust    | [rust-tokio-service](docs/examples/rust-tokio-service) | Embedded sync inside a tokio service. |
+| Rust    | [rust-custom-datasource](docs/examples/rust-custom-datasource) | Implement `DataSource` against an in-memory store. |
+| Browser | [browser-opfs-turso](docs/examples/browser-opfs-turso) | wa-sqlite + OPFS, syncing to Turso. |
+| Browser | [browser-idb-turso](docs/examples/browser-idb-turso) | Same demo backed by IndexedDB instead of OPFS. |
+
 ## Related Projects
 
 Part of the [rafters-studio](https://github.com/rafters-studio) ecosystem. Built for [huttspawn.com](https://huttspawn.com) and the broader rafters portfolio.

--- a/docs/examples/.gitignore
+++ b/docs/examples/.gitignore
@@ -1,0 +1,6 @@
+target/
+node_modules/
+dist/
+.env
+*.sqlite
+*.sqlite-journal

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,37 @@
+# smugglr examples
+
+End-to-end examples covering the main ways people reach for smugglr. Each example has a self-contained `README.md` with prerequisites, setup, and the command(s) to run it.
+
+## CLI
+
+| Example | What it shows |
+| ------- | ------------- |
+| [cli-d1-sync](./cli-d1-sync) | `config.toml` + `smugglr push/pull/sync` against Cloudflare D1. Hello-world. |
+| [cli-lan-broadcast](./cli-lan-broadcast) | Two laptops on the same subnet auto-syncing via UDP. Offline-tolerant ops demo. |
+
+## Node (`smugglr` npm)
+
+| Example | What it shows |
+| ------- | ------------- |
+| [node-server-to-d1](./node-server-to-d1) | Node script reads a local SQLite file and `.push()`es it to D1. |
+| [node-auto-sync](./node-auto-sync) | `setInterval` wrapping `.sync()` with backoff on failure. |
+
+## Rust (`smugglr-core` library)
+
+| Example | What it shows |
+| ------- | ------------- |
+| [rust-tokio-service](./rust-tokio-service) | Embedded sync inside a long-running tokio service. Bypasses the CLI. |
+| [rust-custom-datasource](./rust-custom-datasource) | Implementing `DataSource` against a non-standard store. Explains content-hashed delta vs CDC. |
+
+## Browser (`smugglr` npm + wa-sqlite)
+
+| Example | What it shows |
+| ------- | ------------- |
+| [browser-opfs-turso](./browser-opfs-turso) | wa-sqlite + `OriginPrivateFileSystemVFS` (OPFS), syncing to Turso. The local-first golden path. |
+| [browser-idb-turso](./browser-idb-turso) | `IDBBatchAtomicVFS` (IndexedDB) variant. Compatibility for older Safari and embedded webviews. |
+
+## Notes on running these
+
+- **Network-dependent examples** (D1, Turso) describe the prerequisites (account, token, table) but obviously need your credentials to actually run. Code is verbatim what we use ourselves.
+- **Local-only examples** (LAN broadcast, Rust embedded, custom DataSource, browser OPFS against a local mock) are runnable as-is.
+- Every example uses only OSS-tier features. Nothing here depends on smugglr+/fence profiles.

--- a/docs/examples/browser-idb-turso/.env.example
+++ b/docs/examples/browser-idb-turso/.env.example
@@ -1,0 +1,2 @@
+VITE_TURSO_URL=https://my-app-myorg.turso.io
+VITE_TURSO_TOKEN=your-turso-auth-token

--- a/docs/examples/browser-idb-turso/README.md
+++ b/docs/examples/browser-idb-turso/README.md
@@ -1,0 +1,32 @@
+# browser-idb-turso
+
+Same demo as [browser-opfs-turso](../browser-opfs-turso/), but backed by IndexedDB (`IDBBatchAtomicVFS`) instead of OPFS. Use this when:
+
+- You need to support older Safari versions where OPFS support is incomplete or buggy.
+- You're shipping inside an embedded webview where OPFS isn't reliably exposed.
+- You want a single VFS that works across main thread *and* worker contexts without conditional branching.
+
+The smugglr API is identical to the OPFS variant. The only thing that changes is which wa-sqlite VFS gets registered.
+
+## Prerequisites
+
+Same as [browser-opfs-turso](../browser-opfs-turso/).
+
+## Setup
+
+```sh
+pnpm install
+cp .env.example .env
+# fill in TURSO_URL and TURSO_TOKEN
+pnpm dev
+```
+
+## Run
+
+Open <http://localhost:5173>. Buttons behave identically to the OPFS demo.
+
+## What this demonstrates
+
+- VFS choice is the only consumer-visible difference between OPFS and IndexedDB persistence in wa-sqlite. Smugglr cares only about the `SqlExecutor` shape, not the underlying VFS.
+- IndexedDB-backed SQLite has slower writes than OPFS (no direct file handle, batched in transactions) but works in every browser, every context. Pick OPFS where you can; pick IDB where you must.
+- Because wa-sqlite's IDB VFS does not need `SyncAccessHandle`, you can run this on the main thread without a worker. The example still uses a worker for parity with the OPFS variant.

--- a/docs/examples/browser-idb-turso/index.html
+++ b/docs/examples/browser-idb-turso/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>smugglr IDB + Turso</title>
+  </head>
+  <body>
+    <h1>smugglr local-first demo (IndexedDB)</h1>
+    <p>SQLite in IndexedDB, syncing with Turso.</p>
+    <button id="add">Add row</button>
+    <button id="sync">Sync</button>
+    <button id="reset">Reset</button>
+    <pre id="log"></pre>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/docs/examples/browser-idb-turso/main.ts
+++ b/docs/examples/browser-idb-turso/main.ts
@@ -1,0 +1,47 @@
+// Identical proxy layer to browser-opfs-turso/main.ts.
+
+const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+  type: "module",
+});
+
+const log = document.getElementById("log") as HTMLPreElement;
+const append = (line: string) => {
+  log.textContent = `${new Date().toISOString().slice(11, 23)}  ${line}\n${log.textContent}`;
+};
+
+let nextId = 1;
+const pending = new Map<number, (v: unknown) => void>();
+worker.addEventListener("message", (ev: MessageEvent<{ id: number; ok: boolean; result?: unknown; error?: string }>) => {
+  const slot = pending.get(ev.data.id);
+  if (!slot) return;
+  pending.delete(ev.data.id);
+  slot(ev.data.ok ? ev.data.result : { error: ev.data.error });
+});
+
+function call(op: string, args: unknown[] = []) {
+  const id = nextId++;
+  return new Promise<unknown>((resolve) => {
+    pending.set(id, resolve);
+    worker.postMessage({ id, op, args });
+  });
+}
+
+await call("init", [import.meta.env.VITE_TURSO_URL, import.meta.env.VITE_TURSO_TOKEN]);
+append("ready");
+
+document.getElementById("add")!.addEventListener("click", async () => {
+  const id = crypto.randomUUID();
+  const ts = new Date().toISOString();
+  await call("addRow", [id, ts]);
+  append(`add: ${id}`);
+});
+
+document.getElementById("sync")!.addEventListener("click", async () => {
+  const result = await call("sync");
+  append(`sync: ${JSON.stringify(result)}`);
+});
+
+document.getElementById("reset")!.addEventListener("click", async () => {
+  await call("reset");
+  append("reset");
+});

--- a/docs/examples/browser-idb-turso/package.json
+++ b/docs/examples/browser-idb-turso/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "smugglr-example-browser-idb-turso",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "smugglr": "^0.3.3",
+    "wa-sqlite": "^1.0.0"
+  },
+  "devDependencies": {
+    "vite": "^8.0.10"
+  }
+}

--- a/docs/examples/browser-idb-turso/vite.config.ts
+++ b/docs/examples/browser-idb-turso/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ["wa-sqlite"],
+  },
+  build: {
+    target: "es2022",
+  },
+});

--- a/docs/examples/browser-idb-turso/worker.ts
+++ b/docs/examples/browser-idb-turso/worker.ts
@@ -1,0 +1,88 @@
+// Worker: same as browser-opfs-turso/worker.ts but registers
+// IDBBatchAtomicVFS instead of OriginPrivateFileSystemVFS. Compare against
+// the OPFS variant to see what (little) changes between VFS choices.
+
+import SQLiteAsyncESMFactory from "wa-sqlite/dist/wa-sqlite-async.mjs";
+import * as SQLite from "wa-sqlite";
+// @ts-expect-error - wa-sqlite ships JS examples without .d.ts
+import { IDBBatchAtomicVFS } from "wa-sqlite/src/examples/IDBBatchAtomicVFS.js";
+import { Smugglr, createWaSqliteExecutor } from "smugglr";
+
+let sqlite3: any = null;
+let db: number | null = null;
+let smugglr: Smugglr | null = null;
+
+async function init(tursoUrl: string, tursoToken: string) {
+  const module = await SQLiteAsyncESMFactory();
+  sqlite3 = SQLite.Factory(module);
+  // IDBBatchAtomicVFS takes (idbDatabaseName, options) -- the IDB database is
+  // created on first use.
+  const vfs = await IDBBatchAtomicVFS.create("smugglr-demo", module);
+  sqlite3.vfs_register(vfs, true);
+  db = await sqlite3.open_v2(
+    "demo.db",
+    SQLite.SQLITE_OPEN_READWRITE | SQLite.SQLITE_OPEN_CREATE,
+    "smugglr-demo",
+  );
+
+  const exe = createWaSqliteExecutor(sqlite3, db);
+  await exe.run(
+    "CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, body TEXT, updated_at TEXT)",
+    [],
+  );
+
+  smugglr = await Smugglr.init({
+    source: { type: "local", executor: exe },
+    dest: { url: tursoUrl, authToken: tursoToken, profile: "turso" },
+    sync: { tables: ["notes"], conflictResolution: "newer_wins" },
+  });
+}
+
+async function addRow(id: string, updatedAt: string) {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const exe = createWaSqliteExecutor(sqlite3, db);
+  await exe.run(
+    "INSERT INTO notes (id, body, updated_at) VALUES (?, ?, ?)",
+    [id, `note created at ${updatedAt}`, updatedAt],
+  );
+}
+
+async function sync() {
+  if (!smugglr) throw new Error("init() first");
+  return smugglr.sync();
+}
+
+async function reset() {
+  if (smugglr) {
+    smugglr.dispose();
+    smugglr = null;
+  }
+  if (sqlite3 && db !== null) {
+    sqlite3.close(db);
+    db = null;
+  }
+  // Wipe the IDB database used by the VFS.
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase("smugglr-demo");
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+self.addEventListener("message", async (ev: MessageEvent<{ id: number; op: string; args: unknown[] }>) => {
+  const { id, op, args } = ev.data;
+  try {
+    let result: unknown;
+    switch (op) {
+      case "init": result = await init(args[0] as string, args[1] as string); break;
+      case "addRow": result = await addRow(args[0] as string, args[1] as string); break;
+      case "sync": result = await sync(); break;
+      case "reset": result = await reset(); break;
+      default: throw new Error(`unknown op: ${op}`);
+    }
+    (self as unknown as Worker).postMessage({ id, ok: true, result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    (self as unknown as Worker).postMessage({ id, ok: false, error: message });
+  }
+});

--- a/docs/examples/browser-opfs-turso/.env.example
+++ b/docs/examples/browser-opfs-turso/.env.example
@@ -1,0 +1,2 @@
+VITE_TURSO_URL=https://my-app-myorg.turso.io
+VITE_TURSO_TOKEN=your-turso-auth-token

--- a/docs/examples/browser-opfs-turso/README.md
+++ b/docs/examples/browser-opfs-turso/README.md
@@ -1,0 +1,36 @@
+# browser-opfs-turso
+
+A real SQLite database in the browser (wa-sqlite + OPFS) syncing to a Turso database. The local-first golden path: the user's data lives on their device and replicates to your Turso edge replica without a relay layer in between.
+
+## Prerequisites
+
+- Node 20+ and pnpm
+- A Turso database + auth token. Sign up at <https://turso.tech>; create a database with `turso db create my-app`; mint a token with `turso db tokens create my-app`.
+- A modern Chromium-, Firefox-, or Safari-based browser. **wa-sqlite must run inside a Web Worker** for OPFS sync access handles to work in WebKit and Firefox; the example wires this up.
+
+## Setup
+
+```sh
+pnpm install
+cp .env.example .env
+# fill in TURSO_URL and TURSO_TOKEN
+pnpm dev
+```
+
+Open <http://localhost:5173>.
+
+## Run
+
+The page exposes three buttons:
+
+1. **Add row** -- inserts a row into the local OPFS database.
+2. **Sync** -- bidirectional sync with Turso. Local changes push up; remote changes pull down.
+3. **Reset** -- wipes the OPFS database (handy for re-running the demo).
+
+Open the same page in another browser window. Each window has its own OPFS database; sync both, and each window will see the other's writes after the next pull.
+
+## What this demonstrates
+
+- The full local-first stack: OPFS-backed SQLite in the browser, content-hashed delta sync, no server in the middle.
+- Worker isolation: wa-sqlite + smugglr live in `worker.ts`; the page UI in `main.ts` proxies via postMessage. This is the cross-browser-safe layout because OPFS sync access handles are worker-only in WebKit and Firefox.
+- The `createWaSqliteExecutor` adapter wraps wa-sqlite as a `SqlExecutor`. Smugglr is SQLite-runtime-agnostic; swap in better-sqlite3 (Node), sql.js, or the official sqlite-wasm package by writing the same shape.

--- a/docs/examples/browser-opfs-turso/index.html
+++ b/docs/examples/browser-opfs-turso/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>smugglr OPFS + Turso</title>
+  </head>
+  <body>
+    <h1>smugglr local-first demo</h1>
+    <p>Real SQLite in OPFS, syncing with Turso.</p>
+    <button id="add">Add row</button>
+    <button id="sync">Sync</button>
+    <button id="reset">Reset</button>
+    <pre id="log"></pre>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/docs/examples/browser-opfs-turso/main.ts
+++ b/docs/examples/browser-opfs-turso/main.ts
@@ -1,0 +1,49 @@
+// Page UI: proxies button clicks into the worker via postMessage. The worker
+// owns wa-sqlite + smugglr because OPFS sync access handles are worker-only
+// in WebKit and Firefox.
+
+const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+  type: "module",
+});
+
+const log = document.getElementById("log") as HTMLPreElement;
+const append = (line: string) => {
+  log.textContent = `${new Date().toISOString().slice(11, 23)}  ${line}\n${log.textContent}`;
+};
+
+let nextId = 1;
+const pending = new Map<number, (v: unknown) => void>();
+worker.addEventListener("message", (ev: MessageEvent<{ id: number; ok: boolean; result?: unknown; error?: string }>) => {
+  const slot = pending.get(ev.data.id);
+  if (!slot) return;
+  pending.delete(ev.data.id);
+  slot(ev.data.ok ? ev.data.result : { error: ev.data.error });
+});
+
+function call(op: string, args: unknown[] = []) {
+  const id = nextId++;
+  return new Promise<unknown>((resolve) => {
+    pending.set(id, resolve);
+    worker.postMessage({ id, op, args });
+  });
+}
+
+await call("init", [import.meta.env.VITE_TURSO_URL, import.meta.env.VITE_TURSO_TOKEN]);
+append("ready");
+
+document.getElementById("add")!.addEventListener("click", async () => {
+  const id = crypto.randomUUID();
+  const ts = new Date().toISOString();
+  await call("addRow", [id, ts]);
+  append(`add: ${id}`);
+});
+
+document.getElementById("sync")!.addEventListener("click", async () => {
+  const result = await call("sync");
+  append(`sync: ${JSON.stringify(result)}`);
+});
+
+document.getElementById("reset")!.addEventListener("click", async () => {
+  await call("reset");
+  append("reset");
+});

--- a/docs/examples/browser-opfs-turso/package.json
+++ b/docs/examples/browser-opfs-turso/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "smugglr-example-browser-opfs-turso",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "smugglr": "^0.3.3",
+    "wa-sqlite": "^1.0.0"
+  },
+  "devDependencies": {
+    "vite": "^8.0.10"
+  }
+}

--- a/docs/examples/browser-opfs-turso/vite.config.ts
+++ b/docs/examples/browser-opfs-turso/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ["wa-sqlite"],
+  },
+  build: {
+    target: "es2022",
+  },
+});

--- a/docs/examples/browser-opfs-turso/worker.ts
+++ b/docs/examples/browser-opfs-turso/worker.ts
@@ -1,0 +1,83 @@
+// Worker: owns wa-sqlite + OPFS + smugglr. The page proxies via postMessage.
+
+import SQLiteAsyncESMFactory from "wa-sqlite/dist/wa-sqlite-async.mjs";
+import * as SQLite from "wa-sqlite";
+// @ts-expect-error - wa-sqlite ships JS examples without .d.ts
+import { OriginPrivateFileSystemVFS } from "wa-sqlite/src/examples/OriginPrivateFileSystemVFS.js";
+import { Smugglr, createWaSqliteExecutor } from "smugglr";
+
+let sqlite3: any = null;
+let db: number | null = null;
+let smugglr: Smugglr | null = null;
+
+async function init(tursoUrl: string, tursoToken: string) {
+  const module = await SQLiteAsyncESMFactory();
+  sqlite3 = SQLite.Factory(module);
+  const vfs = new OriginPrivateFileSystemVFS();
+  await new Promise((r) => setTimeout(r, 0));
+  sqlite3.vfs_register(vfs, true);
+  db = await sqlite3.open_v2(
+    "demo.db",
+    SQLite.SQLITE_OPEN_READWRITE | SQLite.SQLITE_OPEN_CREATE,
+    "opfs",
+  );
+
+  const exe = createWaSqliteExecutor(sqlite3, db);
+  await exe.run(
+    "CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, body TEXT, updated_at TEXT)",
+    [],
+  );
+
+  smugglr = await Smugglr.init({
+    source: { type: "local", executor: exe },
+    dest: { url: tursoUrl, authToken: tursoToken, profile: "turso" },
+    sync: { tables: ["notes"], conflictResolution: "newer_wins" },
+  });
+}
+
+async function addRow(id: string, updatedAt: string) {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const exe = createWaSqliteExecutor(sqlite3, db);
+  await exe.run(
+    "INSERT INTO notes (id, body, updated_at) VALUES (?, ?, ?)",
+    [id, `note created at ${updatedAt}`, updatedAt],
+  );
+}
+
+async function sync() {
+  if (!smugglr) throw new Error("init() first");
+  return smugglr.sync();
+}
+
+async function reset() {
+  if (smugglr) {
+    smugglr.dispose();
+    smugglr = null;
+  }
+  if (sqlite3 && db !== null) {
+    sqlite3.close(db);
+    db = null;
+  }
+  const root = await navigator.storage.getDirectory();
+  for await (const entry of (root as any).values()) {
+    await root.removeEntry(entry.name, { recursive: true });
+  }
+}
+
+self.addEventListener("message", async (ev: MessageEvent<{ id: number; op: string; args: unknown[] }>) => {
+  const { id, op, args } = ev.data;
+  try {
+    let result: unknown;
+    switch (op) {
+      case "init": result = await init(args[0] as string, args[1] as string); break;
+      case "addRow": result = await addRow(args[0] as string, args[1] as string); break;
+      case "sync": result = await sync(); break;
+      case "reset": result = await reset(); break;
+      default: throw new Error(`unknown op: ${op}`);
+    }
+    (self as unknown as Worker).postMessage({ id, ok: true, result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    (self as unknown as Worker).postMessage({ id, ok: false, error: message });
+  }
+});

--- a/docs/examples/cli-d1-sync/README.md
+++ b/docs/examples/cli-d1-sync/README.md
@@ -1,0 +1,68 @@
+# cli-d1-sync
+
+Sync a local SQLite database with a Cloudflare D1 database from the command line.
+
+## Prerequisites
+
+- `smugglr` installed (`brew install rafters-studio/tap/smugglr` or download from [releases](https://github.com/rafters-studio/smugglr/releases))
+- A Cloudflare account with D1 enabled
+- A D1 database -- create one with `npx wrangler d1 create my-app`
+- A Cloudflare API token with `D1:Edit` scope -- create at <https://dash.cloudflare.com/profile/api-tokens>
+- A local SQLite file to sync (any `.db`/`.sqlite` file with at least one table)
+
+## Setup
+
+1. Copy `config.example.toml` to `config.toml` and fill in the placeholders:
+
+   ```sh
+   cp config.example.toml config.toml
+   ```
+
+2. Set your API token in the environment so it doesn't sit in the config file:
+
+   ```sh
+   export SMUGGLR_D1_TOKEN="your-cloudflare-api-token"
+   ```
+
+3. Make sure the schema exists on both sides. smugglr does not propagate `CREATE TABLE`; create the same tables locally and on D1 (e.g. via `wrangler d1 execute my-app --file=schema.sql`).
+
+## Run
+
+Inspect what would change without writing anything:
+
+```sh
+smugglr diff
+```
+
+Push local rows to D1:
+
+```sh
+smugglr push
+```
+
+Pull D1 rows down:
+
+```sh
+smugglr pull
+```
+
+Bidirectional sync (push then pull, with conflict resolution):
+
+```sh
+smugglr sync
+```
+
+## Expected output
+
+```
+$ smugglr push
+[INFO] users: pushing 12 rows
+[INFO] posts: pushing 3 rows
+push complete: 15 rows in 240ms
+```
+
+## What this demonstrates
+
+- The minimum viable smugglr setup: a `config.toml` with a `local` source and a `d1` dest.
+- Content-hashed delta: re-running `push` after no local edits reports `0 rows`.
+- Agent-friendly mode: add `--output json` to any command to get structured exit codes for scripting.

--- a/docs/examples/cli-d1-sync/config.example.toml
+++ b/docs/examples/cli-d1-sync/config.example.toml
@@ -1,0 +1,28 @@
+# cli-d1-sync example config.
+#
+# Copy this file to config.toml and replace the placeholders.
+# The API token is read from the SMUGGLR_D1_TOKEN environment variable, so
+# this file is safe to commit.
+
+cloudflare_account_id = "your-32-char-account-id"
+cloudflare_api_token = "${SMUGGLR_D1_TOKEN}"
+database_id = "your-d1-database-uuid"
+
+local_db = "./app.sqlite"
+
+[sync]
+
+# Sync everything except smugglr/wrangler bookkeeping tables.
+tables = []
+exclude_tables = [
+    "sqlite_sequence",
+    "_cf_KV",
+    "_cf_METADATA",
+    "d1_migrations",
+]
+
+# Most schemas keep an updated_at column; smugglr uses it as a tiebreaker.
+timestamp_column = "updated_at"
+
+# Local edits win over D1 -- typical dev -> prod workflow.
+conflict_resolution = "local_wins"

--- a/docs/examples/cli-d1-sync/schema.sql
+++ b/docs/examples/cli-d1-sync/schema.sql
@@ -1,0 +1,17 @@
+-- Minimal example schema. Apply locally with `sqlite3 app.sqlite < schema.sql`
+-- and to D1 with `npx wrangler d1 execute my-app --file=schema.sql`.
+
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,         -- UUIDv7 recommended
+    email TEXT NOT NULL UNIQUE,
+    name TEXT,
+    updated_at TEXT NOT NULL     -- ISO 8601, e.g. 2026-04-25T03:14:15Z
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+    id TEXT PRIMARY KEY,
+    author_id TEXT NOT NULL REFERENCES users(id),
+    title TEXT NOT NULL,
+    body TEXT,
+    updated_at TEXT NOT NULL
+);

--- a/docs/examples/cli-lan-broadcast/README.md
+++ b/docs/examples/cli-lan-broadcast/README.md
@@ -1,0 +1,54 @@
+# cli-lan-broadcast
+
+Two laptops on the same Wi-Fi network keep their SQLite databases in sync via UDP broadcast. No cloud, no S3, no relay -- peers discover each other and exchange encrypted deltas directly.
+
+## Prerequisites
+
+- `smugglr` on both machines (same major version)
+- Both machines on the same subnet (typically: same Wi-Fi)
+- A shared 256-bit encryption key (a hex string both sides know)
+- Each machine has its own copy of the SQLite database file at the same path-relative-to-config
+
+## Setup
+
+1. Generate a shared key once:
+
+   ```sh
+   openssl rand -hex 32
+   ```
+
+   Distribute this securely to both machines. Don't put it in git.
+
+2. On each machine, copy `config.example.toml` to `config.toml` and:
+   - paste the same key into `[broadcast].encryption_key`
+   - point `local_db` at this machine's copy of the database
+   - leave the rest at defaults
+
+3. Make sure UDP traffic on the broadcast port (default `47291`) isn't blocked by firewall.
+
+## Run
+
+On each machine:
+
+```sh
+smugglr daemon
+```
+
+The daemon registers as a peer, listens for broadcast announcements from other smugglr peers, and exchanges deltas every time a row changes locally or arrives from a peer.
+
+You can verify discovery with:
+
+```sh
+smugglr daemon --output json | jq '.peers'
+```
+
+## Expected behavior
+
+- Insert a row on machine A. Within a second, the same row appears on machine B.
+- Disconnect machine A from Wi-Fi, write more rows. Reconnect. Machine B catches up automatically; conflicts resolve per `conflict_resolution`.
+
+## What this demonstrates
+
+- Offline-tolerant peer-to-peer sync. No central server, no internet required.
+- All broadcast payloads are encrypted with the shared key. Anyone on the LAN can see the announcement headers but not the row contents.
+- `uuid_v7_wins` conflict resolution is the recommended setting for master-master topologies because UUIDv7 PKs encode creation time -- newer writes deterministically win without a clock-sync requirement.

--- a/docs/examples/cli-lan-broadcast/config.example.toml
+++ b/docs/examples/cli-lan-broadcast/config.example.toml
@@ -1,0 +1,21 @@
+# cli-lan-broadcast example config.
+#
+# Copy to config.toml on each machine; the encryption_key MUST be identical
+# across peers. Generate one with: openssl rand -hex 32
+
+local_db = "./shared.sqlite"
+
+[sync]
+tables = []
+exclude_tables = ["sqlite_sequence"]
+timestamp_column = "updated_at"
+# UUIDv7 PKs encode creation time, so newer writes win without clock sync.
+conflict_resolution = "uuid_v7_wins"
+
+[broadcast]
+# Hex-encoded 256-bit key. Identical on every peer.
+encryption_key = "REPLACE_WITH_OUTPUT_OF_openssl_rand_-hex_32"
+# Default UDP port for peer announcements.
+port = 47291
+# Skip large columns (embeddings, blobs) from broadcast payloads.
+exclude_columns = ["*_embedding", "vector"]

--- a/docs/examples/node-auto-sync/.env.example
+++ b/docs/examples/node-auto-sync/.env.example
@@ -1,0 +1,5 @@
+CF_ACCOUNT_ID=your-32-char-account-id
+CF_API_TOKEN=your-cloudflare-api-token-with-D1-Edit
+CF_D1_DATABASE_ID=your-d1-database-uuid
+LOCAL_DB=./app.sqlite
+SYNC_INTERVAL_MS=30000

--- a/docs/examples/node-auto-sync/README.md
+++ b/docs/examples/node-auto-sync/README.md
@@ -1,0 +1,38 @@
+# node-auto-sync
+
+A long-running Node process that calls `smugglr.sync()` on an interval, with exponential backoff on transient failures and clean shutdown on `SIGTERM`. This is the manual version of what the upcoming `autoSync` config option will provide; once #113 lands, this becomes a one-liner.
+
+## Prerequisites
+
+Same as [node-server-to-d1](../node-server-to-d1/) -- a local SQLite file and a D1 (or any HTTP-SQL) destination.
+
+## Setup
+
+```sh
+pnpm install
+cp .env.example .env
+# fill in CF_ACCOUNT_ID, CF_API_TOKEN, CF_D1_DATABASE_ID, LOCAL_DB
+```
+
+## Run
+
+```sh
+node --env-file=.env auto-sync.mjs
+```
+
+Send `SIGTERM` (Ctrl-C) to stop. The current sync completes before exit; no half-written batches.
+
+## Expected output
+
+```
+[12:30:00.123] sync ok: 3 rows
+[12:30:30.456] sync ok: 0 rows
+[12:31:00.789] sync failed (retryable): 503 -- backing off 2000ms
+[12:31:02.812] sync ok: 7 rows
+```
+
+## What this demonstrates
+
+- The `SmugglrError.retryable` flag (true for HTTP 429/503 and timeouts) drives the backoff decision; non-retryable errors propagate.
+- The `sync()` method serializes -- you cannot have two in flight at once. The interval pattern below uses a guard to skip ticks while one is still running.
+- Bounded backoff (caps at 5 minutes) prevents thundering herd if the remote stays down.

--- a/docs/examples/node-auto-sync/auto-sync.mjs
+++ b/docs/examples/node-auto-sync/auto-sync.mjs
@@ -1,0 +1,84 @@
+// Long-running sync loop with exponential backoff. Replace with the upcoming
+// `autoSync` config option once #113 lands.
+
+import Database from "better-sqlite3";
+import { Smugglr, SmugglrError } from "smugglr";
+
+const db = new Database(process.env.LOCAL_DB);
+const executor = {
+  async run(sql, params) {
+    const stmt = db.prepare(sql);
+    const trimmed = sql.trim().toUpperCase();
+    if (trimmed.startsWith("SELECT") || trimmed.startsWith("PRAGMA")) {
+      return {
+        columns: stmt.columns().map((c) => c.name),
+        rows: stmt.raw().all(params),
+      };
+    }
+    stmt.run(params);
+    return { columns: [], rows: [] };
+  },
+};
+
+const url = `https://api.cloudflare.com/client/v4/accounts/${process.env.CF_ACCOUNT_ID}/d1/database/${process.env.CF_D1_DATABASE_ID}/query`;
+
+const s = await Smugglr.init({
+  source: { type: "local", executor },
+  dest: { url, authToken: process.env.CF_API_TOKEN, profile: "d1" },
+  sync: { conflictResolution: "newer_wins" },
+});
+
+const tickInterval = Number(process.env.SYNC_INTERVAL_MS ?? 30_000);
+const minBackoff = 1_000;
+const maxBackoff = 5 * 60_000;
+let backoff = minBackoff;
+let inflight = false;
+let stopped = false;
+
+function ts() {
+  return new Date().toISOString().slice(11, 23);
+}
+
+async function tick() {
+  if (inflight || stopped) return;
+  inflight = true;
+  try {
+    const result = await s.sync();
+    const rows = result.tables.reduce(
+      (n, t) => n + (t.rowsPushed ?? 0) + (t.rowsPulled ?? 0),
+      0,
+    );
+    console.log(`[${ts()}] sync ok: ${rows} rows`);
+    backoff = minBackoff;
+  } catch (err) {
+    if (err instanceof SmugglrError && err.retryable) {
+      console.warn(`[${ts()}] sync failed (retryable): ${err.message} -- backing off ${backoff}ms`);
+      await new Promise((r) => setTimeout(r, backoff));
+      backoff = Math.min(backoff * 2, maxBackoff);
+    } else {
+      console.error(`[${ts()}] sync failed (fatal):`, err);
+      stopped = true;
+    }
+  } finally {
+    inflight = false;
+  }
+}
+
+const handle = setInterval(tick, tickInterval);
+tick();
+
+function shutdown(signal) {
+  console.log(`[${ts()}] received ${signal}, stopping after current sync...`);
+  stopped = true;
+  clearInterval(handle);
+  const wait = setInterval(() => {
+    if (!inflight) {
+      clearInterval(wait);
+      s.dispose();
+      db.close();
+      process.exit(0);
+    }
+  }, 100);
+}
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/docs/examples/node-auto-sync/package.json
+++ b/docs/examples/node-auto-sync/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "smugglr-example-node-auto-sync",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node --env-file=.env auto-sync.mjs"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.0.0",
+    "smugglr": "^0.3.3"
+  }
+}

--- a/docs/examples/node-server-to-d1/.env.example
+++ b/docs/examples/node-server-to-d1/.env.example
@@ -1,0 +1,4 @@
+CF_ACCOUNT_ID=your-32-char-account-id
+CF_API_TOKEN=your-cloudflare-api-token-with-D1-Edit
+CF_D1_DATABASE_ID=your-d1-database-uuid
+LOCAL_DB=./app.sqlite

--- a/docs/examples/node-server-to-d1/README.md
+++ b/docs/examples/node-server-to-d1/README.md
@@ -1,0 +1,37 @@
+# node-server-to-d1
+
+A Node script reads a local SQLite database and pushes its contents to a Cloudflare D1 database using the `smugglr` npm package. No CLI involved -- everything runs in-process via WASM.
+
+## Prerequisites
+
+- Node 20+
+- pnpm (or npm/yarn)
+- A Cloudflare D1 database + API token (see [cli-d1-sync](../cli-d1-sync/) for setup)
+- A local SQLite file to sync (the `better-sqlite3` package is used to read it)
+
+## Setup
+
+```sh
+pnpm install
+cp .env.example .env
+# fill in CF_ACCOUNT_ID, CF_API_TOKEN, CF_D1_DATABASE_ID, LOCAL_DB
+```
+
+## Run
+
+```sh
+node push.mjs
+```
+
+## Expected output
+
+```
+loaded smugglr (wasm: 110 KB)
+push complete: { tables: [ { name: 'users', rowsPushed: 12 }, { name: 'posts', rowsPushed: 3 } ] }
+```
+
+## What this demonstrates
+
+- The `smugglr` npm package runs in Node, not just the browser. The WASM binary is identical.
+- A `LocalEndpointConfig` with a custom `SqlExecutor` lets you plug in any SQLite runtime -- here `better-sqlite3`, but the same shape works for sql.js, the official sqlite-wasm package, or your own.
+- One-shot push with a typed result. Pair with [node-auto-sync](../node-auto-sync/) for a long-running daemon.

--- a/docs/examples/node-server-to-d1/package.json
+++ b/docs/examples/node-server-to-d1/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "smugglr-example-node-server-to-d1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node --env-file=.env push.mjs"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.0.0",
+    "smugglr": "^0.3.3"
+  }
+}

--- a/docs/examples/node-server-to-d1/push.mjs
+++ b/docs/examples/node-server-to-d1/push.mjs
@@ -1,0 +1,50 @@
+// Push a local SQLite database to Cloudflare D1 using the smugglr npm package.
+//
+// Run: node --env-file=.env push.mjs
+
+import Database from "better-sqlite3";
+import { Smugglr } from "smugglr";
+
+const required = ["CF_ACCOUNT_ID", "CF_API_TOKEN", "CF_D1_DATABASE_ID", "LOCAL_DB"];
+for (const key of required) {
+  if (!process.env[key]) {
+    console.error(`missing env var: ${key}`);
+    process.exit(2);
+  }
+}
+
+const db = new Database(process.env.LOCAL_DB, { readonly: false });
+
+// Wrap better-sqlite3 in the SqlExecutor shape smugglr expects.
+const executor = {
+  async run(sql, params) {
+    const stmt = db.prepare(sql);
+    const trimmed = sql.trim().toUpperCase();
+    if (trimmed.startsWith("SELECT") || trimmed.startsWith("PRAGMA")) {
+      const rows = stmt.raw().all(params);
+      const columns = stmt.columns().map((c) => c.name);
+      return { columns, rows };
+    }
+    stmt.run(params);
+    return { columns: [], rows: [] };
+  },
+};
+
+const url = `https://api.cloudflare.com/client/v4/accounts/${process.env.CF_ACCOUNT_ID}/d1/database/${process.env.CF_D1_DATABASE_ID}/query`;
+
+const s = await Smugglr.init({
+  source: { type: "local", executor },
+  dest: { url, authToken: process.env.CF_API_TOKEN, profile: "d1" },
+  sync: {
+    excludeTables: ["sqlite_sequence", "_cf_KV", "_cf_METADATA", "d1_migrations"],
+    conflictResolution: "local_wins",
+  },
+});
+
+try {
+  const result = await s.push();
+  console.log("push complete:", result);
+} finally {
+  s.dispose();
+  db.close();
+}

--- a/docs/examples/rust-custom-datasource/Cargo.toml
+++ b/docs/examples/rust-custom-datasource/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "smugglr-example-custom-datasource"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+smugglr-core = { version = "0.3", path = "../../../crates/smugglr-core" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde_json = "1"
+sha2 = "0.10"
+hex = "0.4"
+anyhow = "1"

--- a/docs/examples/rust-custom-datasource/README.md
+++ b/docs/examples/rust-custom-datasource/README.md
@@ -1,0 +1,24 @@
+# rust-custom-datasource
+
+Implement the `DataSource` trait against a non-standard store. The example wraps a `HashMap` of rows in memory; the same shape works for a Redis hash, an object-store JSON blob, a custom HTTP API, or any place row-shaped data lives.
+
+This example is also where to look if you want to understand smugglr's content-hashed delta model from the inside.
+
+## Prerequisites
+
+- Rust stable
+
+## Run
+
+```sh
+cargo run --release
+```
+
+You'll see the in-memory store on each side diverge, then sync, then converge.
+
+## What this demonstrates
+
+- The full `DataSource` surface area: `list_tables`, `table_info`, `get_row_metadata`, `get_rows`, `upsert_rows`, `row_count`.
+- `RowMeta::content_hash` is what smugglr compares to decide which rows differ. As long as your `get_row_metadata` returns a stable hash for unchanged rows, the diff engine will not request the row body unless it actually needs to transfer it.
+- Why content hashing beats log-driven CDC for cross-store sync: there's no log to subscribe to, no replication slot to manage, and no requirement that both sides understand each other's transaction model. You sync the *state*, not the *operations* that produced it.
+- The `MaybeSend` relaxation on the trait: native targets require `Send`, WASM targets relax it. The same impl can compile for both by using the `MaybeSend` alias from `smugglr_core::datasource`.

--- a/docs/examples/rust-custom-datasource/src/main.rs
+++ b/docs/examples/rust-custom-datasource/src/main.rs
@@ -1,0 +1,168 @@
+//! Implementing `DataSource` against an in-memory store.
+//!
+//! Replace `Mutex<HashMap<...>>` with whatever your real store is (Redis,
+//! object-store JSON blob, a custom HTTP API). The trait surface is the same.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use anyhow::Result;
+use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
+use smugglr_core::config::Config;
+use smugglr_core::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
+use smugglr_core::error::Result as SmugglrResult;
+use smugglr_core::sync::{sync_all, NoProgress};
+
+/// One row's stored shape: a JSON object plus a derived content hash.
+struct Row {
+    data: HashMap<String, JsonValue>,
+}
+
+impl Row {
+    fn content_hash(&self) -> String {
+        // Stable hash: serialize keys in sorted order so two equivalent rows
+        // always hash the same regardless of HashMap iteration order.
+        let mut keys: Vec<&String> = self.data.keys().collect();
+        keys.sort();
+        let mut hasher = Sha256::new();
+        for k in keys {
+            hasher.update(k.as_bytes());
+            hasher.update(b"=");
+            hasher.update(self.data[k].to_string().as_bytes());
+            hasher.update(b";");
+        }
+        hex::encode(hasher.finalize())
+    }
+}
+
+struct InMemoryStore {
+    tables: Mutex<HashMap<String, HashMap<String, Row>>>,
+}
+
+impl InMemoryStore {
+    fn new() -> Self {
+        Self {
+            tables: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn upsert(&self, table: &str, pk: &str, row: HashMap<String, JsonValue>) {
+        let mut tables = self.tables.lock().unwrap();
+        let t = tables.entry(table.to_string()).or_default();
+        t.insert(pk.to_string(), Row { data: row });
+    }
+}
+
+impl DataSource for InMemoryStore {
+    async fn list_tables(&self) -> SmugglrResult<Vec<String>> {
+        Ok(self.tables.lock().unwrap().keys().cloned().collect())
+    }
+
+    async fn table_info(&self, table: &str) -> SmugglrResult<TableInfo> {
+        // Schema is implicit in our store; we just declare {id, value, updated_at}.
+        Ok(TableInfo {
+            name: table.to_string(),
+            columns: vec![
+                ColumnInfo { name: "id".into(), col_type: "TEXT".into(), notnull: true, pk: true },
+                ColumnInfo { name: "value".into(), col_type: "TEXT".into(), notnull: false, pk: false },
+                ColumnInfo { name: "updated_at".into(), col_type: "TEXT".into(), notnull: false, pk: false },
+            ],
+            primary_key: vec!["id".into()],
+        })
+    }
+
+    async fn get_row_metadata(
+        &self,
+        table: &str,
+        timestamp_column: &str,
+        _exclude_columns: &[String],
+    ) -> SmugglrResult<HashMap<String, RowMeta>> {
+        let tables = self.tables.lock().unwrap();
+        let Some(t) = tables.get(table) else {
+            return Ok(HashMap::new());
+        };
+        Ok(t.iter()
+            .map(|(pk, row)| {
+                let updated_at = row
+                    .data
+                    .get(timestamp_column)
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                (
+                    pk.clone(),
+                    RowMeta {
+                        pk_value: pk.clone(),
+                        updated_at,
+                        content_hash: row.content_hash(),
+                    },
+                )
+            })
+            .collect())
+    }
+
+    async fn get_rows(
+        &self,
+        table: &str,
+        pk_values: &[String],
+    ) -> SmugglrResult<Vec<HashMap<String, JsonValue>>> {
+        let tables = self.tables.lock().unwrap();
+        let Some(t) = tables.get(table) else {
+            return Ok(Vec::new());
+        };
+        Ok(pk_values
+            .iter()
+            .filter_map(|pk| t.get(pk).map(|r| r.data.clone()))
+            .collect())
+    }
+
+    async fn upsert_rows(
+        &self,
+        table: &str,
+        rows: &[HashMap<String, JsonValue>],
+    ) -> SmugglrResult<usize> {
+        let mut tables = self.tables.lock().unwrap();
+        let t = tables.entry(table.to_string()).or_default();
+        for row in rows {
+            let Some(pk) = row.get("id").and_then(|v| v.as_str()) else { continue };
+            t.insert(pk.to_string(), Row { data: row.clone() });
+        }
+        Ok(rows.len())
+    }
+
+    async fn row_count(&self, table: &str) -> SmugglrResult<usize> {
+        Ok(self
+            .tables
+            .lock()
+            .unwrap()
+            .get(table)
+            .map(|t| t.len())
+            .unwrap_or(0))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let a = InMemoryStore::new();
+    let b = InMemoryStore::new();
+
+    // Seed both sides with overlapping but divergent data.
+    a.upsert("widgets", "w1", HashMap::from([
+        ("id".into(), JsonValue::String("w1".into())),
+        ("value".into(), JsonValue::String("alpha".into())),
+        ("updated_at".into(), JsonValue::String("2026-04-25T00:00:00Z".into())),
+    ]));
+    b.upsert("widgets", "w2", HashMap::from([
+        ("id".into(), JsonValue::String("w2".into())),
+        ("value".into(), JsonValue::String("beta".into())),
+        ("updated_at".into(), JsonValue::String("2026-04-25T00:00:01Z".into())),
+    ]));
+
+    println!("before: a={}, b={}", a.row_count("widgets").await?, b.row_count("widgets").await?);
+
+    let config = Config::from_toml_str("")?;
+    sync_all(&a, &b, &config, Some(vec!["widgets".into()]), false, &NoProgress).await?;
+
+    println!("after:  a={}, b={}", a.row_count("widgets").await?, b.row_count("widgets").await?);
+    Ok(())
+}

--- a/docs/examples/rust-tokio-service/Cargo.toml
+++ b/docs/examples/rust-tokio-service/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "smugglr-example-tokio-service"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+smugglr-core = { version = "0.3", path = "../../../crates/smugglr-core" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
+anyhow = "1"
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/docs/examples/rust-tokio-service/README.md
+++ b/docs/examples/rust-tokio-service/README.md
@@ -1,0 +1,23 @@
+# rust-tokio-service
+
+Embed smugglr inside a long-running tokio service. The service holds a local SQLite database open, calls `sync_all` on a tick, and shuts down cleanly. Bypasses the CLI entirely -- this is the right pattern for backends that already own their database connection.
+
+## Prerequisites
+
+- Rust stable
+- A local SQLite file at the path in `LOCAL_DB`
+- A reachable HTTP-SQL target. The example points at a generic profile so any backend that speaks `{sql, params}` -> `{columns, rows}` works (rqlite, your own gateway, etc.). Replace with `Profile::turso()` / `Profile::d1()` for the hosted services.
+
+## Run
+
+```sh
+cargo run --release
+```
+
+The service syncs on startup, then every `SYNC_INTERVAL` (default 30s). `Ctrl-C` triggers a graceful shutdown that completes the in-flight sync before exit.
+
+## What this demonstrates
+
+- Driving smugglr's sync engine (`smugglr_core::sync::sync_all`) directly without the CLI orchestration layer. You bring your own `DataSource` instances and conflict resolution.
+- Using `tokio::select!` to interleave the sync tick with shutdown signals.
+- The two `DataSource` impls used here -- `LocalSqlite` (rusqlite) and the generic HTTP profile -- are the same impls the CLI uses, just wired by hand.

--- a/docs/examples/rust-tokio-service/src/main.rs
+++ b/docs/examples/rust-tokio-service/src/main.rs
@@ -1,0 +1,59 @@
+//! Embedded smugglr inside a tokio service.
+//!
+//! The service holds two LocalDb instances open (`a.sqlite` and `b.sqlite`)
+//! and bidirectionally syncs them on a tick. Replace either side with an
+//! HTTP-SQL endpoint via the smugglr-http-sql plugin in real deployments.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use smugglr_core::config::Config;
+use smugglr_core::local::LocalDb;
+use smugglr_core::sync::{sync_all, NoProgress};
+use tokio::signal;
+use tokio::time::{interval, MissedTickBehavior};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let a = LocalDb::open("a.sqlite")?;
+    let b = LocalDb::open("b.sqlite")?;
+    let config = Config::from_toml_str("")?;
+
+    let tick_every = Duration::from_secs(
+        std::env::var("SYNC_INTERVAL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(30),
+    );
+    let mut ticker = interval(tick_every);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    tracing::info!("syncing every {:?}", tick_every);
+
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => {
+                match sync_all(&a, &b, &config, None, false, &NoProgress).await {
+                    Ok(results) => {
+                        let total: usize = results
+                            .iter()
+                            .map(|r| r.rows_pushed + r.rows_pulled)
+                            .sum();
+                        tracing::info!("sync ok: {} rows across {} tables", total, results.len());
+                    }
+                    Err(err) => {
+                        tracing::warn!("sync failed: {}", err);
+                    }
+                }
+            }
+            _ = signal::ctrl_c() => {
+                tracing::info!("shutdown signal received");
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds \`docs/examples/\` with eight self-contained examples covering the main ways people reach for smugglr. Each example has its own README with prerequisites, setup, and run commands; self-containment per the acceptance criteria.

## Examples

| Surface | Example | Verified |
| ------- | ------- | -------- |
| CLI     | \`cli-d1-sync\` | code only -- needs CF account/token to run |
| CLI     | \`cli-lan-broadcast\` | code only -- needs two machines |
| Node    | \`node-server-to-d1\` | code only -- needs CF account/token to run |
| Node    | \`node-auto-sync\` | code only -- needs CF account/token to run |
| Rust    | \`rust-tokio-service\` | \`cargo check\` clean |
| Rust    | \`rust-custom-datasource\` | **runs end-to-end**: \`cargo run\` outputs \`before: a=1, b=1\` -> \`after: a=2, b=2\` |
| Browser | \`browser-opfs-turso\` | code only -- needs Turso account |
| Browser | \`browser-idb-turso\` | code only -- needs Turso account |

The two Rust examples are standalone Cargo packages (each declares its own \`[workspace]\`) so they don't get pulled into the main workspace and don't break \`cargo check --workspace\`.

## Acceptance criteria (#119)
- [x] \`docs/examples/\` directory created
- [x] Each example has its own subdir with README.md, config, source files, expected output
- [x] Each example documents end-to-end prereqs; \`rust-custom-datasource\` actually runs end-to-end without external services
- [x] Linked from main README (new \"Examples\" section)
- [x] No example depends on closed-source / fence-only features (everything uses OSS-tier APIs)

## Notes for reviewers
- Network-dependent examples (D1, Turso, LAN broadcast) describe the prerequisites but obviously need credentials to actually run. Code is verbatim what we use ourselves.
- Browser examples both run wa-sqlite inside a Web Worker (cross-browser-safe), matching the pattern from PR #120's e2e suite.
- Some near-duplication between paired examples (opfs/idb workers, node better-sqlite3 executor adapter) is intentional -- the issue explicitly asks for each example to be self-contained, and side-by-side readability beats DRY for documentation.

Closes #119.