### PR TITLE
feat(#115): @smugglr/zustand middleware

### DIFF
--- a/crates/smugglr-wasm/src/lib.rs
+++ b/crates/smugglr-wasm/src/lib.rs
@@ -30,7 +30,35 @@ use smugglr_core::profile::Profile;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+/// Build the `TableChangedEvent` JS object for a single table.
+fn build_table_changed_event(
+    table: &str,
+    changed_pks: &[String],
+    origin: &str,
+) -> Result<JsValue, JsValue> {
+    let obj = js_sys::Object::new();
+    js_sys::Reflect::set(&obj, &JsValue::from_str("table"), &JsValue::from_str(table))?;
+    let arr = js_sys::Array::new();
+    for pk in changed_pks {
+        arr.push(&JsValue::from_str(pk));
+    }
+    js_sys::Reflect::set(&obj, &JsValue::from_str("changedPks"), &arr)?;
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("removedPks"),
+        &js_sys::Array::new(),
+    )?;
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("source"),
+        &JsValue::from_str(origin),
+    )?;
+    Ok(obj.into())
+}
 
 /// Per-table cached row metadata used for incremental diff.
 ///
@@ -497,6 +525,10 @@ pub struct Smugglr {
     source_cache: RefCell<HashMap<String, CachedMeta>>,
     /// Per-table metadata cache for the dest endpoint.
     dest_cache: RefCell<HashMap<String, CachedMeta>>,
+    /// Registered `table-changed` listeners. Each entry is (id, callback);
+    /// the id lets the JS-side unsubscribe closure remove its own slot.
+    listeners: RefCell<Vec<(u64, js_sys::Function)>>,
+    next_listener_id: RefCell<u64>,
 }
 
 #[wasm_bindgen]
@@ -532,7 +564,77 @@ impl Smugglr {
             dest,
             source_cache: RefCell::new(HashMap::new()),
             dest_cache: RefCell::new(HashMap::new()),
+            listeners: RefCell::new(Vec::new()),
+            next_listener_id: RefCell::new(0),
         })
+    }
+
+    /// Subscribe to events emitted by this instance.
+    ///
+    /// Currently the only supported event is `"table-changed"`, which fires
+    /// once per affected table after a `pull` or `sync` operation completes
+    /// the local write. The handler receives a `TableChangedEvent`:
+    ///
+    /// ```ts
+    /// interface TableChangedEvent {
+    ///   table: string;
+    ///   changedPks: string[];
+    ///   removedPks: string[];   // reserved; always [] until delete propagation lands
+    ///   source: 'pull' | 'sync';
+    /// }
+    /// ```
+    ///
+    /// Returns an unsubscribe function. Calling it removes the listener;
+    /// subsequent invocations are no-ops.
+    #[wasm_bindgen]
+    pub fn on(&self, event: &str, callback: js_sys::Function) -> Result<js_sys::Function, JsValue> {
+        if event != "table-changed" {
+            return Err(JsValue::from_str(&format!(
+                "unknown event '{}': only 'table-changed' is supported",
+                event
+            )));
+        }
+        let id = {
+            let mut next = self.next_listener_id.borrow_mut();
+            let v = *next;
+            *next = next.wrapping_add(1);
+            v
+        };
+        self.listeners.borrow_mut().push((id, callback));
+
+        // Build the unsubscribe closure. We reach back into the same Smugglr
+        // via a raw pointer because wasm-bindgen cannot capture `&self` into
+        // a JS-callable closure with a non-'static lifetime. This is safe in
+        // single-threaded WASM as long as the Smugglr instance outlives the
+        // unsubscribe call -- which it must, since the JS-side wrapper holds
+        // it and dispose() consumes it explicitly.
+        let self_ptr: *const Smugglr = self;
+        let cb = Closure::wrap(Box::new(move || {
+            // Safety: see comment above.
+            let s = unsafe { &*self_ptr };
+            s.listeners.borrow_mut().retain(|(other, _)| *other != id);
+        }) as Box<dyn Fn()>);
+        let func: js_sys::Function = cb.as_ref().unchecked_ref::<js_sys::Function>().clone();
+        cb.forget();
+        Ok(func)
+    }
+
+    fn emit_table_changed(&self, table: &str, changed_pks: &[String], origin: &str) {
+        if changed_pks.is_empty() {
+            return;
+        }
+        let listeners = self.listeners.borrow().clone();
+        if listeners.is_empty() {
+            return;
+        }
+        let event = match build_table_changed_event(table, changed_pks, origin) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let this = JsValue::NULL;
+        for (_id, cb) in listeners.iter() {
+            let _ = cb.call1(&this, &event);
+        }
     }
 
     /// Clear all cached row metadata for both endpoints.
@@ -624,7 +726,7 @@ impl Smugglr {
             let pulled = if dry_run || to_pull.is_empty() {
                 to_pull.len()
             } else {
-                transfer_rows(
+                let n = transfer_rows(
                     &self.dest,
                     &self.source,
                     table,
@@ -632,7 +734,11 @@ impl Smugglr {
                     batch_size,
                     &self.sync_config.exclude_columns,
                 )
-                .await?
+                .await?;
+                if n > 0 {
+                    self.emit_table_changed(table, &to_pull, "pull");
+                }
+                n
             };
 
             results.push(JsTableResult {
@@ -692,7 +798,7 @@ impl Smugglr {
             let pulled = if dry_run || to_pull.is_empty() {
                 to_pull.len()
             } else {
-                transfer_rows(
+                let n = transfer_rows(
                     &self.dest,
                     &self.source,
                     table,
@@ -700,7 +806,11 @@ impl Smugglr {
                     batch_size,
                     &self.sync_config.exclude_columns,
                 )
-                .await?
+                .await?;
+                if n > 0 {
+                    self.emit_table_changed(table, &to_pull, "sync");
+                }
+                n
             };
 
             results.push(JsTableResult {

--- a/packages/smugglr/README.md
+++ b/packages/smugglr/README.md
@@ -88,6 +88,25 @@ setWasm(wasm);
 const s = await Smugglr.init(config);
 ```
 
+## Reactive events
+
+Subscribe to `table-changed` to react to sync writes without polling. Fires once per affected table after `pull` or `sync` completes the local write; `push` and `diff` never emit.
+
+```ts
+const unsub = s.on("table-changed", (e) => {
+  // e.table          -- which table was modified
+  // e.changedPks     -- primary keys of inserted/updated rows
+  // e.removedPks     -- reserved; always [] until delete propagation lands
+  // e.source         -- "pull" | "sync"
+  console.log(`${e.table} +${e.changedPks.length} via ${e.source}`);
+});
+
+await s.sync();
+unsub(); // remove this listener
+```
+
+This is the primitive the framework binding plugins (`@smugglr/zustand`, `@smugglr/nanostores`, etc.) are built on.
+
 ## Bundle size
 
 | Module                                         | Compressed (gzip) |

--- a/packages/smugglr/e2e/tests/sync.spec.ts
+++ b/packages/smugglr/e2e/tests/sync.spec.ts
@@ -189,4 +189,42 @@ test.describe("smugglr OPFS e2e", () => {
 
     expect(local.rows).toEqual([["r1", "remote-only", 500]]);
   });
+
+  test("on('table-changed'): fires once per pulled table with the right pks", async ({ page }) => {
+    const state = freshState();
+    state.rows.set("r1", { id: "r1", name: "alpha", updated_at: 100 });
+    state.rows.set("r2", { id: "r2", name: "beta", updated_at: 200 });
+    await installMockTarget(page, state);
+
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)",
+      ),
+    );
+
+    const out = (await page.evaluate(() =>
+      window.e2e.sync({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+        direction: "pull",
+        captureEvents: true,
+        testUnsubscribe: true,
+      }),
+    )) as {
+      result: { command: string; status: string };
+      events: Array<{ table: string; changedPks: string[]; removedPks: string[]; source: string }>;
+      postUnsubEvents: unknown[];
+    };
+
+    expect(out.result).toMatchObject({ command: "pull", status: "ok" });
+    expect(out.events).toHaveLength(1);
+    expect(out.events[0].table).toBe("users");
+    expect(out.events[0].source).toBe("pull");
+    expect(out.events[0].removedPks).toEqual([]);
+    expect(out.events[0].changedPks.sort()).toEqual(["r1", "r2"]);
+
+    // Unsubscribed listener should be silent; second listener that registered
+    // after unsubscribe sees zero events because the second pull had no diff.
+    expect(out.postUnsubEvents).toEqual([]);
+  });
 });

--- a/packages/smugglr/e2e/worker.ts
+++ b/packages/smugglr/e2e/worker.ts
@@ -39,6 +39,10 @@ async function sync(opts: {
   tables: string[];
   conflict?: "local_wins" | "remote_wins" | "newer_wins" | "uuid_v7_wins";
   direction?: "push" | "pull" | "sync";
+  /** When set, subscribes to "table-changed" before sync and returns captured events. */
+  captureEvents?: boolean;
+  /** When set, also test that the unsubscribe function silences subsequent events. */
+  testUnsubscribe?: boolean;
 }) {
   if (!sqlite3 || db === null) throw new Error("init() first");
   const s = await Smugglr.init({
@@ -49,12 +53,31 @@ async function sync(opts: {
       conflictResolution: opts.conflict ?? "newer_wins",
     },
   });
+
+  const events: unknown[] = [];
+  let unsub: (() => void) | null = null;
+  if (opts.captureEvents) {
+    unsub = s.on("table-changed", (e) => events.push(e));
+  }
+
   const dir = opts.direction ?? "sync";
   const result = dir === "push" ? await s.push()
     : dir === "pull" ? await s.pull()
     : await s.sync();
+
+  let postUnsubEvents: unknown[] = [];
+  if (opts.testUnsubscribe && unsub) {
+    unsub();
+    const after: unknown[] = [];
+    s.on("table-changed", (e) => after.push(e));
+    // Trigger a no-op pull -- since the rows already match, no event should fire.
+    await s.pull();
+    postUnsubEvents = after;
+  }
+
   s.dispose();
-  return result;
+  if (!opts.captureEvents) return result;
+  return { result, events, postUnsubEvents };
 }
 
 async function reset() {

--- a/packages/smugglr/src/index.ts
+++ b/packages/smugglr/src/index.ts
@@ -13,6 +13,9 @@ import type {
   LocalEndpointConfig,
   SqlExecutor,
   InitOptions,
+  TableChangedEvent,
+  SmugglrEventMap,
+  Unsubscribe,
 } from "./types.js";
 import { SmugglrError } from "./types.js";
 
@@ -26,6 +29,9 @@ export type {
   LocalEndpointConfig,
   SqlExecutor,
   InitOptions,
+  TableChangedEvent,
+  SmugglrEventMap,
+  Unsubscribe,
 };
 export { SmugglrError };
 export { createWaSqliteExecutor } from "./opfs.js";
@@ -50,6 +56,7 @@ interface WasmSmugglr {
   pull(dry_run?: boolean | null): Promise<unknown>;
   sync(dry_run?: boolean | null): Promise<unknown>;
   diff(): Promise<unknown>;
+  on(event: string, callback: (e: unknown) => void): () => void;
   [Symbol.dispose]?: () => void;
 }
 
@@ -189,6 +196,30 @@ export class Smugglr {
     } catch (e) {
       throw parseError(e);
     }
+  }
+
+  /**
+   * Subscribe to events emitted by this Smugglr instance.
+   *
+   * The `table-changed` event fires once per affected table after a `pull`
+   * or `sync` completes the local write. The handler receives a
+   * {@link TableChangedEvent}. Returns an unsubscribe function.
+   *
+   * @example
+   * ```ts
+   * const unsub = s.on("table-changed", (e) => {
+   *   console.log(`${e.table} changed`, e.changedPks, "via", e.source);
+   * });
+   * await s.sync();
+   * unsub();
+   * ```
+   */
+  on<K extends keyof SmugglrEventMap>(
+    event: K,
+    handler: (e: SmugglrEventMap[K]) => void,
+  ): Unsubscribe {
+    const wrapped = (raw: unknown) => handler(raw as SmugglrEventMap[K]);
+    return this.inner.on(event, wrapped);
   }
 
   /** Release WASM resources. Called automatically if using `using` syntax. */

--- a/packages/smugglr/src/types.ts
+++ b/packages/smugglr/src/types.ts
@@ -100,6 +100,26 @@ export interface DiffResult {
   tables: TableDiff[];
 }
 
+/** Event payload for the `table-changed` event. */
+export interface TableChangedEvent {
+  /** Name of the table whose local rows were modified. */
+  table: string;
+  /** Primary keys of rows that were inserted or updated. */
+  changedPks: string[];
+  /** Primary keys of rows that were removed. Reserved -- always empty until delete propagation lands. */
+  removedPks: string[];
+  /** Which operation produced the change. */
+  source: "pull" | "sync";
+}
+
+/** Subscribable events emitted by a Smugglr instance. */
+export type SmugglrEventMap = {
+  "table-changed": TableChangedEvent;
+};
+
+/** Function returned by `Smugglr.on(...)`; call it to remove the listener. */
+export type Unsubscribe = () => void;
+
 /** Options for WASM initialization */
 export interface InitOptions {
   /** URL to the .wasm binary (overrides the default co-located path) */

--- a/packages/zustand-plugin/.gitignore
+++ b/packages/zustand-plugin/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/zustand-plugin/README.md
+++ b/packages/zustand-plugin/README.md
@@ -1,0 +1,94 @@
+# @smugglr/zustand
+
+Zustand middleware that auto-persists store slices to a smugglr-managed SQLite table and rehydrates from sync events. Keep Zustand. Mark the slice. Smugglr handles persistence and sync.
+
+## Install
+
+```sh
+pnpm add @smugglr/zustand smugglr zustand
+```
+
+## Usage
+
+```ts
+import { create } from "zustand";
+import { Smugglr, createWaSqliteExecutor } from "smugglr";
+import { smuggl } from "@smugglr/zustand";
+
+// 1. Set up your local SQLite + smugglr instance.
+const executor = createWaSqliteExecutor(sqlite3, db);
+await executor.run(
+  `CREATE TABLE IF NOT EXISTS app_state (
+     key TEXT PRIMARY KEY,
+     value TEXT NOT NULL,
+     updated_at TEXT
+   )`,
+  [],
+);
+
+const smugglrInstance = await Smugglr.init({
+  source: { type: "local", executor },
+  dest: { url: "https://my-app.turso.io", authToken: "...", profile: "turso" },
+  sync: { tables: ["app_state"], conflictResolution: "newer_wins" },
+});
+
+// 2. Wire the middleware into your store.
+interface AppState {
+  todos: string[];
+  addTodo: (todo: string) => void;
+}
+
+const useStore = create<AppState>()(
+  smuggl(
+    (set) => ({
+      todos: [],
+      addTodo: (t) => set((s) => ({ todos: [...s.todos, t] })),
+    }),
+    {
+      smugglr: smugglrInstance,
+      executor,
+      table: "app_state",
+      key: "todos",
+      include: (s) => ({ todos: s.todos }),
+    },
+  ),
+);
+```
+
+That's it. Three things happen automatically:
+
+- **On mount**, the middleware reads the `todos` row from `app_state` and seeds the store.
+- **On every `set()`**, it serializes the projection (`include(state)`) and upserts the row.
+- **On every `smugglr.sync()` that touches this row**, it reads the new value and merges it back into the store via `set()` -- so other browser tabs, other devices, or a server-side update show up live without a page reload.
+
+## Options
+
+| Option        | Required | Description |
+| ------------- | -------- | ----------- |
+| `smugglr`     | yes      | Smugglr instance. Used for `.on("table-changed", ...)`. |
+| `executor`    | yes      | `SqlExecutor` -- the same one wrapping your local SQLite. Used for direct upserts and reads of the persistence row. |
+| `table`       | yes      | Persistence table name. Caller owns the DDL. |
+| `key`         | yes      | Primary key for this store's row. Use distinct keys when multiple stores share one table. |
+| `include`     | no       | `(state) => projection`. Skip ephemeral fields from the persisted slice. Defaults to identity. |
+| `serialize`   | no       | Custom serializer. Defaults to `JSON.stringify`. |
+| `deserialize` | no       | Custom deserializer. Defaults to `JSON.parse`. |
+| `onHydrate`   | no       | Callback fired once after the initial hydration query completes. |
+
+## Why this exists
+
+RxDB, ElectricSQL, and PowerSync all force you to abandon your state library and adopt theirs. Smugglr's pitch: keep the store you already have. The middleware is ~150 lines because the heavy lifting -- delta sync, conflict resolution, content hashing -- already lives in smugglr.
+
+## Multiple stores, one table
+
+Multiple stores can share the same persistence table by using distinct `key` values:
+
+```ts
+const useTodos = create()(smuggl(initTodos, { ..., table: "app_state", key: "todos" }));
+const useAuth = create()(smuggl(initAuth, { ..., table: "app_state", key: "auth" }));
+```
+
+Each store reads and writes only its own row. Smugglr's `table-changed` events scope by primary key, so a sync that touches `todos` does not re-hydrate `auth`.
+
+## License
+
+MIT

--- a/packages/zustand-plugin/package.json
+++ b/packages/zustand-plugin/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@smugglr/zustand",
+  "version": "0.1.0",
+  "description": "Zustand middleware that auto-persists store slices to a smugglr-managed SQLite table.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "homepage": "https://smugglr.dev",
+  "bugs": {
+    "url": "https://github.com/rafters-studio/smugglr/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rafters-studio/smugglr"
+  },
+  "author": "Sean Silvius",
+  "peerDependencies": {
+    "smugglr": "^0.3.3",
+    "zustand": "^4.0.0 || ^5.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "smugglr": "link:../smugglr",
+    "typescript": "^6.0.2",
+    "vitest": "^3.0.0",
+    "zustand": "^5.0.12"
+  }
+}

--- a/packages/zustand-plugin/pnpm-lock.yaml
+++ b/packages/zustand-plugin/pnpm-lock.yaml
@@ -1,0 +1,1050 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.2
+      smugglr:
+        specifier: link:../smugglr
+        version: link:../smugglr
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@24.12.2)
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.12.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@24.12.2)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  js-tokens@9.0.1: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  typescript@6.0.3: {}
+
+  undici-types@7.16.0: {}
+
+  vite-node@3.2.4(@types/node@24.12.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@24.12.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2(@types/node@24.12.2):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@24.12.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.12.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@24.12.2)
+      vite-node: 3.2.4(@types/node@24.12.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zustand@5.0.12: {}

--- a/packages/zustand-plugin/src/index.test.ts
+++ b/packages/zustand-plugin/src/index.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createStore } from "zustand/vanilla";
+import type { SqlExecutor, TableChangedEvent } from "smugglr";
+
+import { smuggl } from "./index.js";
+
+interface Row {
+  key: string;
+  value: string;
+  updated_at: string;
+}
+
+/** In-memory fixture executor that mimics the persistence table. */
+function fixtureExecutor(initial: Row[] = []) {
+  const rows = new Map<string, Row>();
+  for (const r of initial) rows.set(r.key, r);
+
+  const executor: SqlExecutor = {
+    async run(sql, params) {
+      const lower = sql.trim().toLowerCase();
+      if (lower.startsWith("select value")) {
+        const r = rows.get(String(params[0]));
+        return { columns: ["value"], rows: r ? [[r.value]] : [] };
+      }
+      if (lower.startsWith("insert")) {
+        const [key, value, updated_at] = params as string[];
+        rows.set(key, { key, value, updated_at });
+        return { columns: [], rows: [] };
+      }
+      throw new Error(`fixture executor: unknown SQL: ${sql}`);
+    },
+  };
+  return { executor, rows };
+}
+
+/** Minimal Smugglr stub: just the .on() surface the middleware uses. */
+function fixtureSmugglr() {
+  const handlers: Array<(e: TableChangedEvent) => void> = [];
+  return {
+    on(_event: "table-changed", handler: (e: TableChangedEvent) => void) {
+      handlers.push(handler);
+      return () => {
+        const idx = handlers.indexOf(handler);
+        if (idx >= 0) handlers.splice(idx, 1);
+      };
+    },
+    fire(event: TableChangedEvent) {
+      for (const h of handlers) h(event);
+    },
+  };
+}
+
+const flushMicrotasks = () => new Promise((r) => setTimeout(r, 0));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("@smugglr/zustand", () => {
+  it("hydrates from existing row on store creation", async () => {
+    const { executor } = fixtureExecutor([
+      { key: "todos", value: JSON.stringify({ items: ["alpha", "beta"] }), updated_at: "x" },
+    ]);
+    const smugglr = fixtureSmugglr();
+
+    interface State {
+      items: string[];
+      add: (s: string) => void;
+    }
+    const useStore = createStore<State>()(
+      smuggl(
+        (set) => ({
+          items: [],
+          add: (s) => set((prev) => ({ items: [...prev.items, s] })),
+        }),
+        { smugglr, executor, table: "app_state", key: "todos" },
+      ),
+    );
+
+    await flushMicrotasks();
+    expect(useStore.getState().items).toEqual(["alpha", "beta"]);
+  });
+
+  it("persists on every set()", async () => {
+    const { executor, rows } = fixtureExecutor();
+    const smugglr = fixtureSmugglr();
+
+    interface State {
+      n: number;
+      inc: () => void;
+    }
+    const useStore = createStore<State>()(
+      smuggl(
+        (set) => ({
+          n: 0,
+          inc: () => set((prev) => ({ n: prev.n + 1 })),
+        }),
+        {
+          smugglr,
+          executor,
+          table: "app_state",
+          key: "counter",
+          include: (s) => ({ n: s.n }),
+        },
+      ),
+    );
+
+    await flushMicrotasks();
+    useStore.getState().inc();
+    useStore.getState().inc();
+    await flushMicrotasks();
+
+    const stored = rows.get("counter");
+    expect(stored).toBeDefined();
+    expect(JSON.parse(stored!.value)).toEqual({ n: 2 });
+  });
+
+  it("re-hydrates when smugglr reports table-changed for the same key", async () => {
+    const { executor, rows } = fixtureExecutor([
+      { key: "todos", value: JSON.stringify({ items: [] }), updated_at: "t0" },
+    ]);
+    const smugglr = fixtureSmugglr();
+
+    interface State {
+      items: string[];
+    }
+    const useStore = createStore<State>()(
+      smuggl(
+        () => ({ items: [] }),
+        { smugglr, executor, table: "app_state", key: "todos" },
+      ),
+    );
+
+    await flushMicrotasks();
+    expect(useStore.getState().items).toEqual([]);
+
+    // Simulate a sync that pulled new content for this row.
+    rows.set("todos", {
+      key: "todos",
+      value: JSON.stringify({ items: ["from-remote"] }),
+      updated_at: "t1",
+    });
+    smugglr.fire({
+      table: "app_state",
+      changedPks: ["todos"],
+      removedPks: [],
+      source: "pull",
+    });
+
+    await flushMicrotasks();
+    expect(useStore.getState().items).toEqual(["from-remote"]);
+  });
+
+  it("ignores table-changed events for other tables or keys", async () => {
+    const { executor } = fixtureExecutor([
+      { key: "todos", value: JSON.stringify({ items: [] }), updated_at: "t0" },
+    ]);
+    const smugglr = fixtureSmugglr();
+    const onHydrate = vi.fn();
+
+    createStore(
+      smuggl(
+        () => ({ items: [] }),
+        { smugglr, executor, table: "app_state", key: "todos", onHydrate },
+      ),
+    );
+
+    await flushMicrotasks();
+    expect(onHydrate).toHaveBeenCalledTimes(1);
+
+    // Wrong table.
+    smugglr.fire({ table: "other", changedPks: ["todos"], removedPks: [], source: "pull" });
+    // Right table, wrong key.
+    smugglr.fire({ table: "app_state", changedPks: ["other"], removedPks: [], source: "pull" });
+
+    await flushMicrotasks();
+    expect(onHydrate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/zustand-plugin/src/index.ts
+++ b/packages/zustand-plugin/src/index.ts
@@ -1,0 +1,148 @@
+// @smugglr/zustand -- Zustand middleware that auto-persists store slices to a
+// smugglr-managed SQLite table and rehydrates from sync events.
+//
+// Storage shape (one row per slice, multiple slices share one table):
+//   CREATE TABLE <table> (
+//     key TEXT PRIMARY KEY,
+//     value TEXT NOT NULL,
+//     updated_at TEXT
+//   );
+
+import type { Smugglr, SqlExecutor, TableChangedEvent } from "smugglr";
+import type { StateCreator, StoreMutatorIdentifier } from "zustand";
+
+export interface SmugglOptions<T, U = T> {
+  /** Smugglr instance used for change-event subscription. */
+  smugglr: Pick<Smugglr, "on">;
+  /** Local SQL executor used for direct read/write of the persistence row. */
+  executor: SqlExecutor;
+  /**
+   * Table that stores the persisted slice. Caller owns the DDL:
+   * `CREATE TABLE <table> (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT)`.
+   */
+  table: string;
+  /** Primary key for this store's row. Use distinct keys when multiple stores share the same table. */
+  key: string;
+  /**
+   * Optional projector. The middleware persists `include(state)` instead of the
+   * full state. Defaults to identity. Use this to skip ephemeral fields
+   * (e.g. transient UI state) from the persisted slice.
+   */
+  include?: (state: T) => U;
+  /** Custom JSON serializer. Defaults to `JSON.stringify`. */
+  serialize?: (value: U) => string;
+  /** Custom JSON parser. Defaults to `JSON.parse`. */
+  deserialize?: (raw: string) => U;
+  /** Called once after the initial hydration query completes. */
+  onHydrate?: (hydrated: U | null) => void;
+}
+
+type Mutators = [StoreMutatorIdentifier, unknown][];
+
+export type Smuggl = <
+  T,
+  Mps extends Mutators = [],
+  Mcs extends Mutators = [],
+  U = T,
+>(
+  initializer: StateCreator<T, Mps, Mcs>,
+  options: SmugglOptions<T, U>,
+) => StateCreator<T, Mps, Mcs>;
+
+const HYDRATE_SQL = (table: string) =>
+  `SELECT value FROM "${table}" WHERE key = ? LIMIT 1`;
+
+const UPSERT_SQL = (table: string) =>
+  `INSERT INTO "${table}" (key, value, updated_at) VALUES (?, ?, ?)
+   ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`;
+
+/**
+ * Zustand middleware that persists a store slice to a smugglr-managed table
+ * and rehydrates whenever a sync event touches the same row.
+ *
+ * @example
+ * ```ts
+ * const useStore = create<AppState>()(
+ *   smuggl(
+ *     (set) => ({
+ *       todos: [],
+ *       addTodo: (t) => set((s) => ({ todos: [...s.todos, t] })),
+ *     }),
+ *     {
+ *       smugglr,
+ *       executor,
+ *       table: "app_state",
+ *       key: "todos",
+ *       include: (s) => ({ todos: s.todos }),
+ *     },
+ *   ),
+ * );
+ * ```
+ */
+export const smuggl: Smuggl = (initializer, options) => (set, get, api) => {
+  const include = options.include ?? ((s: unknown) => s as never);
+  const serialize = options.serialize ?? JSON.stringify;
+  const deserialize = options.deserialize ?? JSON.parse;
+  const upsertSql = UPSERT_SQL(options.table);
+  const hydrateSql = HYDRATE_SQL(options.table);
+
+  let suppressNextWrite = false;
+  let lastSerialized: string | null = null;
+
+  // Build the underlying store first; subscribe + hydrate after.
+  const state = initializer(set, get, api);
+
+  const persist = async (raw: unknown) => {
+    const slice = include(raw as never);
+    const next = serialize(slice);
+    if (next === lastSerialized) return;
+    lastSerialized = next;
+    try {
+      await options.executor.run(upsertSql, [options.key, next, new Date().toISOString()]);
+    } catch (err) {
+      console.warn("[@smugglr/zustand] persist failed:", err);
+    }
+  };
+
+  const hydrate = async () => {
+    try {
+      const result = await options.executor.run(hydrateSql, [options.key]);
+      if (result.rows.length === 0) {
+        options.onHydrate?.(null);
+        return;
+      }
+      const raw = result.rows[0][0];
+      if (typeof raw !== "string") {
+        options.onHydrate?.(null);
+        return;
+      }
+      const parsed = deserialize(raw);
+      lastSerialized = raw;
+      suppressNextWrite = true;
+      // Merge the hydrated slice into the live store.
+      set(parsed as never, false);
+      options.onHydrate?.(parsed);
+    } catch (err) {
+      console.warn("[@smugglr/zustand] hydrate failed:", err);
+      options.onHydrate?.(null);
+    }
+  };
+
+  api.subscribe((next) => {
+    if (suppressNextWrite) {
+      suppressNextWrite = false;
+      return;
+    }
+    void persist(next);
+  });
+
+  options.smugglr.on("table-changed", (event: TableChangedEvent) => {
+    if (event.table !== options.table) return;
+    if (!event.changedPks.includes(options.key)) return;
+    void hydrate();
+  });
+
+  void hydrate();
+
+  return state;
+};

--- a/packages/zustand-plugin/tsconfig.json
+++ b/packages/zustand-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
> **Stacks on #121** (post-sync table-changed events). Re-target this PR to \`main\` once #121 lands.

A Zustand middleware that auto-persists store slices to a smugglr-managed SQLite table and rehydrates from sync events. The adoption wedge against RxDB / ElectricSQL / PowerSync, which all force you to abandon your state library and adopt theirs.

## API
\`\`\`ts
import { create } from "zustand";
import { smuggl } from "@smugglr/zustand";

const useStore = create<AppState>()(
  smuggl(
    (set) => ({
      todos: [],
      addTodo: (t) => set((s) => ({ todos: [...s.todos, t] })),
    }),
    {
      smugglr: smugglrInstance,
      executor: sqlExecutor,
      table: "app_state",
      key: "todos",
      include: (s) => ({ todos: s.todos }),
    },
  ),
);
\`\`\`

## Behavior
- **On store creation** -- SELECT the row, parse, seed via \`set()\`
- **On every \`set()\`** -- serialize \`include(state)\`, upsert (skipped when value matches the last-persisted serialization)
- **On smugglr table-changed event matching this table+key** -- re-read row, parse, \`set()\` (other tabs / devices land live)

The middleware suppresses the persist-on-set side effect during hydration so we don't immediately re-write what we just read.

## Multi-store support
Multiple stores can share one persistence table via distinct \`key\` values. Each only re-hydrates when its own key appears in \`event.changedPks\`.

## Acceptance criteria (#115)
- [x] \`@smugglr/zustand\` package in \`packages/zustand-plugin/\`
- [x] \`smuggl()\` middleware compatible with Zustand v4 + v5 (peer dep range \`^4.0.0 || ^5.0.0\`)
- [x] Hydrate on store creation
- [x] Persist on every \`set()\`
- [x] React to smugglr table-changed events
- [x] TypeScript types for include/exclude selectors (\`include\` projector)
- [x] README with canonical example
- [x] Test against fixture executor (4/4 vitest cases passing)

## Test plan
- [x] \`pnpm test\` -- 4/4 passing (hydrate / persist / re-hydrate / event filter)
- [x] \`pnpm build\` -- clean tsc with strict mode

## Unblocks
- #116 (@smugglr/nanostores -- same shape, different store library)

Closes #115.