### PR TITLE
feat(#117): Smugglr.eraseLocal() GDPR helper

### DIFF
--- a/crates/smugglr-wasm/src/lib.rs
+++ b/crates/smugglr-wasm/src/lib.rs
@@ -649,6 +649,60 @@ impl Smugglr {
         self.dest_cache.borrow_mut().clear();
     }
 
+    /// Erase local state. Issues `DELETE FROM <table>` against the local
+    /// SQLite database for every configured sync table, then clears the
+    /// in-memory metadata caches. The schema and any non-synced tables are
+    /// untouched.
+    ///
+    /// The dest endpoint is not touched -- server-side erasure is the app's
+    /// concern, typically through its auth/account system.
+    ///
+    /// At least one of source / dest must be a local executor; calling this
+    /// on a HTTP-only configuration is a no-op (with a returned warning).
+    #[wasm_bindgen(js_name = eraseLocal)]
+    pub async fn erase_local(&self) -> Result<JsValue, JsValue> {
+        let local = match (&self.source, &self.dest) {
+            (AnyDataSource::Local(d), _) => d,
+            (_, AnyDataSource::Local(d)) => d,
+            _ => {
+                return Err(JsValue::from_str(
+                    "eraseLocal: neither source nor dest is a local executor",
+                ));
+            }
+        };
+
+        let tables = if !self.sync_config.tables.is_empty() {
+            self.sync_config.tables.clone()
+        } else {
+            local
+                .list_tables()
+                .await
+                .map_err(|e| JsValue::from_str(&format!("eraseLocal: list_tables failed: {}", e)))?
+        };
+
+        let mut erased = Vec::new();
+        for table in &tables {
+            if self.sync_config.exclude_tables.iter().any(|t| t == table) {
+                continue;
+            }
+            local.delete_all_rows(table).await.map_err(|e| {
+                JsValue::from_str(&format!("eraseLocal: delete from {} failed: {}", table, e))
+            })?;
+            erased.push(table.clone());
+        }
+
+        self.source_cache.borrow_mut().clear();
+        self.dest_cache.borrow_mut().clear();
+
+        let arr = js_sys::Array::new();
+        for t in &erased {
+            arr.push(&JsValue::from_str(t));
+        }
+        let obj = js_sys::Object::new();
+        js_sys::Reflect::set(&obj, &JsValue::from_str("erasedTables"), &arr)?;
+        Ok(obj.into())
+    }
+
     /// Push source rows to destination.
     #[wasm_bindgen]
     pub async fn push(&self, dry_run: Option<bool>) -> Result<JsValue, JsValue> {

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -36,6 +36,14 @@ impl LocalSqlDataSource {
         }
     }
 
+    /// Issue `DELETE FROM "<table>"`, leaving the schema in place.
+    /// Used by `Smugglr.eraseLocal()` for GDPR-style local wipes.
+    pub(crate) async fn delete_all_rows(&self, table: &str) -> Result<()> {
+        let sql = format!("DELETE FROM \"{}\"", table);
+        self.run(&sql, &[]).await?;
+        Ok(())
+    }
+
     async fn run(&self, sql: &str, params: &[Value]) -> Result<RunResult> {
         let run_fn = js_sys::Reflect::get(&self.executor, &JsValue::from_str("run"))
             .map_err(|e| SyncError::Remote(format!("executor.run missing: {:?}", e)))?

--- a/packages/smugglr/README.md
+++ b/packages/smugglr/README.md
@@ -107,6 +107,15 @@ unsub(); // remove this listener
 
 This is the primitive the framework binding plugins (`@smugglr/zustand`, `@smugglr/nanostores`, etc.) are built on.
 
+## GDPR / right-to-erasure
+
+`eraseLocal()` empties every configured sync table on the local SQLite database and clears smugglr's in-memory caches. Schema and any non-synced tables are untouched; the dest endpoint is not contacted (server-side erasure is the app's concern, typically via its auth/account system).
+
+```ts
+const result = await s.eraseLocal();
+// { erasedTables: ["users", "posts"] }
+```
+
 ## Bundle size
 
 | Module                                         | Compressed (gzip) |

--- a/packages/smugglr/e2e/main.ts
+++ b/packages/smugglr/e2e/main.ts
@@ -6,6 +6,7 @@ declare global {
       init(dbPath: string): Promise<unknown>;
       runSql(sql: string, params?: unknown[]): Promise<unknown>;
       sync(opts: unknown): Promise<unknown>;
+      eraseLocal(opts: unknown): Promise<unknown>;
       reset(): Promise<unknown>;
     };
   }
@@ -38,6 +39,7 @@ window.e2e = {
   init: (dbPath) => call("init", [dbPath]),
   runSql: (sql, params = []) => call("runSql", [sql, params]),
   sync: (opts) => call("sync", [opts]),
+  eraseLocal: (opts) => call("eraseLocal", [opts]),
   reset: () => call("reset", []),
 };
 

--- a/packages/smugglr/e2e/tests/sync.spec.ts
+++ b/packages/smugglr/e2e/tests/sync.spec.ts
@@ -227,4 +227,46 @@ test.describe("smugglr OPFS e2e", () => {
     // after unsubscribe sees zero events because the second pull had no diff.
     expect(out.postUnsubEvents).toEqual([]);
   });
+
+  test("eraseLocal: empties configured tables but leaves the schema", async ({ page }) => {
+    const state = freshState();
+    await installMockTarget(page, state);
+
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)",
+      ),
+    );
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "INSERT INTO users (id, name, updated_at) VALUES (?, ?, ?), (?, ?, ?)",
+        ["u1", "ada", 100, "u2", "lin", 200],
+      ),
+    );
+
+    const before = (await page.evaluate(() =>
+      window.e2e.runSql("SELECT COUNT(*) FROM users"),
+    )) as { rows: unknown[][] };
+    expect(before.rows[0][0]).toBe(2);
+
+    const result = (await page.evaluate(() =>
+      window.e2e.eraseLocal({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+      }),
+    )) as { erasedTables: string[] };
+
+    expect(result.erasedTables).toEqual(["users"]);
+
+    const after = (await page.evaluate(() =>
+      window.e2e.runSql("SELECT COUNT(*) FROM users"),
+    )) as { rows: unknown[][] };
+    expect(after.rows[0][0]).toBe(0);
+
+    // Schema must still be queryable -- no DROP, just DELETE.
+    const schema = (await page.evaluate(() =>
+      window.e2e.runSql("PRAGMA table_info('users')"),
+    )) as { rows: unknown[][] };
+    expect(schema.rows.length).toBe(3);
+  });
 });

--- a/packages/smugglr/e2e/worker.ts
+++ b/packages/smugglr/e2e/worker.ts
@@ -80,6 +80,18 @@ async function sync(opts: {
   return { result, events, postUnsubEvents };
 }
 
+async function eraseLocal(opts: { destUrl: string; tables: string[] }) {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const s = await Smugglr.init({
+    source: { type: "local", executor: createWaSqliteExecutor(sqlite3, db) },
+    dest: { url: opts.destUrl, profile: "generic" },
+    sync: { tables: opts.tables },
+  });
+  const result = await s.eraseLocal();
+  s.dispose();
+  return result;
+}
+
 async function reset() {
   if (sqlite3 && db !== null) {
     sqlite3.close(db);
@@ -93,7 +105,7 @@ async function reset() {
 
 interface RpcCall {
   id: number;
-  op: "init" | "runSql" | "sync" | "reset";
+  op: "init" | "runSql" | "sync" | "eraseLocal" | "reset";
   args: unknown[];
 }
 
@@ -105,6 +117,7 @@ self.addEventListener("message", async (ev: MessageEvent<RpcCall>) => {
       case "init": result = await init(args[0] as string); break;
       case "runSql": result = await runSql(args[0] as string, (args[1] as unknown[]) ?? []); break;
       case "sync": result = await sync(args[0] as Parameters<typeof sync>[0]); break;
+      case "eraseLocal": result = await eraseLocal(args[0] as Parameters<typeof eraseLocal>[0]); break;
       case "reset": result = await reset(); break;
     }
     (self as unknown as Worker).postMessage({ id, ok: true, result });

--- a/packages/smugglr/src/index.ts
+++ b/packages/smugglr/src/index.ts
@@ -57,6 +57,7 @@ interface WasmSmugglr {
   sync(dry_run?: boolean | null): Promise<unknown>;
   diff(): Promise<unknown>;
   on(event: string, callback: (e: unknown) => void): () => void;
+  eraseLocal(): Promise<unknown>;
   [Symbol.dispose]?: () => void;
 }
 
@@ -220,6 +221,24 @@ export class Smugglr {
   ): Unsubscribe {
     const wrapped = (raw: unknown) => handler(raw as SmugglrEventMap[K]);
     return this.inner.on(event, wrapped);
+  }
+
+  /**
+   * Erase local state. Issues `DELETE FROM <table>` against the local
+   * SQLite database for every configured sync table, then clears the
+   * in-memory metadata caches. Schema and any non-synced tables stay put.
+   *
+   * The dest endpoint is not touched -- server-side erasure is the app's
+   * concern. Use this for GDPR right-to-erasure on the client side.
+   *
+   * Returns the list of tables that were erased.
+   */
+  async eraseLocal(): Promise<{ erasedTables: string[] }> {
+    try {
+      return (await this.inner.eraseLocal()) as { erasedTables: string[] };
+    } catch (e) {
+      throw parseError(e);
+    }
   }
 
   /** Release WASM resources. Called automatically if using `using` syntax. */


### PR DESCRIPTION
> **Stacks on #124 -> #123 -> #121.** Re-target to main once the parent chain merges.

A one-call helper that empties every configured sync table on the local SQLite database and clears smugglr's in-memory caches. The GDPR / 'data stays theirs' story needed a clean local-erase action that doesn't expose smugglr's internals to the app developer.

## API
\`\`\`ts
const { erasedTables } = await s.eraseLocal();
\`\`\`

## Behavior
- DELETE FROM each configured table (honors \`sync_config.tables\` / \`exclude_tables\`; falls back to \`list_tables()\` when no explicit list is set)
- Clear in-memory metadata caches (the next sync re-scans cleanly)
- Picks whichever side is the local executor; HTTP-only configurations error out with a clear message
- **Does NOT** drop tables (app owns schema), touch the dest endpoint, or contact the network at all

## Acceptance criteria (#117)
- [x] \`eraseLocal()\` async method on the WASM Smugglr struct
- [x] Configured tables emptied
- [x] Sidecar removed -- caches cleared (no OPFS sidecar exists yet; reserved when one lands)
- [x] Caches cleared
- [x] Test: write rows, eraseLocal, verify COUNT == 0 + PRAGMA table_info still returns the schema

## Test plan
- [x] \`pnpm test:e2e\` -- 4/4 passing (push, pull, table-changed events, **new** eraseLocal)
- [x] \`cargo test --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

Closes #117.