### PR TITLE
feat(#112): updateAuth + updateDest for runtime endpoint changes

### DIFF
--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -16,7 +16,9 @@ use web_sys::{Request, RequestInit, RequestMode, Response};
 
 pub struct FetchDataSource {
     url: String,
-    auth_token: String,
+    // Interior-mutable so `Smugglr.updateAuth(...)` can swap the token at
+    // runtime without touching the table_info_cache or the source endpoint.
+    auth_token: std::sync::Mutex<String>,
     profile: Profile,
     table_info_cache: std::sync::Mutex<HashMap<String, TableInfo>>,
 }
@@ -25,10 +27,16 @@ impl FetchDataSource {
     pub fn new(url: String, auth_token: String, profile: Profile) -> Self {
         Self {
             url,
-            auth_token,
+            auth_token: std::sync::Mutex::new(auth_token),
             profile,
             table_info_cache: std::sync::Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Replace the auth token. Subsequent requests use the new value.
+    /// Safe to call mid-flight; no in-flight request is mutated.
+    pub fn set_auth_token(&self, token: String) {
+        *self.auth_token.lock().unwrap() = token;
     }
 
     async fn execute(&self, sql: &str, params: &[Value]) -> Result<Value> {
@@ -49,18 +57,19 @@ impl FetchDataSource {
             .set("Content-Type", "application/json")
             .map_err(|e| SyncError::Remote(format!("failed to set header: {:?}", e)))?;
 
-        if !self.auth_token.is_empty() {
+        let token = self.auth_token.lock().unwrap().clone();
+        if !token.is_empty() {
             match self.profile.auth_format {
                 AuthFormat::Bearer => {
                     headers
-                        .set("Authorization", &format!("Bearer {}", self.auth_token))
+                        .set("Authorization", &format!("Bearer {}", token))
                         .map_err(|e| {
                             SyncError::Remote(format!("failed to set auth header: {:?}", e))
                         })?;
                 }
                 AuthFormat::Basic => {
                     headers
-                        .set("Authorization", &format!("Basic {}", self.auth_token))
+                        .set("Authorization", &format!("Basic {}", token))
                         .map_err(|e| {
                             SyncError::Remote(format!("failed to set auth header: {:?}", e))
                         })?;

--- a/crates/smugglr-wasm/src/lib.rs
+++ b/crates/smugglr-wasm/src/lib.rs
@@ -520,7 +520,11 @@ async fn diff_table_cached(
 pub struct Smugglr {
     sync_config: SyncConfig,
     source: AnyDataSource,
-    dest: AnyDataSource,
+    // Interior-mutable so `updateDest()` can swap the entire endpoint and
+    // `updateAuth()` can reach into the underlying FetchDataSource. The
+    // borrow is held across awaits inside push/pull/sync; do not call
+    // updateAuth/updateDest while a sync future is pending.
+    dest: RefCell<AnyDataSource>,
     /// Per-table metadata cache for the source endpoint.
     source_cache: RefCell<HashMap<String, CachedMeta>>,
     /// Per-table metadata cache for the dest endpoint.
@@ -561,7 +565,7 @@ impl Smugglr {
         Ok(Smugglr {
             sync_config,
             source,
-            dest,
+            dest: RefCell::new(dest),
             source_cache: RefCell::new(HashMap::new()),
             dest_cache: RefCell::new(HashMap::new()),
             listeners: RefCell::new(Vec::new()),
@@ -658,17 +662,19 @@ impl Smugglr {
     /// concern, typically through its auth/account system.
     ///
     /// At least one of source / dest must be a local executor; calling this
-    /// on a HTTP-only configuration is a no-op (with a returned warning).
+    /// on a HTTP-only configuration errors out.
+    #[allow(clippy::await_holding_refcell_ref)]
     #[wasm_bindgen(js_name = eraseLocal)]
     pub async fn erase_local(&self) -> Result<JsValue, JsValue> {
-        let local = match (&self.source, &self.dest) {
-            (AnyDataSource::Local(d), _) => d,
-            (_, AnyDataSource::Local(d)) => d,
-            _ => {
-                return Err(JsValue::from_str(
-                    "eraseLocal: neither source nor dest is a local executor",
-                ));
-            }
+        let dest = self.dest.borrow();
+        let local = if let AnyDataSource::Local(d) = &self.source {
+            d
+        } else if let AnyDataSource::Local(d) = &*dest {
+            d
+        } else {
+            return Err(JsValue::from_str(
+                "eraseLocal: neither source nor dest is a local executor",
+            ));
         };
 
         let tables = if !self.sync_config.tables.is_empty() {
@@ -691,6 +697,7 @@ impl Smugglr {
             erased.push(table.clone());
         }
 
+        drop(dest);
         self.source_cache.borrow_mut().clear();
         self.dest_cache.borrow_mut().clear();
 
@@ -703,11 +710,56 @@ impl Smugglr {
         Ok(obj.into())
     }
 
+    /// Replace the dest auth token. The dest URL, profile, and metadata
+    /// cache are unchanged -- the next request just uses the new token.
+    /// Errors if the dest is not an HTTP endpoint.
+    ///
+    /// **Do not call while a sync future is pending.** Await any in-flight
+    /// push/pull/sync first; the implementation borrows the dest across
+    /// awaits and a concurrent mutation will panic.
+    #[wasm_bindgen(js_name = updateAuth)]
+    pub fn update_auth(&self, auth_token: String) -> Result<(), JsValue> {
+        let dest = self.dest.borrow();
+        match &*dest {
+            AnyDataSource::Fetch(d) => {
+                d.set_auth_token(auth_token);
+                Ok(())
+            }
+            AnyDataSource::Local(_) => Err(JsValue::from_str(
+                "updateAuth: dest is a local executor, not an HTTP endpoint",
+            )),
+        }
+    }
+
+    /// Replace the entire dest endpoint. Accepts the same shape as the
+    /// `dest` field of `Smugglr.init({...})`. Clears the dest metadata
+    /// cache so the next sync re-scans against the new endpoint; the
+    /// source cache is untouched.
+    ///
+    /// Use this for the anonymous -> account-upgrade flow: start with
+    /// an anonymous ingress dest, swap to the account-bound dest after
+    /// the user signs in. Local OPFS data and the source cache survive.
+    ///
+    /// **Do not call while a sync future is pending.** Same caveat as
+    /// `updateAuth` -- await first.
+    #[wasm_bindgen(js_name = updateDest)]
+    pub fn update_dest(&self, dest_js: JsValue) -> Result<(), JsValue> {
+        let new_dest = build_datasource(&dest_js)?;
+        *self.dest.borrow_mut() = new_dest;
+        self.dest_cache.borrow_mut().clear();
+        Ok(())
+    }
+
     /// Push source rows to destination.
+    // RefCell borrow held across await is safe here: WASM is single-threaded
+    // and `updateAuth` / `updateDest` are documented as not safe to call
+    // concurrently with sync futures. See struct docstring on `dest`.
+    #[allow(clippy::await_holding_refcell_ref)]
     #[wasm_bindgen]
     pub async fn push(&self, dry_run: Option<bool>) -> Result<JsValue, JsValue> {
+        let dest = self.dest.borrow();
         let dry_run = dry_run.unwrap_or(false);
-        let tables = get_sync_tables(&self.source, &self.dest, &self.sync_config).await?;
+        let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
         let conflict = self.sync_config.conflict_resolution;
         let batch_size = self.sync_config.batch_size;
 
@@ -715,7 +767,7 @@ impl Smugglr {
         for table in &tables {
             let diff = diff_table_cached(
                 &self.source,
-                &self.dest,
+                &dest,
                 &self.source_cache,
                 &self.dest_cache,
                 table,
@@ -730,7 +782,7 @@ impl Smugglr {
             } else {
                 transfer_rows(
                     &self.source,
-                    &self.dest,
+                    &dest,
                     table,
                     &to_push,
                     batch_size,
@@ -756,10 +808,12 @@ impl Smugglr {
     }
 
     /// Pull destination rows to source.
+    #[allow(clippy::await_holding_refcell_ref)]
     #[wasm_bindgen]
     pub async fn pull(&self, dry_run: Option<bool>) -> Result<JsValue, JsValue> {
+        let dest = self.dest.borrow();
         let dry_run = dry_run.unwrap_or(false);
-        let tables = get_sync_tables(&self.source, &self.dest, &self.sync_config).await?;
+        let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
         let conflict = self.sync_config.conflict_resolution;
         let batch_size = self.sync_config.batch_size;
 
@@ -767,7 +821,7 @@ impl Smugglr {
         for table in &tables {
             let diff = diff_table_cached(
                 &self.source,
-                &self.dest,
+                &dest,
                 &self.source_cache,
                 &self.dest_cache,
                 table,
@@ -781,7 +835,7 @@ impl Smugglr {
                 to_pull.len()
             } else {
                 let n = transfer_rows(
-                    &self.dest,
+                    &dest,
                     &self.source,
                     table,
                     &to_pull,
@@ -812,10 +866,12 @@ impl Smugglr {
     }
 
     /// Bidirectional sync.
+    #[allow(clippy::await_holding_refcell_ref)]
     #[wasm_bindgen]
     pub async fn sync(&self, dry_run: Option<bool>) -> Result<JsValue, JsValue> {
+        let dest = self.dest.borrow();
         let dry_run = dry_run.unwrap_or(false);
-        let tables = get_sync_tables(&self.source, &self.dest, &self.sync_config).await?;
+        let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
         let conflict = self.sync_config.conflict_resolution;
         let batch_size = self.sync_config.batch_size;
 
@@ -823,7 +879,7 @@ impl Smugglr {
         for table in &tables {
             let diff = diff_table_cached(
                 &self.source,
-                &self.dest,
+                &dest,
                 &self.source_cache,
                 &self.dest_cache,
                 table,
@@ -840,7 +896,7 @@ impl Smugglr {
             } else {
                 transfer_rows(
                     &self.source,
-                    &self.dest,
+                    &dest,
                     table,
                     &to_push,
                     batch_size,
@@ -853,7 +909,7 @@ impl Smugglr {
                 to_pull.len()
             } else {
                 let n = transfer_rows(
-                    &self.dest,
+                    &dest,
                     &self.source,
                     table,
                     &to_pull,
@@ -884,15 +940,17 @@ impl Smugglr {
     }
 
     /// Read-only diff between source and destination.
+    #[allow(clippy::await_holding_refcell_ref)]
     #[wasm_bindgen]
     pub async fn diff(&self) -> Result<JsValue, JsValue> {
-        let tables = get_sync_tables(&self.source, &self.dest, &self.sync_config).await?;
+        let dest = self.dest.borrow();
+        let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
 
         let mut table_diffs = Vec::new();
         for table in &tables {
             let diff = diff_table_cached(
                 &self.source,
-                &self.dest,
+                &dest,
                 &self.source_cache,
                 &self.dest_cache,
                 table,

--- a/packages/smugglr/README.md
+++ b/packages/smugglr/README.md
@@ -116,6 +116,26 @@ const result = await s.eraseLocal();
 // { erasedTables: ["users", "posts"] }
 ```
 
+## Auth rotation and dest swapping
+
+`updateAuth(token)` rotates the dest auth token without re-initializing the WASM module or losing the metadata cache. `updateDest(dest)` replaces the entire dest endpoint -- URL, profile, token -- and clears only the dest cache (source cache survives).
+
+```ts
+// Token rotation
+s.updateAuth(newToken);
+await s.sync(); // uses newToken
+
+// Anonymous -> account upgrade
+s.updateDest({
+  url: "https://api.acme.com/sync",
+  authToken: accountToken,
+  profile: "generic",
+});
+await s.sync(); // first sync against the new dest re-scans then pushes
+```
+
+> **Do not call while a sync future is pending.** Await any in-flight push/pull/sync first; the implementation borrows the dest across awaits and a concurrent mutation will panic.
+
 ## Bundle size
 
 | Module                                         | Compressed (gzip) |

--- a/packages/smugglr/e2e/main.ts
+++ b/packages/smugglr/e2e/main.ts
@@ -7,6 +7,7 @@ declare global {
       runSql(sql: string, params?: unknown[]): Promise<unknown>;
       sync(opts: unknown): Promise<unknown>;
       eraseLocal(opts: unknown): Promise<unknown>;
+      syncWithAuthSwap(opts: unknown): Promise<unknown>;
       reset(): Promise<unknown>;
     };
   }
@@ -40,6 +41,7 @@ window.e2e = {
   runSql: (sql, params = []) => call("runSql", [sql, params]),
   sync: (opts) => call("sync", [opts]),
   eraseLocal: (opts) => call("eraseLocal", [opts]),
+  syncWithAuthSwap: (opts) => call("syncWithAuthSwap", [opts]),
   reset: () => call("reset", []),
 };
 

--- a/packages/smugglr/e2e/tests/sync.spec.ts
+++ b/packages/smugglr/e2e/tests/sync.spec.ts
@@ -15,7 +15,7 @@ interface RemoteRow {
 interface MockState {
   tableExists: boolean;
   rows: Map<string, RemoteRow>;
-  requests: Array<{ sql: string; params: unknown[] }>;
+  requests: Array<{ sql: string; params: unknown[]; auth: string | null }>;
 }
 
 function freshState(): MockState {
@@ -42,7 +42,8 @@ function installMockTarget(page: Page, state: MockState, host = "https://mock.sm
     };
     const sql = body.sql.trim();
     const params = body.params ?? [];
-    state.requests.push({ sql, params });
+    const auth = route.request().headerValue("authorization");
+    state.requests.push({ sql, params, auth: await auth });
 
     const lower = sql.toLowerCase();
 
@@ -268,5 +269,44 @@ test.describe("smugglr OPFS e2e", () => {
       window.e2e.runSql("PRAGMA table_info('users')"),
     )) as { rows: unknown[][] };
     expect(schema.rows.length).toBe(3);
+  });
+
+  test("updateAuth: token swap is reflected in subsequent request headers", async ({ page }) => {
+    const state = freshState();
+    await installMockTarget(page, state);
+
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)",
+      ),
+    );
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "INSERT INTO users (id, name, updated_at) VALUES (?, ?, ?)",
+        ["u1", "ada", 100],
+      ),
+    );
+
+    await page.evaluate(() =>
+      window.e2e.syncWithAuthSwap({
+        destUrl: "https://mock.smugglr.test",
+        initialToken: "anonymous-token",
+        newToken: "account-token",
+        tables: ["users"],
+      }),
+    );
+
+    // Group requests by which token they carried.
+    const withInitial = state.requests.filter((r) => r.auth === "Bearer anonymous-token");
+    const withNew = state.requests.filter((r) => r.auth === "Bearer account-token");
+
+    expect(withInitial.length).toBeGreaterThan(0);
+    expect(withNew.length).toBeGreaterThan(0);
+
+    // Verify temporal ordering: every request with the new token came after
+    // every request with the initial one.
+    const lastInitialIdx = state.requests.findLastIndex((r) => r.auth === "Bearer anonymous-token");
+    const firstNewIdx = state.requests.findIndex((r) => r.auth === "Bearer account-token");
+    expect(firstNewIdx).toBeGreaterThan(lastInitialIdx);
   });
 });

--- a/packages/smugglr/e2e/worker.ts
+++ b/packages/smugglr/e2e/worker.ts
@@ -92,6 +92,27 @@ async function eraseLocal(opts: { destUrl: string; tables: string[] }) {
   return result;
 }
 
+async function syncWithAuthSwap(opts: {
+  destUrl: string;
+  initialToken: string;
+  newToken: string;
+  tables: string[];
+}) {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const s = await Smugglr.init({
+    source: { type: "local", executor: createWaSqliteExecutor(sqlite3, db) },
+    dest: { url: opts.destUrl, authToken: opts.initialToken, profile: "generic" },
+    sync: { tables: opts.tables },
+  });
+
+  const r1 = await s.push();
+  s.updateAuth(opts.newToken);
+  const r2 = await s.push();
+
+  s.dispose();
+  return { firstPush: r1, secondPush: r2 };
+}
+
 async function reset() {
   if (sqlite3 && db !== null) {
     sqlite3.close(db);
@@ -105,7 +126,7 @@ async function reset() {
 
 interface RpcCall {
   id: number;
-  op: "init" | "runSql" | "sync" | "eraseLocal" | "reset";
+  op: "init" | "runSql" | "sync" | "eraseLocal" | "syncWithAuthSwap" | "reset";
   args: unknown[];
 }
 
@@ -118,6 +139,7 @@ self.addEventListener("message", async (ev: MessageEvent<RpcCall>) => {
       case "runSql": result = await runSql(args[0] as string, (args[1] as unknown[]) ?? []); break;
       case "sync": result = await sync(args[0] as Parameters<typeof sync>[0]); break;
       case "eraseLocal": result = await eraseLocal(args[0] as Parameters<typeof eraseLocal>[0]); break;
+      case "syncWithAuthSwap": result = await syncWithAuthSwap(args[0] as Parameters<typeof syncWithAuthSwap>[0]); break;
       case "reset": result = await reset(); break;
     }
     (self as unknown as Worker).postMessage({ id, ok: true, result });

--- a/packages/smugglr/src/index.ts
+++ b/packages/smugglr/src/index.ts
@@ -58,6 +58,8 @@ interface WasmSmugglr {
   diff(): Promise<unknown>;
   on(event: string, callback: (e: unknown) => void): () => void;
   eraseLocal(): Promise<unknown>;
+  updateAuth(authToken: string): void;
+  updateDest(dest: unknown): void;
   [Symbol.dispose]?: () => void;
 }
 
@@ -236,6 +238,43 @@ export class Smugglr {
   async eraseLocal(): Promise<{ erasedTables: string[] }> {
     try {
       return (await this.inner.eraseLocal()) as { erasedTables: string[] };
+    } catch (e) {
+      throw parseError(e);
+    }
+  }
+
+  /**
+   * Replace the dest auth token without re-initializing.
+   * The dest URL, profile, and metadata cache are unchanged; the next
+   * request just uses the new token. Use this for token rotation.
+   *
+   * Errors if the dest is not an HTTP endpoint.
+   *
+   * **Do not call while a sync future is pending.** Await any in-flight
+   * push/pull/sync first.
+   */
+  updateAuth(authToken: string): void {
+    try {
+      this.inner.updateAuth(authToken);
+    } catch (e) {
+      throw parseError(e);
+    }
+  }
+
+  /**
+   * Replace the entire dest endpoint. Accepts the same shape as the
+   * `dest` field of `Smugglr.init({...})`. Clears the dest metadata
+   * cache so the next sync re-scans against the new endpoint; the
+   * source cache (and local OPFS data) survive.
+   *
+   * Use this for the anonymous-to-account upgrade flow: start with an
+   * anonymous ingress dest, swap to the account-bound dest after sign-in.
+   *
+   * **Do not call while a sync future is pending.** Await first.
+   */
+  updateDest(dest: EndpointConfig): void {
+    try {
+      this.inner.updateDest(dest);
     } catch (e) {
       throw parseError(e);
     }


### PR DESCRIPTION
Adds two WASM Smugglr methods for runtime mutation of the dest endpoint without re-initializing the instance or losing the metadata cache.

## API
\`\`\`ts
Smugglr.updateAuth(authToken: string): void
Smugglr.updateDest(dest: EndpointConfig): void
\`\`\`

\`updateAuth\` rotates just the bearer token. URL / profile / metadata cache untouched.

\`updateDest\` replaces the entire dest endpoint -- the anonymous-first -> account-upgrade primitive. Source cache and local OPFS data survive; only the dest cache resets so the next sync re-scans against the new endpoint.

## Implementation
- \`FetchDataSource.auth_token\` wrapped in \`Mutex<String>\` + \`set_auth_token()\` for atomic token swap.
- \`Smugglr.dest\` wrapped in \`RefCell<AnyDataSource>\` for full endpoint replacement.
- \`push\` / \`pull\` / \`sync\` / \`diff\` open a \`let dest = self.dest.borrow();\` at the top so the borrow lives across the .awaits.
- \`#[allow(clippy::await_holding_refcell_ref)]\` on those four methods, with a rationale comment: WASM is single-threaded and the constraint \"do not call updateAuth/updateDest while a sync future is pending\" is documented in both Rust and TS.

## Acceptance criteria (#112)
- [x] \`updateAuth(token)\` on the WASM Smugglr struct
- [x] \`updateDest(dest)\` accepts the same shape \`build_datasource\` accepts; replaces dest, clears the dest_cache (source cache untouched)
- [x] TypeScript wrapper exposes both methods
- [x] Test: anonymous push -> updateAuth -> push under new token -> verify Authorization header swap

## Test plan
- [x] \`pnpm test:e2e\` -- 3/3 passing (push, pull, **new** token-swap verification)
- [x] \`cargo test --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

Closes #112.