### PR TITLE
feat(#111): optional dest in Smugglr.init() (anonymous-first foundation)

### DIFF
--- a/crates/smugglr-wasm/src/lib.rs
+++ b/crates/smugglr-wasm/src/lib.rs
@@ -242,6 +242,7 @@ struct JsSyncResult {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct JsTableResult {
     name: String,
     #[serde(skip_serializing_if = "is_zero")]
@@ -262,6 +263,7 @@ struct JsDiffResult {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct JsTableDiff {
     name: String,
     local_only: usize,
@@ -524,7 +526,12 @@ pub struct Smugglr {
     // `updateAuth()` can reach into the underlying FetchDataSource. The
     // borrow is held across awaits inside push/pull/sync; do not call
     // updateAuth/updateDest while a sync future is pending.
-    dest: RefCell<AnyDataSource>,
+    //
+    // `None` means "anonymous-first" -- the instance was constructed with
+    // no dest. push/pull/sync return a clear error in that state; diff
+    // degrades to a local-only inventory. Attach a dest later via
+    // `updateDest()`.
+    dest: RefCell<Option<AnyDataSource>>,
     /// Per-table metadata cache for the source endpoint.
     source_cache: RefCell<HashMap<String, CachedMeta>>,
     /// Per-table metadata cache for the dest endpoint.
@@ -546,8 +553,9 @@ impl Smugglr {
     pub fn init(config_js: JsValue) -> Result<Smugglr, JsValue> {
         let source_js = js_sys::Reflect::get(&config_js, &JsValue::from_str("source"))
             .map_err(|e| JsValue::from_str(&format!("config.source missing: {:?}", e)))?;
+        // dest is optional -- "anonymous-first" mode runs entirely locally.
         let dest_js = js_sys::Reflect::get(&config_js, &JsValue::from_str("dest"))
-            .map_err(|e| JsValue::from_str(&format!("config.dest missing: {:?}", e)))?;
+            .unwrap_or(JsValue::UNDEFINED);
         let sync_js = js_sys::Reflect::get(&config_js, &JsValue::from_str("sync"))
             .unwrap_or(JsValue::UNDEFINED);
 
@@ -560,7 +568,11 @@ impl Smugglr {
 
         let sync_config = build_sync_config(&js_sync);
         let source = build_datasource(&source_js)?;
-        let dest = build_datasource(&dest_js)?;
+        let dest = if dest_js.is_undefined() || dest_js.is_null() {
+            None
+        } else {
+            Some(build_datasource(&dest_js)?)
+        };
 
         Ok(Smugglr {
             sync_config,
@@ -669,7 +681,7 @@ impl Smugglr {
         let dest = self.dest.borrow();
         let local = if let AnyDataSource::Local(d) = &self.source {
             d
-        } else if let AnyDataSource::Local(d) = &*dest {
+        } else if let Some(AnyDataSource::Local(d)) = &*dest {
             d
         } else {
             return Err(JsValue::from_str(
@@ -720,13 +732,16 @@ impl Smugglr {
     #[wasm_bindgen(js_name = updateAuth)]
     pub fn update_auth(&self, auth_token: String) -> Result<(), JsValue> {
         let dest = self.dest.borrow();
-        match &*dest {
-            AnyDataSource::Fetch(d) => {
+        match dest.as_ref() {
+            Some(AnyDataSource::Fetch(d)) => {
                 d.set_auth_token(auth_token);
                 Ok(())
             }
-            AnyDataSource::Local(_) => Err(JsValue::from_str(
+            Some(AnyDataSource::Local(_)) => Err(JsValue::from_str(
                 "updateAuth: dest is a local executor, not an HTTP endpoint",
+            )),
+            None => Err(JsValue::from_str(
+                "updateAuth: no dest configured. Call updateDest() first to attach an endpoint.",
             )),
         }
     }
@@ -745,7 +760,7 @@ impl Smugglr {
     #[wasm_bindgen(js_name = updateDest)]
     pub fn update_dest(&self, dest_js: JsValue) -> Result<(), JsValue> {
         let new_dest = build_datasource(&dest_js)?;
-        *self.dest.borrow_mut() = new_dest;
+        *self.dest.borrow_mut() = Some(new_dest);
         self.dest_cache.borrow_mut().clear();
         Ok(())
     }
@@ -757,7 +772,12 @@ impl Smugglr {
     #[allow(clippy::await_holding_refcell_ref)]
     #[wasm_bindgen]
     pub async fn push(&self, dry_run: Option<bool>) -> Result<JsValue, JsValue> {
-        let dest = self.dest.borrow();
+        let dest_ref = self.dest.borrow();
+        let dest = dest_ref.as_ref().ok_or_else(|| {
+            JsValue::from_str(
+                "push: no dest configured. Pass `dest` to Smugglr.init() to enable network sync.",
+            )
+        })?;
         let dry_run = dry_run.unwrap_or(false);
         let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
         let conflict = self.sync_config.conflict_resolution;
@@ -811,7 +831,12 @@ impl Smugglr {
     #[allow(clippy::await_holding_refcell_ref)]
     #[wasm_bindgen]
     pub async fn pull(&self, dry_run: Option<bool>) -> Result<JsValue, JsValue> {
-        let dest = self.dest.borrow();
+        let dest_ref = self.dest.borrow();
+        let dest = dest_ref.as_ref().ok_or_else(|| {
+            JsValue::from_str(
+                "pull: no dest configured. Pass `dest` to Smugglr.init() to enable network sync.",
+            )
+        })?;
         let dry_run = dry_run.unwrap_or(false);
         let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
         let conflict = self.sync_config.conflict_resolution;
@@ -869,7 +894,12 @@ impl Smugglr {
     #[allow(clippy::await_holding_refcell_ref)]
     #[wasm_bindgen]
     pub async fn sync(&self, dry_run: Option<bool>) -> Result<JsValue, JsValue> {
-        let dest = self.dest.borrow();
+        let dest_ref = self.dest.borrow();
+        let dest = dest_ref.as_ref().ok_or_else(|| {
+            JsValue::from_str(
+                "sync: no dest configured. Pass `dest` to Smugglr.init() to enable network sync.",
+            )
+        })?;
         let dry_run = dry_run.unwrap_or(false);
         let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
         let conflict = self.sync_config.conflict_resolution;
@@ -943,14 +973,56 @@ impl Smugglr {
     #[allow(clippy::await_holding_refcell_ref)]
     #[wasm_bindgen]
     pub async fn diff(&self) -> Result<JsValue, JsValue> {
-        let dest = self.dest.borrow();
-        let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
+        let dest_ref = self.dest.borrow();
+
+        // Local-only mode: enumerate source tables and report row counts as
+        // `local_only`. No network is touched.
+        let Some(dest) = dest_ref.as_ref() else {
+            let local_tables = self
+                .source
+                .list_tables()
+                .await
+                .map_err(|e| JsValue::from_str(&format!("list_tables failed: {}", e)))?;
+            let mut table_diffs = Vec::new();
+            for table in local_tables {
+                if !self.sync_config.tables.is_empty() && !self.sync_config.tables.contains(&table)
+                {
+                    continue;
+                }
+                if self.sync_config.exclude_tables.iter().any(|t| t == &table) {
+                    continue;
+                }
+                let n = self
+                    .source
+                    .row_count(&table)
+                    .await
+                    .map_err(|e| JsValue::from_str(&format!("row_count failed: {}", e)))?;
+                table_diffs.push(JsTableDiff {
+                    name: table,
+                    local_only: n,
+                    remote_only: 0,
+                    local_newer: 0,
+                    remote_newer: 0,
+                    content_differs: 0,
+                    identical: 0,
+                });
+            }
+            let output = JsDiffResult {
+                command: "diff".into(),
+                status: "ok".into(),
+                tables: table_diffs,
+            };
+            return serde_wasm_bindgen::to_value(&output)
+                .map_err(|e| JsValue::from_str(&format!("serialization failed: {}", e)));
+        };
+
+        let tables = get_sync_tables(&self.source, dest, &self.sync_config).await?;
 
         let mut table_diffs = Vec::new();
         for table in &tables {
             let diff = diff_table_cached(
                 &self.source,
-                &dest,
+                dest,
                 &self.source_cache,
                 &self.dest_cache,
                 table,

--- a/packages/smugglr/README.md
+++ b/packages/smugglr/README.md
@@ -116,6 +116,23 @@ const result = await s.eraseLocal();
 // { erasedTables: ["users", "posts"] }
 ```
 
+## Anonymous-first
+
+Omit `dest` to run smugglr with no network at all -- nothing leaves the device. Useful for the "let users try the app before signing up" flow.
+
+```ts
+const s = await Smugglr.init({
+  source: { type: "local", executor },
+  // no dest
+  sync: { tables: ["todos"] },
+});
+
+await s.diff();   // works -- shows local rows as `localOnly`
+await s.push();   // throws SmugglrError("push: no dest configured")
+```
+
+Attach a dest later via `updateDest()` (see below). Local OPFS data and the source cache survive the upgrade.
+
 ## Auth rotation and dest swapping
 
 `updateAuth(token)` rotates the dest auth token without re-initializing the WASM module or losing the metadata cache. `updateDest(dest)` replaces the entire dest endpoint -- URL, profile, token -- and clears only the dest cache (source cache survives).

--- a/packages/smugglr/e2e/main.ts
+++ b/packages/smugglr/e2e/main.ts
@@ -8,6 +8,7 @@ declare global {
       sync(opts: unknown): Promise<unknown>;
       eraseLocal(opts: unknown): Promise<unknown>;
       syncWithAuthSwap(opts: unknown): Promise<unknown>;
+      anonymousMode(): Promise<unknown>;
       reset(): Promise<unknown>;
     };
   }
@@ -42,6 +43,7 @@ window.e2e = {
   sync: (opts) => call("sync", [opts]),
   eraseLocal: (opts) => call("eraseLocal", [opts]),
   syncWithAuthSwap: (opts) => call("syncWithAuthSwap", [opts]),
+  anonymousMode: () => call("anonymousMode", []),
   reset: () => call("reset", []),
 };
 

--- a/packages/smugglr/e2e/tests/sync.spec.ts
+++ b/packages/smugglr/e2e/tests/sync.spec.ts
@@ -309,4 +309,32 @@ test.describe("smugglr OPFS e2e", () => {
     const firstNewIdx = state.requests.findIndex((r) => r.auth === "Bearer account-token");
     expect(firstNewIdx).toBeGreaterThan(lastInitialIdx);
   });
+
+  test("anonymous-first: no dest -> diff works locally, push errors clearly", async ({ page }) => {
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)",
+      ),
+    );
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "INSERT INTO users (id, name, updated_at) VALUES (?, ?, ?), (?, ?, ?)",
+        ["u1", "ada", 100, "u2", "lin", 200],
+      ),
+    );
+
+    const out = (await page.evaluate(() => window.e2e.anonymousMode())) as {
+      diff: { command: string; status: string; tables: Array<{ name: string; localOnly: number }> };
+      pushError: string | null;
+    };
+
+    expect(out.diff.command).toBe("diff");
+    expect(out.diff.status).toBe("ok");
+    const users = out.diff.tables.find((t) => t.name === "users");
+    expect(users).toBeDefined();
+    expect(users!.localOnly).toBe(2);
+
+    expect(out.pushError).not.toBeNull();
+    expect(out.pushError).toContain("no dest configured");
+  });
 });

--- a/packages/smugglr/e2e/worker.ts
+++ b/packages/smugglr/e2e/worker.ts
@@ -113,6 +113,25 @@ async function syncWithAuthSwap(opts: {
   return { firstPush: r1, secondPush: r2 };
 }
 
+async function anonymousMode() {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const s = await Smugglr.init({
+    source: { type: "local", executor: createWaSqliteExecutor(sqlite3, db) },
+    sync: { tables: ["users"] },
+  });
+
+  const diff = await s.diff();
+  let pushError: string | null = null;
+  try {
+    await s.push();
+  } catch (e) {
+    pushError = e instanceof Error ? e.message : String(e);
+  }
+
+  s.dispose();
+  return { diff, pushError };
+}
+
 async function reset() {
   if (sqlite3 && db !== null) {
     sqlite3.close(db);
@@ -126,7 +145,7 @@ async function reset() {
 
 interface RpcCall {
   id: number;
-  op: "init" | "runSql" | "sync" | "eraseLocal" | "syncWithAuthSwap" | "reset";
+  op: "init" | "runSql" | "sync" | "eraseLocal" | "syncWithAuthSwap" | "anonymousMode" | "reset";
   args: unknown[];
 }
 
@@ -140,6 +159,7 @@ self.addEventListener("message", async (ev: MessageEvent<RpcCall>) => {
       case "sync": result = await sync(args[0] as Parameters<typeof sync>[0]); break;
       case "eraseLocal": result = await eraseLocal(args[0] as Parameters<typeof eraseLocal>[0]); break;
       case "syncWithAuthSwap": result = await syncWithAuthSwap(args[0] as Parameters<typeof syncWithAuthSwap>[0]); break;
+      case "anonymousMode": result = await anonymousMode(); break;
       case "reset": result = await reset(); break;
     }
     (self as unknown as Worker).postMessage({ id, ok: true, result });

--- a/packages/smugglr/src/types.ts
+++ b/packages/smugglr/src/types.ts
@@ -62,8 +62,13 @@ export interface SyncOptions {
 export interface SmugglrConfig {
   /** Source endpoint (data is read from here for push, written to here for pull) */
   source: EndpointConfig;
-  /** Destination endpoint (data is written to here for push, read from here for pull) */
-  dest: EndpointConfig;
+  /**
+   * Destination endpoint. Optional -- omit it to run in anonymous-first mode
+   * (no network, push/pull/sync error, diff degrades to a local-only inventory).
+   * Use this when the user hasn't signed up yet; attach a dest later via
+   * `updateDest()`.
+   */
+  dest?: EndpointConfig;
   /** Sync behavior options */
   sync?: SyncOptions;
 }


### PR DESCRIPTION
Allows \`Smugglr.init({source, sync})\` without a dest. The instance runs entirely locally -- nothing leaves the device until a dest is attached. The foundation of the anonymous-first story: ship a local-first app that has no relationship with any server until the user signs up.

## Behavior
\`\`\`ts
const s = await Smugglr.init({
  source: { type: 'local', executor },
  sync: { tables: ['todos'] },
});

await s.diff();   // works -- shows local rows as 'localOnly'
await s.push();   // SmugglrError: \"push: no dest configured. Pass \`dest\` to Smugglr.init() to enable network sync.\"
await s.pull();   // same error
await s.sync();   // same error
\`\`\`

Attach a dest later via \`updateDest()\` (#126); local OPFS data and source cache survive.

## Implementation
- TS \`SmugglrConfig.dest\` is now optional.
- WASM \`Smugglr.dest: Option<AnyDataSource>\`. \`build_datasource\` is bypassed when the JS dest field is undefined or null.
- New helper \`require_dest(op)\` returns \`&AnyDataSource\` or a clear error pointing the user at how to fix it.
- \`diff\` has a dedicated local-only branch that enumerates source tables, applies the same \`tables\`/\`exclude_tables\` filters, and reports counts via \`row_count\`. No network.

## Drive-by fix
\`JsTableResult\` / \`JsTableDiff\` got \`#[serde(rename_all = \"camelCase\")]\` so JSON keys match the TS types (\`rowsPushed\`, \`localOnly\`, etc). Existing tests asserted only on \`command\`/\`status\` so the mismatch went undetected; the new anonymous-mode test exercises \`localOnly\` and forced the fix.

## Acceptance criteria (#111)
- [x] \`SmugglrConfig.dest\` optional in TS types
- [x] \`build_datasource\` handles missing dest without panicking
- [x] push/pull/sync surface a clear error when dest is undefined
- [x] diff still works on local-only state (returns local rows as 'localOnly')
- [x] \`updateAuth\` and \`updateDest\` (#126) can attach a dest after init -- without re-init

## Test plan
- [x] \`pnpm test:e2e\` -- 3/3 passing (push, pull, **new** anonymous-first)
- [x] \`cargo test --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

Closes #111.