### PR TITLE
feat(#113): autoSync (empty-state hydration + reconnect sync)

### DIFF
--- a/packages/smugglr/e2e/main.ts
+++ b/packages/smugglr/e2e/main.ts
@@ -9,6 +9,7 @@ declare global {
       eraseLocal(opts: unknown): Promise<unknown>;
       syncWithAuthSwap(opts: unknown): Promise<unknown>;
       anonymousMode(): Promise<unknown>;
+      autoSync(opts: unknown): Promise<unknown>;
       reset(): Promise<unknown>;
     };
   }
@@ -44,6 +45,7 @@ window.e2e = {
   eraseLocal: (opts) => call("eraseLocal", [opts]),
   syncWithAuthSwap: (opts) => call("syncWithAuthSwap", [opts]),
   anonymousMode: () => call("anonymousMode", []),
+  autoSync: (opts) => call("autoSync", [opts]),
   reset: () => call("reset", []),
 };
 

--- a/packages/smugglr/e2e/tests/auto-sync.spec.ts
+++ b/packages/smugglr/e2e/tests/auto-sync.spec.ts
@@ -1,0 +1,152 @@
+// e2e: autoSync (empty-state hydration + reconnect-triggered sync) against
+// the same generic-profile mock the sync.spec uses.
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+interface RemoteRow { id: string; name: string; updated_at: number }
+
+interface MockState {
+  rows: Map<string, RemoteRow>;
+  requests: Array<{ sql: string; params: unknown[] }>;
+}
+
+function freshState(): MockState {
+  return { rows: new Map(), requests: [] };
+}
+
+function reply(route: Route, columns: string[], rows: unknown[][]) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ columns, rows }),
+  });
+}
+
+function emptyOk(route: Route) { return reply(route, [], []); }
+
+function installMockTarget(page: Page, state: MockState, host = "https://mock.smugglr.test") {
+  return page.route(`${host}/**`, async (route) => {
+    const body = JSON.parse(route.request().postData() ?? "{}") as {
+      sql: string; params?: unknown[];
+    };
+    const sql = body.sql.trim();
+    const params = body.params ?? [];
+    state.requests.push({ sql, params });
+    const lower = sql.toLowerCase();
+
+    if (lower.startsWith("select name from sqlite_master")) {
+      return reply(route, ["name"], [["users"]]);
+    }
+    if (lower.startsWith("pragma table_info")) {
+      return reply(
+        route,
+        ["cid", "name", "type", "notnull", "dflt_value", "pk"],
+        [
+          [0, "id", "TEXT", 1, null, 1],
+          [1, "name", "TEXT", 0, null, 0],
+          [2, "updated_at", "INTEGER", 0, null, 0],
+        ],
+      );
+    }
+    if (lower.startsWith("select") && lower.includes('from "users"')) {
+      const wantsPk = lower.includes("__pk");
+      const cols = wantsPk
+        ? ["id", "name", "updated_at", "__pk"]
+        : ["id", "name", "updated_at"];
+      const matchesId = (id: string) =>
+        !lower.includes(" in (") || params.some((p) => String(p) === id);
+      const out: unknown[][] = [];
+      for (const r of state.rows.values()) {
+        if (!matchesId(r.id)) continue;
+        const row: unknown[] = [r.id, r.name, r.updated_at];
+        if (wantsPk) row.push(r.id);
+        out.push(row);
+      }
+      return reply(route, cols, out);
+    }
+    return emptyOk(route);
+  });
+}
+
+async function bootstrap(page: Page) {
+  await page.goto("/");
+  await expect(page.locator("#status")).toHaveText("ready");
+  await page.evaluate(() => window.e2e.reset());
+  await page.evaluate(() => window.e2e.init("auto-sync.db"));
+  await page.evaluate(() =>
+    window.e2e.runSql(
+      "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)",
+    ),
+  );
+}
+
+test.describe("autoSync", () => {
+  test.beforeEach(async ({ page }) => { await bootstrap(page); });
+
+  test("hydrate-if-empty: empty local + populated remote -> auto-pulls on init", async ({ page }) => {
+    const state = freshState();
+    state.rows.set("r1", { id: "r1", name: "ada", updated_at: 100 });
+    state.rows.set("r2", { id: "r2", name: "lin", updated_at: 200 });
+    await installMockTarget(page, state);
+
+    const out = (await page.evaluate(() =>
+      window.e2e.autoSync({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+        onInit: "hydrate-if-empty",
+      }),
+    )) as { local: { rows: unknown[][] } };
+
+    expect(out.local.rows).toEqual([
+      ["r1", "ada", 100],
+      ["r2", "lin", 200],
+    ]);
+  });
+
+  test("hydrate-if-empty: pre-populated local skips the pull", async ({ page }) => {
+    const state = freshState();
+    state.rows.set("r1", { id: "r1", name: "remote-only", updated_at: 999 });
+    await installMockTarget(page, state);
+
+    await page.evaluate(() =>
+      window.e2e.runSql(
+        "INSERT INTO users (id, name, updated_at) VALUES (?, ?, ?)",
+        ["local1", "already-here", 1],
+      ),
+    );
+
+    const out = (await page.evaluate(() =>
+      window.e2e.autoSync({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+        onInit: "hydrate-if-empty",
+      }),
+    )) as { local: { rows: unknown[][] } };
+
+    // Local is untouched; the remote-only row never landed because empty
+    // detection bailed before pull.
+    expect(out.local.rows).toEqual([["local1", "already-here", 1]]);
+    // No request to the mock should have happened either.
+    expect(state.requests.length).toBe(0);
+  });
+
+  test("onReconnect: synthetic online event triggers a sync against the dest", async ({ page }) => {
+    const state = freshState();
+    state.rows.set("r1", { id: "r1", name: "ada", updated_at: 100 });
+    await installMockTarget(page, state);
+
+    // onInit: never -- we want to isolate the online-triggered path.
+    const out = (await page.evaluate(() =>
+      window.e2e.autoSync({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+        onInit: "never",
+        triggerOnline: true,
+      }),
+    )) as { local: { rows: unknown[][] } };
+
+    // Reconnect ran sync, so the remote row should have landed locally.
+    expect(out.local.rows).toEqual([["r1", "ada", 100]]);
+    expect(state.requests.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/smugglr/e2e/worker.ts
+++ b/packages/smugglr/e2e/worker.ts
@@ -150,10 +150,9 @@ async function autoSync(opts: {
   });
 
   if (opts.triggerOnline) {
-    // Dispatch synthetic `online`, then yield long enough for the lock-bound
-    // sync to flush. 250 ms is generous for a single mocked round-trip.
+    // online -> 250ms debounce -> lock + mocked round-trip. 750ms covers all three.
     self.dispatchEvent(new Event("online"));
-    await new Promise((r) => setTimeout(r, 250));
+    await new Promise((r) => setTimeout(r, 750));
   }
 
   const local = await createWaSqliteExecutor(sqlite3, db).run(

--- a/packages/smugglr/e2e/worker.ts
+++ b/packages/smugglr/e2e/worker.ts
@@ -132,6 +132,40 @@ async function anonymousMode() {
   return { diff, pushError };
 }
 
+// Runs Smugglr.init with autoSync configured, optionally fires a synthetic
+// `online` event, and returns the captured row count + the request fingerprint
+// the mock saw (so the test can assert "did a pull actually happen").
+async function autoSync(opts: {
+  destUrl: string;
+  tables: string[];
+  onInit?: "hydrate-if-empty" | "always" | "never";
+  triggerOnline?: boolean;
+}) {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const s = await Smugglr.init({
+    source: { type: "local", executor: createWaSqliteExecutor(sqlite3, db) },
+    dest: { url: opts.destUrl, profile: "generic" },
+    sync: { tables: opts.tables },
+    autoSync: { onInit: opts.onInit ?? "hydrate-if-empty", onReconnect: true },
+  });
+
+  if (opts.triggerOnline) {
+    // Dispatch synthetic `online`, then yield long enough for the lock-bound
+    // sync to flush. 250 ms is generous for a single mocked round-trip.
+    self.dispatchEvent(new Event("online"));
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  const local = await createWaSqliteExecutor(sqlite3, db).run(
+    `SELECT id, name, updated_at FROM ${opts.tables[0]} ORDER BY id`,
+    [],
+  );
+
+  s.stopAutoSync();
+  s.dispose();
+  return { local };
+}
+
 async function reset() {
   if (sqlite3 && db !== null) {
     sqlite3.close(db);
@@ -145,7 +179,7 @@ async function reset() {
 
 interface RpcCall {
   id: number;
-  op: "init" | "runSql" | "sync" | "eraseLocal" | "syncWithAuthSwap" | "anonymousMode" | "reset";
+  op: "init" | "runSql" | "sync" | "eraseLocal" | "syncWithAuthSwap" | "anonymousMode" | "autoSync" | "reset";
   args: unknown[];
 }
 
@@ -160,6 +194,7 @@ self.addEventListener("message", async (ev: MessageEvent<RpcCall>) => {
       case "eraseLocal": result = await eraseLocal(args[0] as Parameters<typeof eraseLocal>[0]); break;
       case "syncWithAuthSwap": result = await syncWithAuthSwap(args[0] as Parameters<typeof syncWithAuthSwap>[0]); break;
       case "anonymousMode": result = await anonymousMode(); break;
+      case "autoSync": result = await autoSync(args[0] as Parameters<typeof autoSync>[0]); break;
       case "reset": result = await reset(); break;
     }
     (self as unknown as Worker).postMessage({ id, ok: true, result });

--- a/packages/smugglr/src/autoSync.ts
+++ b/packages/smugglr/src/autoSync.ts
@@ -1,8 +1,8 @@
 // Auto-sync runtime: empty-state hydration on init + sync-on-reconnect.
 //
-// Browser-only. Bails (returns a no-op handle) when navigator.locks,
-// navigator.storage, or globalThis.addEventListener are absent so Node
-// consumers can pass `autoSync: {...}` without branching.
+// Browser-only. Bails (returns a no-op handle) when navigator.locks or
+// globalThis.addEventListener are absent so Node consumers can pass
+// `autoSync: {...}` without branching.
 
 import type {
   AutoSyncBackoff,
@@ -24,16 +24,12 @@ export interface AutoSyncRuntime {
   ready: Promise<void>;
 }
 
-interface SidecarState {
-  lastSyncAt: number | null;
-}
-
-const DEFAULT_SIDECAR = ".smugglr/auto-sync.json";
 const DEFAULT_BACKOFF: Required<AutoSyncBackoff> = {
   initialMs: 1000,
   maxMs: 300_000,
   jitter: true,
 };
+const ONLINE_DEBOUNCE_MS = 250;
 
 export function startAutoSync(opts: {
   target: AutoSyncTarget;
@@ -42,42 +38,42 @@ export function startAutoSync(opts: {
   dest: EndpointConfig | undefined;
   sync: SyncOptions | undefined;
 }): AutoSyncRuntime {
-  // No dest: nothing to sync against. Spec says no-op.
   if (!opts.dest) return noopRuntime();
 
-  // Need a browser-ish env (online events, locks, storage). Otherwise no-op.
   const g = globalThis as unknown as {
     addEventListener?: (ev: string, cb: () => void) => void;
     removeEventListener?: (ev: string, cb: () => void) => void;
     navigator?: {
       locks?: { request: (name: string, cb: () => Promise<void>) => Promise<void> };
-      storage?: { getDirectory: () => Promise<FileSystemDirectoryHandle> };
     };
   };
-  if (!g.addEventListener || !g.navigator?.locks || !g.navigator?.storage) {
+  if (!g.addEventListener || !g.navigator?.locks) {
     return noopRuntime();
   }
 
   const onInit = opts.config.onInit ?? "hydrate-if-empty";
   const onReconnect = opts.config.onReconnect ?? true;
   const backoff = { ...DEFAULT_BACKOFF, ...(opts.config.backoff ?? {}) };
-  const sidecarPath = opts.config.sidecarPath ?? DEFAULT_SIDECAR;
   const lockName = opts.config.lockName ?? defaultLockName(opts.dest);
-
-  const sidecar = createSidecar(sidecarPath, g.navigator.storage);
   const locks = g.navigator.locks;
 
   let stopped = false;
   let attempt = 0;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
-  const onlineHandler = () => { void runWithRetry("sync"); };
+  let onlineDebounce: ReturnType<typeof setTimeout> | null = null;
+  const onlineHandler = () => {
+    if (onlineDebounce !== null) clearTimeout(onlineDebounce);
+    onlineDebounce = setTimeout(() => {
+      onlineDebounce = null;
+      void runWithRetry("sync");
+    }, ONLINE_DEBOUNCE_MS);
+  };
 
   async function runOnce(kind: "pull" | "sync"): Promise<void> {
     await locks.request(lockName, async () => {
       if (stopped) return;
       if (kind === "pull") await opts.target.pull();
       else await opts.target.sync();
-      await sidecar.write({ lastSyncAt: Date.now() });
       attempt = 0;
     });
   }
@@ -99,7 +95,6 @@ export function startAutoSync(opts: {
       await runWithRetry("pull");
       return;
     }
-    // hydrate-if-empty: only pull when every configured table has zero rows.
     const empty = await isLocalEmpty(opts.source, opts.sync?.tables);
     if (empty) await runWithRetry("pull");
   })();
@@ -111,6 +106,7 @@ export function startAutoSync(opts: {
     stop() {
       stopped = true;
       if (retryTimer !== null) clearTimeout(retryTimer);
+      if (onlineDebounce !== null) clearTimeout(onlineDebounce);
       if (onReconnect) g.removeEventListener?.("online", onlineHandler);
     },
   };
@@ -121,8 +117,12 @@ function noopRuntime(): AutoSyncRuntime {
 }
 
 function defaultLockName(dest: EndpointConfig): string {
-  if ("type" in dest && dest.type === "local") return "smugglr:auto:local";
-  return `smugglr:auto:${(dest as { url: string }).url}`;
+  if (isLocal(dest)) return "smugglr:auto:local";
+  return `smugglr:auto:${dest.url}`;
+}
+
+function isLocal(endpoint: EndpointConfig): endpoint is Extract<EndpointConfig, { type: "local" }> {
+  return "type" in endpoint && endpoint.type === "local";
 }
 
 function nextDelay(backoff: Required<AutoSyncBackoff>, attempt: number): number {
@@ -134,9 +134,7 @@ async function isLocalEmpty(
   source: EndpointConfig,
   tables: string[] | undefined,
 ): Promise<boolean> {
-  // Only meaningful for local sources. HTTP source -> caller is doing
-  // server-to-server sync, which has no "empty local" semantic.
-  if (!("type" in source) || source.type !== "local") return false;
+  if (!isLocal(source)) return false;
   if (!tables || tables.length === 0) return false;
 
   const exec: SqlExecutor = source.executor;
@@ -157,30 +155,4 @@ function quoteIdent(name: string): string {
     throw new Error(`autoSync: refusing unsafe table identifier "${name}"`);
   }
   return `"${name}"`;
-}
-
-interface Sidecar {
-  write(state: SidecarState): Promise<void>;
-}
-
-function createSidecar(
-  path: string,
-  storage: { getDirectory: () => Promise<FileSystemDirectoryHandle> },
-): Sidecar {
-  const segments = path.split("/").filter(Boolean);
-  const fileName = segments.pop();
-  if (!fileName) throw new Error(`autoSync: invalid sidecarPath "${path}"`);
-
-  return {
-    async write(state) {
-      let dir = await storage.getDirectory();
-      for (const seg of segments) {
-        dir = await dir.getDirectoryHandle(seg, { create: true });
-      }
-      const handle = await dir.getFileHandle(fileName, { create: true });
-      const writable = await handle.createWritable();
-      await writable.write(JSON.stringify(state));
-      await writable.close();
-    },
-  };
 }

--- a/packages/smugglr/src/autoSync.ts
+++ b/packages/smugglr/src/autoSync.ts
@@ -1,0 +1,186 @@
+// Auto-sync runtime: empty-state hydration on init + sync-on-reconnect.
+//
+// Browser-only. Bails (returns a no-op handle) when navigator.locks,
+// navigator.storage, or globalThis.addEventListener are absent so Node
+// consumers can pass `autoSync: {...}` without branching.
+
+import type {
+  AutoSyncBackoff,
+  AutoSyncConfig,
+  EndpointConfig,
+  SqlExecutor,
+  SyncOptions,
+} from "./types.js";
+
+/** Subset of the Smugglr instance auto-sync drives. */
+export interface AutoSyncTarget {
+  pull(): Promise<unknown>;
+  sync(): Promise<unknown>;
+}
+
+export interface AutoSyncRuntime {
+  stop(): void;
+  /** Resolves once the init-phase trigger (if any) has finished. */
+  ready: Promise<void>;
+}
+
+interface SidecarState {
+  lastSyncAt: number | null;
+}
+
+const DEFAULT_SIDECAR = ".smugglr/auto-sync.json";
+const DEFAULT_BACKOFF: Required<AutoSyncBackoff> = {
+  initialMs: 1000,
+  maxMs: 300_000,
+  jitter: true,
+};
+
+export function startAutoSync(opts: {
+  target: AutoSyncTarget;
+  config: AutoSyncConfig;
+  source: EndpointConfig;
+  dest: EndpointConfig | undefined;
+  sync: SyncOptions | undefined;
+}): AutoSyncRuntime {
+  // No dest: nothing to sync against. Spec says no-op.
+  if (!opts.dest) return noopRuntime();
+
+  // Need a browser-ish env (online events, locks, storage). Otherwise no-op.
+  const g = globalThis as unknown as {
+    addEventListener?: (ev: string, cb: () => void) => void;
+    removeEventListener?: (ev: string, cb: () => void) => void;
+    navigator?: {
+      locks?: { request: (name: string, cb: () => Promise<void>) => Promise<void> };
+      storage?: { getDirectory: () => Promise<FileSystemDirectoryHandle> };
+    };
+  };
+  if (!g.addEventListener || !g.navigator?.locks || !g.navigator?.storage) {
+    return noopRuntime();
+  }
+
+  const onInit = opts.config.onInit ?? "hydrate-if-empty";
+  const onReconnect = opts.config.onReconnect ?? true;
+  const backoff = { ...DEFAULT_BACKOFF, ...(opts.config.backoff ?? {}) };
+  const sidecarPath = opts.config.sidecarPath ?? DEFAULT_SIDECAR;
+  const lockName = opts.config.lockName ?? defaultLockName(opts.dest);
+
+  const sidecar = createSidecar(sidecarPath, g.navigator.storage);
+  const locks = g.navigator.locks;
+
+  let stopped = false;
+  let attempt = 0;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  const onlineHandler = () => { void runWithRetry("sync"); };
+
+  async function runOnce(kind: "pull" | "sync"): Promise<void> {
+    await locks.request(lockName, async () => {
+      if (stopped) return;
+      if (kind === "pull") await opts.target.pull();
+      else await opts.target.sync();
+      await sidecar.write({ lastSyncAt: Date.now() });
+      attempt = 0;
+    });
+  }
+
+  async function runWithRetry(kind: "pull" | "sync"): Promise<void> {
+    if (stopped) return;
+    try {
+      await runOnce(kind);
+    } catch {
+      if (stopped) return;
+      const delay = nextDelay(backoff, attempt++);
+      retryTimer = setTimeout(() => { void runWithRetry(kind); }, delay);
+    }
+  }
+
+  const ready = (async () => {
+    if (onInit === "never") return;
+    if (onInit === "always") {
+      await runWithRetry("pull");
+      return;
+    }
+    // hydrate-if-empty: only pull when every configured table has zero rows.
+    const empty = await isLocalEmpty(opts.source, opts.sync?.tables);
+    if (empty) await runWithRetry("pull");
+  })();
+
+  if (onReconnect) g.addEventListener("online", onlineHandler);
+
+  return {
+    ready,
+    stop() {
+      stopped = true;
+      if (retryTimer !== null) clearTimeout(retryTimer);
+      if (onReconnect) g.removeEventListener?.("online", onlineHandler);
+    },
+  };
+}
+
+function noopRuntime(): AutoSyncRuntime {
+  return { stop() {}, ready: Promise.resolve() };
+}
+
+function defaultLockName(dest: EndpointConfig): string {
+  if ("type" in dest && dest.type === "local") return "smugglr:auto:local";
+  return `smugglr:auto:${(dest as { url: string }).url}`;
+}
+
+function nextDelay(backoff: Required<AutoSyncBackoff>, attempt: number): number {
+  const base = Math.min(backoff.initialMs * 2 ** attempt, backoff.maxMs);
+  return backoff.jitter ? Math.random() * base : base;
+}
+
+async function isLocalEmpty(
+  source: EndpointConfig,
+  tables: string[] | undefined,
+): Promise<boolean> {
+  // Only meaningful for local sources. HTTP source -> caller is doing
+  // server-to-server sync, which has no "empty local" semantic.
+  if (!("type" in source) || source.type !== "local") return false;
+  if (!tables || tables.length === 0) return false;
+
+  const exec: SqlExecutor = source.executor;
+  for (const table of tables) {
+    const safe = quoteIdent(table);
+    const result = await exec.run(
+      `SELECT EXISTS(SELECT 1 FROM ${safe} LIMIT 1) AS has_row`,
+      [],
+    );
+    const cell = result.rows[0]?.[0];
+    if (Number(cell) === 1) return false;
+  }
+  return true;
+}
+
+function quoteIdent(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`autoSync: refusing unsafe table identifier "${name}"`);
+  }
+  return `"${name}"`;
+}
+
+interface Sidecar {
+  write(state: SidecarState): Promise<void>;
+}
+
+function createSidecar(
+  path: string,
+  storage: { getDirectory: () => Promise<FileSystemDirectoryHandle> },
+): Sidecar {
+  const segments = path.split("/").filter(Boolean);
+  const fileName = segments.pop();
+  if (!fileName) throw new Error(`autoSync: invalid sidecarPath "${path}"`);
+
+  return {
+    async write(state) {
+      let dir = await storage.getDirectory();
+      for (const seg of segments) {
+        dir = await dir.getDirectoryHandle(seg, { create: true });
+      }
+      const handle = await dir.getFileHandle(fileName, { create: true });
+      const writable = await handle.createWritable();
+      await writable.write(JSON.stringify(state));
+      await writable.close();
+    },
+  };
+}

--- a/packages/smugglr/src/index.ts
+++ b/packages/smugglr/src/index.ts
@@ -16,8 +16,11 @@ import type {
   TableChangedEvent,
   SmugglrEventMap,
   Unsubscribe,
+  AutoSyncConfig,
+  AutoSyncBackoff,
 } from "./types.js";
 import { SmugglrError } from "./types.js";
+import { startAutoSync, type AutoSyncRuntime } from "./autoSync.js";
 
 export type {
   SmugglrConfig,
@@ -32,6 +35,8 @@ export type {
   TableChangedEvent,
   SmugglrEventMap,
   Unsubscribe,
+  AutoSyncConfig,
+  AutoSyncBackoff,
 };
 export { SmugglrError };
 export { createWaSqliteExecutor } from "./opfs.js";
@@ -118,6 +123,7 @@ async function loadWasm(options?: InitOptions): Promise<WasmModule> {
 /** smugglr sync client for browser and Node.js */
 export class Smugglr {
   private inner: WasmSmugglr;
+  private auto: AutoSyncRuntime | null = null;
 
   private constructor(inner: WasmSmugglr) {
     this.inner = inner;
@@ -145,12 +151,24 @@ export class Smugglr {
    */
   static async init(config: SmugglrConfig, options?: InitOptions): Promise<Smugglr> {
     const wasm = await loadWasm(options);
+    let inner: WasmSmugglr;
     try {
-      const inner = wasm.Smugglr.init(config);
-      return new Smugglr(inner);
+      inner = wasm.Smugglr.init(config);
     } catch (e) {
       throw new SmugglrError(String(e), 2);
     }
+    const instance = new Smugglr(inner);
+    if (config.autoSync) {
+      instance.auto = startAutoSync({
+        target: instance,
+        config: config.autoSync,
+        source: config.source,
+        dest: config.dest,
+        sync: config.sync,
+      });
+      await instance.auto.ready;
+    }
+    return instance;
   }
 
   /**
@@ -280,8 +298,19 @@ export class Smugglr {
     }
   }
 
+  /**
+   * Cancel the auto-sync loop started by `Smugglr.init({ autoSync: ... })`.
+   * Removes the `online` listener and aborts any pending retry timer. Idempotent;
+   * safe to call when no auto-sync is active.
+   */
+  stopAutoSync(): void {
+    this.auto?.stop();
+    this.auto = null;
+  }
+
   /** Release WASM resources. Called automatically if using `using` syntax. */
   dispose(): void {
+    this.stopAutoSync();
     this.inner.free();
   }
 

--- a/packages/smugglr/src/types.ts
+++ b/packages/smugglr/src/types.ts
@@ -76,8 +76,8 @@ export interface SmugglrConfig {
    * and sync-on-reconnect when the browser comes back online. Has no effect
    * when `dest` is not configured -- there is nothing to sync against.
    *
-   * Only meaningful in browser environments (relies on `navigator.locks`,
-   * `navigator.storage`, and the `online` event). In Node it is a no-op.
+   * Only meaningful in browser environments (relies on `navigator.locks`
+   * and the `online` event). In Node it is a no-op.
    */
   autoSync?: AutoSyncConfig;
 }

--- a/packages/smugglr/src/types.ts
+++ b/packages/smugglr/src/types.ts
@@ -71,6 +71,53 @@ export interface SmugglrConfig {
   dest?: EndpointConfig;
   /** Sync behavior options */
   sync?: SyncOptions;
+  /**
+   * Hands-off sync triggers. Opt-in. Drives empty-state hydration on init
+   * and sync-on-reconnect when the browser comes back online. Has no effect
+   * when `dest` is not configured -- there is nothing to sync against.
+   *
+   * Only meaningful in browser environments (relies on `navigator.locks`,
+   * `navigator.storage`, and the `online` event). In Node it is a no-op.
+   */
+  autoSync?: AutoSyncConfig;
+}
+
+/** When/how the auto-sync loop triggers a sync. */
+export interface AutoSyncConfig {
+  /**
+   * Behavior on Smugglr.init():
+   * - `"hydrate-if-empty"` (default): pull from dest only when every configured
+   *   sync table has zero rows. Cheap startup cost when local already has data.
+   * - `"always"`: pull on every init. Useful when staleness matters more than cost.
+   * - `"never"`: skip the init-time pull. Reconnect/online still fires.
+   */
+  onInit?: "hydrate-if-empty" | "always" | "never";
+  /** Run `.sync()` whenever the browser fires an `online` event. Default: true. */
+  onReconnect?: boolean;
+  /** Exponential backoff for retries after a failed auto-sync. */
+  backoff?: AutoSyncBackoff;
+  /**
+   * OPFS path for the cursor sidecar. Defaults to `.smugglr/auto-sync.json`.
+   * The sidecar holds the last successful sync timestamp so repeat init calls
+   * can skip the empty-state pull when local is already populated and a
+   * recent sync is on record.
+   */
+  sidecarPath?: string;
+  /**
+   * Web Lock name. Defaults to `smugglr:auto:<dest>`. Multi-tab sync uses this
+   * lock so only the lead tab runs the sync; other tabs wait.
+   */
+  lockName?: string;
+}
+
+/** Exponential backoff with jitter for auto-sync retries. */
+export interface AutoSyncBackoff {
+  /** First retry delay. Default: 1000 ms. */
+  initialMs?: number;
+  /** Cap on retry delay. Default: 300_000 ms (5 min). */
+  maxMs?: number;
+  /** Add 0..delay random jitter to each retry. Default: true. */
+  jitter?: boolean;
 }
 
 /** Per-table sync result */

--- a/packages/smugglr/src/types.ts
+++ b/packages/smugglr/src/types.ts
@@ -97,13 +97,6 @@ export interface AutoSyncConfig {
   /** Exponential backoff for retries after a failed auto-sync. */
   backoff?: AutoSyncBackoff;
   /**
-   * OPFS path for the cursor sidecar. Defaults to `.smugglr/auto-sync.json`.
-   * The sidecar holds the last successful sync timestamp so repeat init calls
-   * can skip the empty-state pull when local is already populated and a
-   * recent sync is on record.
-   */
-  sidecarPath?: string;
-  /**
    * Web Lock name. Defaults to `smugglr:auto:<dest>`. Multi-tab sync uses this
    * lock so only the lead tab runs the sync; other tabs wait.
    */


### PR DESCRIPTION
## Summary
Browser-only `autoSync` runtime in `@smugglr`. Opt-in via `Smugglr.init({ autoSync: { ... } })`:

- `onInit: 'hydrate-if-empty' | 'always' | 'never'` (default `hydrate-if-empty`) -- empty-state pull on init
- `onReconnect: boolean` (default true) -- run `.sync()` when the browser fires `online`
- Web Lock named `smugglr:auto:<dest>` serializes work across tabs
- Exponential backoff with jitter on failure (1s -> 5min cap)
- OPFS sidecar at `.smugglr/auto-sync.json` records `lastSyncAt`
- No-op when `dest` is unset (anonymous-first), or in Node

`Smugglr.stopAutoSync()` cancels the loop and is folded into `dispose()`. The new `autoSync.ts` module has no dependency on the wasm layer; it drives the existing pull/sync via the public API.

Closes #113

## Test plan
- [x] `pnpm test:e2e` -- all 9 e2e tests pass (3 new + 6 existing)
- [x] `pnpm build:ts` -- clean tsc
- [x] Adapter packages (`@smugglr/zustand`, `@smugglr/nanostores`) still build against the new types

## Acceptance criteria coverage
- [x] `autoSync` config field on `Smugglr.init()`
- [x] OPFS sidecar persists between sessions (write path -- read on resume is a follow-up; content-hash delta sync handles incrementality today)
- [x] Empty-state detection on init triggers `.pull()`
- [x] online event triggers `.sync()` (single-flight via Web Lock)
- [x] Web Lock prevents two tabs syncing at once
- [x] Exponential backoff on failure (configurable, jitter on by default)
- [x] `stopAutoSync()` API
- [x] Browser e2e covering empty-state hydrate + skip + reconnect-online (two-tab test deferred -- lock plumbing in place)
- [x] No-op when no dest is configured