### PR TITLE
docs(#129): browser-WASM multi-tenant sync to a shared D1 example

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -29,6 +29,7 @@ End-to-end examples covering the main ways people reach for smugglr. Each exampl
 | ------- | ------------- |
 | [browser-opfs-turso](./browser-opfs-turso) | wa-sqlite + `OriginPrivateFileSystemVFS` (OPFS), syncing to Turso. The local-first golden path. |
 | [browser-idb-turso](./browser-idb-turso) | `IDBBatchAtomicVFS` (IndexedDB) variant. Compatibility for older Safari and embedded webviews. |
+| [browser-wasm-d1-multitenant](./browser-wasm-d1-multitenant) | Many browsers, each its own SQLite, syncing into one shared D1 partitioned by `tenant_id`. Includes a Cloudflare Worker that authenticates, scopes reads, and validates writes. |
 
 ## Notes on running these
 

--- a/docs/examples/browser-wasm-d1-multitenant/.env.example
+++ b/docs/examples/browser-wasm-d1-multitenant/.env.example
@@ -1,0 +1,7 @@
+# URL of the deployed Cloudflare Worker that fronts D1.
+VITE_FENCE_URL=https://your-fence-worker.example.workers.dev/sql
+
+# One token per tenant. The Worker maps token -> tenant_id (see tenant-worker/src/index.ts).
+# Open the app as ?tenant=alice or ?tenant=bob to use the matching token.
+VITE_TENANT_TOKEN_ALICE=alice-dev-token
+VITE_TENANT_TOKEN_BOB=bob-dev-token

--- a/docs/examples/browser-wasm-d1-multitenant/README.md
+++ b/docs/examples/browser-wasm-d1-multitenant/README.md
@@ -1,0 +1,125 @@
+# browser-wasm-d1-multitenant
+
+Many browsers, each holding their own full SQLite database, all syncing into one shared D1. Rows in D1 are partitioned by `tenant_id`. A small Cloudflare Worker is the fence: it authenticates each request, scopes reads to the caller's tenant, and rejects writes carrying anyone else's id.
+
+## The model
+
+```
++----------------+         +----------------+         +-------------------+         +------+
+| browser tab    |         | browser tab    |         | Cloudflare Worker |         |  D1  |
+| ?tenant=alice  |  HTTPS  | ?tenant=bob    |  HTTPS  |   (tenant fence)  |  bind   | one  |
+| wa-sqlite+OPFS |-------> | wa-sqlite+OPFS |-------> |  Bearer -> tenant |-------> | DB   |
+| tenant-alice.db|         | tenant-bob.db  |         |  scope + validate |         |      |
++----------------+         +----------------+         +-------------------+         +------+
+        ^                                                                              |
+        |                              tenant-scoped rows only                          |
+        +------------------------------------------------------------------------------+
+```
+
+- **Browser** runs `smugglr` over `wa-sqlite` on OPFS. Each tenant's local database is its own OPFS file (`tenant-<id>.db`), so two tabs don't trample one another.
+- **Worker** speaks D1's HTTP shape exactly, so the browser uses `profile: "d1"` unchanged and points at the Worker URL. The Worker does the tenancy work the smugglr client cannot do on its own.
+- **D1** holds every tenant's rows in one table. The `tenant_id` column is the partition key.
+
+## Why the Worker exists
+
+`smugglr-core` does not ship a per-tenant `WHERE` filter on `pull`. Without something in the middle, every browser would pull every tenant's rows out of the shared D1. The Worker is what makes shared-D1 multi-tenancy real -- it authenticates the request, scopes reads to the caller's tenant, and validates that writes carry the matching id.
+
+## Prerequisites
+
+- Node 20+, pnpm
+- A Cloudflare account with D1 and Workers enabled
+- `wrangler` available (`pnpm dlx wrangler --help`)
+- A modern Chromium/Firefox/Safari (OPFS sync access handles are worker-only outside Chromium; the example already wires that up)
+
+## Setup
+
+### 1. Create the D1 database and apply the schema
+
+```sh
+cd tenant-worker
+pnpm dlx wrangler d1 create smugglr_demo
+```
+
+Wrangler prints a `database_id`. Paste it into `tenant-worker/wrangler.toml` (replace `REPLACE_WITH_YOUR_D1_DATABASE_ID`).
+
+```sh
+pnpm install
+pnpm db:schema
+```
+
+`db:schema` is just `wrangler d1 execute smugglr_demo --file=../schema.sql --remote`.
+
+### 2. Deploy the fence Worker
+
+```sh
+pnpm deploy
+```
+
+Wrangler prints a `*.workers.dev` URL. Note it.
+
+### 3. Configure the browser app
+
+From the example root:
+
+```sh
+pnpm install
+cp .env.example .env
+```
+
+Edit `.env`:
+
+```
+VITE_FENCE_URL=https://smugglr-tenant-fence.<your-subdomain>.workers.dev
+VITE_TENANT_TOKEN_ALICE=alice-dev-token
+VITE_TENANT_TOKEN_BOB=bob-dev-token
+```
+
+The token values must match the `[vars]` in `tenant-worker/wrangler.toml`. For real apps, generate proper tokens and ship them through your auth flow; this example uses a hardcoded map so the moving parts stay visible.
+
+### 4. Run
+
+```sh
+pnpm dev
+```
+
+Open two windows:
+
+- <http://localhost:5173/?tenant=alice>
+- <http://localhost:5173/?tenant=bob>
+
+In each: click **Add note** a few times, then **Sync**. Click **List local rows** to confirm each browser only holds its own tenant's rows. Switch to the other tab, click **Sync**, then **List local rows** -- you should still only see that tenant's rows, even though D1 now holds both sets.
+
+## What this demonstrates
+
+- **Tenant partitioning at the table level.** Every row carries `tenant_id`. There is no separate-database-per-tenant overhead.
+- **The fence does what the client cannot.** The browser is trusted enough to tag its own rows; the Worker is what stops a bad client from inserting rows tagged with someone else's id.
+- **The D1 profile is a contract.** The Worker mimics D1's HTTP shape so the browser code is identical to a direct-to-D1 setup. Swap `VITE_FENCE_URL` for a real D1 endpoint and the client doesn't notice.
+- **Per-tenant OPFS isolation.** Two tabs on the same origin do not collide because the OPFS filename embeds the tenant id.
+
+## What the Worker actually does
+
+`tenant-worker/src/index.ts` is ~120 lines. The interesting half:
+
+- Resolves `Bearer <token>` to a `tenant_id` via a hardcoded map.
+- For `SELECT`s, wraps the query as a subquery and appends `WHERE tenant_id = ?` bound to the authenticated tenant. This works for every shape smugglr's d1 adapter emits because the subquery preserves the original projection.
+- For `INSERT OR REPLACE`, parses the column list, finds `tenant_id`, and verifies every row in the batched VALUES matches the authenticated tenant.
+- Passes through `SELECT 1` and `sqlite_master` queries (smugglr's connection ping and table discovery).
+- Rejects every other statement shape.
+
+The rewriter is naive on purpose -- it's there to make the pattern visible. A production version of this Worker would use prepared-statement enforcement, JWT claims for the tenant, and a real allowlist instead of a hardcoded token map.
+
+## Lesson 2 (sketch): same pattern, Rust client
+
+The same fence Worker accepts any `smugglr` client speaking the `d1` profile. A Rust client built on `smugglr-core` (e.g. a desktop companion app, a migration script, or a server-side admin tool) becomes another tenant by:
+
+1. Resolving a tenant token through whatever auth flow it uses.
+2. Building a target with `Profile::d1()`, pointing at the Worker URL, with the token in the `Bearer` header.
+3. Carrying `tenant_id` in every inserted row, the same way the browser does.
+
+Code for this lesson lives in `rust-custom-datasource/` already as a starting point; the only delta is the dest configuration.
+
+## Limits to call out
+
+- This example does not handle deletes. `smugglr` push uses `INSERT OR REPLACE`; once row deletion lands, the fence will need to gate `DELETE` the same way it gates `INSERT`.
+- The token map lives in plaintext `wrangler.toml [vars]`. Use Workers secrets in production.
+- The Worker has no rate limiting, audit log, or per-tenant quota. Add them at the Worker layer if you need them.

--- a/docs/examples/browser-wasm-d1-multitenant/index.html
+++ b/docs/examples/browser-wasm-d1-multitenant/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>smugglr WASM + D1 multi-tenant</title>
+  </head>
+  <body>
+    <h1>smugglr browser-WASM <span id="tenant-label"></span> &rarr; D1</h1>
+    <p>Each browser is its own SQLite database. D1 is shared, partitioned by tenant_id. The Cloudflare Worker is the fence.</p>
+    <p>Open this page in a second tab with a different <code>?tenant=</code> query param to see isolation.</p>
+    <button id="add">Add note</button>
+    <button id="sync">Sync</button>
+    <button id="list">List local rows</button>
+    <button id="reset">Reset local</button>
+    <pre id="log"></pre>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/docs/examples/browser-wasm-d1-multitenant/main.ts
+++ b/docs/examples/browser-wasm-d1-multitenant/main.ts
@@ -1,0 +1,71 @@
+// Page UI: proxies button clicks into the worker via postMessage. The worker
+// owns wa-sqlite + smugglr because OPFS sync access handles are worker-only
+// in WebKit and Firefox.
+//
+// Tenant identity comes from the ?tenant= query param. Real apps would derive
+// the tenant token from an auth flow (Smugglr.updateAuth on login).
+
+const params = new URLSearchParams(location.search);
+const tenant = params.get("tenant") ?? "alice";
+const tenantToken = import.meta.env[`VITE_TENANT_TOKEN_${tenant.toUpperCase()}`];
+const fenceUrl = import.meta.env.VITE_FENCE_URL;
+
+if (!tenantToken) {
+  throw new Error(
+    `No VITE_TENANT_TOKEN_${tenant.toUpperCase()} in .env -- add a token for tenant "${tenant}".`,
+  );
+}
+
+document.getElementById("tenant-label")!.textContent = `[${tenant}]`;
+document.title = `smugglr [${tenant}] -> D1`;
+
+const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+  type: "module",
+});
+
+const log = document.getElementById("log") as HTMLPreElement;
+const append = (line: string) => {
+  log.textContent = `${new Date().toISOString().slice(11, 23)}  ${line}\n${log.textContent}`;
+};
+
+let nextId = 1;
+const pending = new Map<number, (v: unknown) => void>();
+worker.addEventListener("message", (ev: MessageEvent<{ id: number; ok: boolean; result?: unknown; error?: string }>) => {
+  const slot = pending.get(ev.data.id);
+  if (!slot) return;
+  pending.delete(ev.data.id);
+  slot(ev.data.ok ? ev.data.result : { error: ev.data.error });
+});
+
+function call(op: string, args: unknown[] = []) {
+  const id = nextId++;
+  return new Promise<unknown>((resolve) => {
+    pending.set(id, resolve);
+    worker.postMessage({ id, op, args });
+  });
+}
+
+await call("init", [tenant, tenantToken, fenceUrl]);
+append(`ready as tenant=${tenant}`);
+
+document.getElementById("add")!.addEventListener("click", async () => {
+  const id = crypto.randomUUID();
+  const ts = new Date().toISOString();
+  await call("addRow", [id, ts]);
+  append(`add: ${id}`);
+});
+
+document.getElementById("sync")!.addEventListener("click", async () => {
+  const result = await call("sync");
+  append(`sync: ${JSON.stringify(result)}`);
+});
+
+document.getElementById("list")!.addEventListener("click", async () => {
+  const rows = await call("listRows");
+  append(`local rows: ${JSON.stringify(rows)}`);
+});
+
+document.getElementById("reset")!.addEventListener("click", async () => {
+  await call("reset");
+  append("reset");
+});

--- a/docs/examples/browser-wasm-d1-multitenant/package.json
+++ b/docs/examples/browser-wasm-d1-multitenant/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "smugglr-example-browser-wasm-d1-multitenant",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "smugglr": "^0.3.3",
+    "wa-sqlite": "^1.0.0"
+  },
+  "devDependencies": {
+    "vite": "^8.0.10"
+  }
+}

--- a/docs/examples/browser-wasm-d1-multitenant/schema.sql
+++ b/docs/examples/browser-wasm-d1-multitenant/schema.sql
@@ -1,0 +1,14 @@
+-- D1 schema for the multi-tenant example.
+--
+-- Every table has a tenant_id column. The fence Worker validates that writes
+-- carry the authenticated tenant and scopes reads by it. The index on
+-- (tenant_id, id) keeps per-tenant scans cheap as the shared table grows.
+
+CREATE TABLE IF NOT EXISTS notes (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  body TEXT,
+  updated_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS notes_tenant_id_idx ON notes (tenant_id, id);

--- a/docs/examples/browser-wasm-d1-multitenant/tenant-worker/package.json
+++ b/docs/examples/browser-wasm-d1-multitenant/tenant-worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "smugglr-example-tenant-worker",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "db:schema": "wrangler d1 execute smugglr_demo --file=../schema.sql --remote"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240620.0",
+    "typescript": "^5.5.0",
+    "wrangler": "^3.60.0"
+  }
+}

--- a/docs/examples/browser-wasm-d1-multitenant/tenant-worker/src/index.ts
+++ b/docs/examples/browser-wasm-d1-multitenant/tenant-worker/src/index.ts
@@ -1,0 +1,126 @@
+// Tenant fence in front of D1.
+//
+// Speaks D1's REST shape so a smugglr client using `profile: "d1"` can point
+// straight at this Worker's URL. The Worker authenticates the Bearer token,
+// resolves it to a tenant_id, rewrites SELECTs to scope by tenant, and
+// validates that every INSERT carries the authenticated tenant_id.
+
+export interface Env {
+  DB: D1Database;
+  TENANT_TOKEN_ALICE: string;
+  TENANT_TOKEN_BOB: string;
+}
+
+interface Body {
+  sql: string;
+  params?: unknown[];
+}
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Authorization, Content-Type",
+};
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    if (req.method === "OPTIONS") return new Response(null, { headers: CORS });
+    if (req.method !== "POST") return json({ error: "POST only" }, 405);
+
+    const tenant = resolveTenant(req, env);
+    if (!tenant) return json({ error: "unauthorized" }, 401);
+
+    let body: Body;
+    try {
+      body = await req.json();
+    } catch {
+      return json({ error: "invalid json" }, 400);
+    }
+
+    try {
+      const rewritten = enforce(body.sql, body.params ?? [], tenant);
+      const stmt = env.DB.prepare(rewritten.sql).bind(...rewritten.params);
+      const result = await stmt.all();
+      // Match the D1 REST response shape that smugglr's d1 profile expects:
+      //   { result: [ { results: [...], success: true, meta: {...} } ] }
+      return json({
+        result: [
+          {
+            results: result.results ?? [],
+            success: true,
+            meta: result.meta ?? {},
+          },
+        ],
+        success: true,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return json({ error: message }, 400);
+    }
+  },
+};
+
+function resolveTenant(req: Request, env: Env): string | null {
+  const header = req.headers.get("authorization") ?? "";
+  const token = header.replace(/^Bearer\s+/i, "").trim();
+  if (!token) return null;
+  if (token === env.TENANT_TOKEN_ALICE) return "alice";
+  if (token === env.TENANT_TOKEN_BOB) return "bob";
+  return null;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...CORS },
+  });
+}
+
+// Rewrite the incoming SQL so the authenticated tenant cannot see or write
+// another tenant's rows. Three cases cover everything smugglr's d1 adapter emits.
+function enforce(
+  rawSql: string,
+  params: unknown[],
+  tenant: string,
+): { sql: string; params: unknown[] } {
+  const sql = rawSql.trim().replace(/;\s*$/, "");
+  const head = sql.slice(0, 32).toUpperCase();
+
+  // Passthrough: smugglr's connection ping and table discovery.
+  if (sql.toUpperCase() === "SELECT 1") return { sql, params };
+  if (/FROM\s+SQLITE_MASTER/i.test(sql)) return { sql, params };
+
+  if (head.startsWith("SELECT")) {
+    // Wrap the query so we can filter without parsing it. Smugglr's d1 adapter
+    // emits queries like SELECT * FROM "notes" or SELECT *, pk_expr AS __pk
+    // FROM "notes"; the subquery preserves their projection.
+    return {
+      sql: `SELECT * FROM (${sql}) WHERE tenant_id = ?`,
+      params: [...params, tenant],
+    };
+  }
+
+  if (head.startsWith("INSERT")) {
+    // smugglr push: INSERT OR REPLACE INTO "table" ("col1", "col2", ...) VALUES (?, ?, ...), (?, ?, ...)
+    const m = sql.match(/INSERT\s+(?:OR\s+\w+\s+)?INTO\s+"?([^"\s(]+)"?\s*\(([^)]+)\)/i);
+    if (!m) throw new Error("cannot parse INSERT columns");
+    const cols = m[2].split(",").map((c) => c.trim().replace(/^"|"$/g, ""));
+    const tenantIdx = cols.indexOf("tenant_id");
+    if (tenantIdx < 0) {
+      throw new Error("INSERT must include tenant_id column for this fence");
+    }
+    if (params.length % cols.length !== 0) {
+      throw new Error("param count not a multiple of column count");
+    }
+    for (let i = tenantIdx; i < params.length; i += cols.length) {
+      if (params[i] !== tenant) {
+        throw new Error(
+          `tenant_id mismatch in row ${i / cols.length}: got ${String(params[i])}, expected ${tenant}`,
+        );
+      }
+    }
+    return { sql, params };
+  }
+
+  throw new Error(`statement not allowed: ${head.split(/\s/)[0]}`);
+}

--- a/docs/examples/browser-wasm-d1-multitenant/tenant-worker/tsconfig.json
+++ b/docs/examples/browser-wasm-d1-multitenant/tenant-worker/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docs/examples/browser-wasm-d1-multitenant/tenant-worker/wrangler.toml
+++ b/docs/examples/browser-wasm-d1-multitenant/tenant-worker/wrangler.toml
@@ -1,0 +1,17 @@
+name = "smugglr-tenant-fence"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+
+# Bind the shared D1 database. Create it first with:
+#   npx wrangler d1 create smugglr_demo
+# then paste the returned database_id below.
+[[d1_databases]]
+binding = "DB"
+database_name = "smugglr_demo"
+database_id = "REPLACE_WITH_YOUR_D1_DATABASE_ID"
+
+# Demo-only token -> tenant_id map. In production this is a JWT verification
+# step or a lookup against a secrets table. Plain vars keep the example small.
+[vars]
+TENANT_TOKEN_ALICE = "alice-dev-token"
+TENANT_TOKEN_BOB = "bob-dev-token"

--- a/docs/examples/browser-wasm-d1-multitenant/vite.config.ts
+++ b/docs/examples/browser-wasm-d1-multitenant/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ["wa-sqlite"],
+  },
+  build: {
+    target: "es2022",
+  },
+});

--- a/docs/examples/browser-wasm-d1-multitenant/worker.ts
+++ b/docs/examples/browser-wasm-d1-multitenant/worker.ts
@@ -1,0 +1,101 @@
+// Web Worker: owns wa-sqlite + OPFS + smugglr. Each tenant gets its own
+// OPFS database (filename includes tenant id) so two tabs cannot collide.
+//
+// The browser uses profile: "d1" pointed at the Cloudflare Worker URL. The
+// Worker mimics D1's HTTP shape exactly, so nothing on the smugglr side knows
+// or cares that a fence sits in between.
+
+import SQLiteAsyncESMFactory from "wa-sqlite/dist/wa-sqlite-async.mjs";
+import * as SQLite from "wa-sqlite";
+// @ts-expect-error - wa-sqlite ships JS examples without .d.ts
+import { OriginPrivateFileSystemVFS } from "wa-sqlite/src/examples/OriginPrivateFileSystemVFS.js";
+import { Smugglr, createWaSqliteExecutor } from "smugglr";
+
+let sqlite3: any = null;
+let db: number | null = null;
+let smugglr: Smugglr | null = null;
+let tenantId: string | null = null;
+
+async function init(tenant: string, tenantToken: string, fenceUrl: string) {
+  tenantId = tenant;
+
+  const module = await SQLiteAsyncESMFactory();
+  sqlite3 = SQLite.Factory(module);
+  const vfs = new OriginPrivateFileSystemVFS();
+  await new Promise((r) => setTimeout(r, 0));
+  sqlite3.vfs_register(vfs, true);
+  db = await sqlite3.open_v2(
+    `tenant-${tenant}.db`,
+    SQLite.SQLITE_OPEN_READWRITE | SQLite.SQLITE_OPEN_CREATE,
+    "opfs",
+  );
+
+  const exe = createWaSqliteExecutor(sqlite3, db);
+  // tenant_id is part of the schema so smugglr's row-level push carries it
+  // upstream and the fence Worker can validate it against the auth token.
+  await exe.run(
+    "CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, body TEXT, updated_at TEXT)",
+    [],
+  );
+
+  smugglr = await Smugglr.init({
+    source: { type: "local", executor: exe },
+    dest: { url: fenceUrl, authToken: tenantToken, profile: "d1" },
+    sync: { tables: ["notes"], conflictResolution: "newer_wins" },
+  });
+}
+
+async function addRow(id: string, updatedAt: string) {
+  if (!sqlite3 || db === null || !tenantId) throw new Error("init() first");
+  const exe = createWaSqliteExecutor(sqlite3, db);
+  await exe.run(
+    "INSERT INTO notes (id, tenant_id, body, updated_at) VALUES (?, ?, ?, ?)",
+    [id, tenantId, `note from ${tenantId} at ${updatedAt}`, updatedAt],
+  );
+}
+
+async function listRows() {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const exe = createWaSqliteExecutor(sqlite3, db);
+  const result = await exe.run("SELECT id, tenant_id, body, updated_at FROM notes ORDER BY updated_at DESC", []);
+  return result.rows;
+}
+
+async function sync() {
+  if (!smugglr) throw new Error("init() first");
+  return smugglr.sync();
+}
+
+async function reset() {
+  if (smugglr) {
+    smugglr.dispose();
+    smugglr = null;
+  }
+  if (sqlite3 && db !== null) {
+    sqlite3.close(db);
+    db = null;
+  }
+  const root = await navigator.storage.getDirectory();
+  for await (const entry of (root as any).values()) {
+    await root.removeEntry(entry.name, { recursive: true });
+  }
+}
+
+self.addEventListener("message", async (ev: MessageEvent<{ id: number; op: string; args: unknown[] }>) => {
+  const { id, op, args } = ev.data;
+  try {
+    let result: unknown;
+    switch (op) {
+      case "init": result = await init(args[0] as string, args[1] as string, args[2] as string); break;
+      case "addRow": result = await addRow(args[0] as string, args[1] as string); break;
+      case "listRows": result = await listRows(); break;
+      case "sync": result = await sync(); break;
+      case "reset": result = await reset(); break;
+      default: throw new Error(`unknown op: ${op}`);
+    }
+    (self as unknown as Worker).postMessage({ id, ok: true, result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    (self as unknown as Worker).postMessage({ id, ok: false, error: message });
+  }
+});


### PR DESCRIPTION
Closes #129.

## Summary

- New runnable example at `docs/examples/browser-wasm-d1-multitenant/`.
- Browser app (Vite + wa-sqlite + smugglr-wasm): each tenant gets its own OPFS database, identified via `?tenant=` query param.
- `tenant-worker/`: small Cloudflare Worker that fences a shared D1 by `tenant_id`. Mimics D1's HTTP shape so the browser uses `profile: "d1"` unchanged.
- `schema.sql`: tables with `tenant_id` columns + indexes.
- README walks through the model (browser = SQLite, D1 = shared, Worker = fence), the setup, the run, what the Worker actually does, a sketch for "Lesson 2: same pattern, Rust client," and an honest "Limits to call out" section.
- Updated `docs/examples/README.md` index.

## Why now

`browser-opfs-turso` is the only browser example and it's single-tenant against Turso. The most-asked-about cloud shape -- one D1, many users -- had no walkthrough. Without a tenant-aware proxy, smugglr-core has no per-pull WHERE filter, so every browser would pull every tenant's rows out of a shared D1. The example makes the DIY answer concrete today and positions smugglr-fence (#118) as the managed upgrade.

## Test plan

- [ ] Open the README cold and confirm the model + setup are clear without external context.
- [ ] `cd docs/examples/browser-wasm-d1-multitenant && pnpm install && pnpm dev` (after `.env` filled in) -- app loads, OPFS database opens.
- [ ] `cd tenant-worker && pnpm install && pnpm dlx wrangler dev` -- Worker starts and answers POSTs with the D1 response shape.
- [ ] Add notes from `?tenant=alice`, sync, then from `?tenant=bob`, sync. Each tab's "List local rows" only shows its own tenant.
- [ ] Confirm the Worker rejects a request with a missing/invalid Bearer token (401) and rejects an INSERT whose `tenant_id` value does not match the authenticated tenant.

## Out of scope

- Rust client (sketched in README, not coded).
- `fence` profile (blocked on #118).
- Delete propagation (called out as a limit in the README).