### PR TITLE
feat(#131): http-sql v0.1 profile

### DIFF
--- a/crates/smugglr-core/src/profile.rs
+++ b/crates/smugglr-core/src/profile.rs
@@ -42,6 +42,9 @@ pub enum RequestFormat {
     Datasette,
     /// Flat JSON: `{"sql": "<sql>", "params": [...]}`
     Generic,
+    /// http-sql v0.1 spec: `{"sql": "<sql>", "params": [...]}`
+    /// See <https://github.com/rafters-studio/http-sql>.
+    HttpSql,
 }
 
 impl Profile {
@@ -54,6 +57,7 @@ impl Profile {
             "sqlite-cloud" | "sqlitecloud" => Some(Self::sqlite_cloud()),
             "starbasedb" | "starbase" => Some(Self::starbasedb()),
             "generic" => Some(Self::generic()),
+            "http-sql" | "httpsql" => Some(Self::http_sql()),
             _ => None,
         }
     }
@@ -140,6 +144,18 @@ impl Profile {
         }
     }
 
+    /// Profile for any server conforming to the http-sql v0.1 spec.
+    /// See <https://github.com/rafters-studio/http-sql>.
+    pub fn http_sql() -> Self {
+        Self {
+            auth_format: AuthFormat::Bearer,
+            request_format: RequestFormat::HttpSql,
+            rows_path: vec!["rows".into()],
+            columns_path: vec!["columns".into()],
+            max_bind_params: 0,
+        }
+    }
+
     /// Build the request body for a SQL query.
     pub fn build_request(&self, sql: &str, params: &[Value]) -> Value {
         match self.request_format {
@@ -194,6 +210,13 @@ impl Profile {
                 serde_json::json!({"sql": sql, "_shape": "array"})
             }
             RequestFormat::Generic => {
+                if params.is_empty() {
+                    serde_json::json!({"sql": sql})
+                } else {
+                    serde_json::json!({"sql": sql, "params": params})
+                }
+            }
+            RequestFormat::HttpSql => {
                 if params.is_empty() {
                     serde_json::json!({"sql": sql})
                 } else {
@@ -306,6 +329,36 @@ mod tests {
         assert!(Profile::from_name("starbasedb").is_some());
         assert!(Profile::from_name("starbase").is_some());
         assert!(Profile::from_name("generic").is_some());
+        assert!(Profile::from_name("http-sql").is_some());
+        assert!(Profile::from_name("httpsql").is_some());
         assert!(Profile::from_name("unknown").is_none());
+    }
+
+    #[test]
+    fn test_http_sql_request_no_params() {
+        let p = Profile::http_sql();
+        let body = p.build_request("SELECT 1", &[]);
+        assert_eq!(body["sql"], "SELECT 1");
+        assert!(body.get("params").is_none());
+    }
+
+    #[test]
+    fn test_http_sql_request_with_params() {
+        let p = Profile::http_sql();
+        let body = p.build_request(
+            "SELECT * FROM notes WHERE id = ?",
+            &[Value::String("42".into())],
+        );
+        assert_eq!(body["sql"], "SELECT * FROM notes WHERE id = ?");
+        assert_eq!(body["params"][0], "42");
+    }
+
+    #[test]
+    fn test_http_sql_response_paths() {
+        // The v0.1 success envelope is {"columns": [...], "rows": [...], ...}
+        // at the top level. Verify the profile points there.
+        let p = Profile::http_sql();
+        assert_eq!(p.rows_path, vec!["rows".to_string()]);
+        assert_eq!(p.columns_path, vec!["columns".to_string()]);
     }
 }


### PR DESCRIPTION
Closes #131.

## Summary

Adds `Profile::http_sql()` to `crates/smugglr-core/src/profile.rs`, joining the existing vendor profiles. The wire format matches the [http-sql v0.1 spec](https://github.com/rafters-studio/http-sql):

- Request: `{"sql": "...", "params": [...]}` with `Authorization: Bearer <token>`
- Response: `{"columns": [...], "rows": [...], "rowsAffected": N, "lastInsertId": ...}` at the top level

The `smugglr-http-sql` plugin re-exports profiles from core (`pub use smugglr_core::profile::*`) so it picks the new profile up with no plugin changes. WASM npm `EndpointConfig` accepts `profile: "http-sql"` through the same re-export.

## Tests

`cargo test -p smugglr-core` passes (187 tests, including 3 new for the profile: no-params request shape, with-params request shape, response paths).

## Notes on the design

The HttpSql arm in `build_request()` is byte-identical to D1 and Generic today. Kept as a distinct variant so future spec evolution (batch envelopes, tagged param encoding, version negotiation header) can land on the HttpSql arm without disturbing the others. This is the same forward-compat pattern the existing profiles follow.

## Out of scope (called out in #131)

- Batch request envelope (`{"batch": [...], "atomic": true}`) -- smugglr-core doesn't emit batches at this layer.
- Tagged parameter encoding (`{"$type": "blob", ...}`) -- smugglr passes JSON values today; tagged encoding can come when the sync layer needs blob columns.
- `smugglr-http-sql` plugin edits -- no plugin code needs to change.

## Test plan

- [ ] `cargo test -p smugglr-core` passes locally (verified).
- [ ] Manually verify the WASM npm path accepts `profile: "http-sql"` (no code change expected, but worth one smoke test).
- [ ] Dogfood: point a smugglr instance at the example [cloudflare-durable-object Worker](https://github.com/rafters-studio/http-sql/tree/main/examples/cloudflare-durable-object) and confirm round-trip sync.