### PR TITLE
feat(#133): masterless multicast gossip for LAN broadcast sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1277,7 +1277,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror",
  "tokio",
  "tracing",
@@ -1314,7 +1314,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1755,6 +1755,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "socket2 0.5.10",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1800,6 +1801,16 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1970,7 +1981,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Smuggler is a universal SQLite sync engine. It started as a way to sync local de
 - **Content hashing** - SHA256 comparison of actual row data, not just timestamps
 - **Delta sync** - Only moves rows that changed
 - **Bidirectional** - Push, pull, or both with configurable conflict resolution
-- **LAN broadcast sync** - UDP peer discovery + encrypted delta exchange between machines on the same subnet
+- **LAN broadcast sync** - masterless UDP multicast: every node broadcasts a content-hash digest, peers pull what they're missing, no coordinator -- two or two hundred nodes converge
 - **Agent-friendly** - `--output json` across all commands, structured exit codes for programmatic callers
 - **No state files** - Fresh comparison every run, no stale state to haunt you
 - **Pluggable backends** - `DataSource` trait abstracts any database backend
@@ -245,20 +245,22 @@ This is the current browser story: sync between two remote HTTP SQL endpoints fr
 
 ## LAN Broadcast Sync
 
-Smuggler can keep SQLite databases in sync across machines on the same LAN. No relay server, no cloud dependency -- just encrypted UDP broadcast for peer discovery and TCP for delta exchange.
+Smuggler keeps SQLite databases in sync across machines on the same LAN with no relay, no cloud, and no coordinator. Every node runs the identical loop -- masterless UDP multicast gossip -- so two or two hundred nodes converge automatically. Membership is key possession: hold the shared key, you're on the network.
 
 ```
-Machine A                  LAN (port 31337)               Machine B
-  legion.db  --broadcast-->  [encrypted deltas]  <--broadcast--  legion.db
+Machine A           multicast group 239.255.43.21 (encrypted)          Machine B
+  legion.db  <---- content-hash digest / pull / row, all multicast ---->  legion.db
 ```
 
 ### How it works
 
-1. `smugglr broadcast` sends UDP announcements on port 31337
-2. Peers on the same subnet discover each other automatically
-3. On discovery, peers exchange deltas over TCP (only changed rows)
-4. All traffic is encrypted with XChaCha20-Poly1305 (pre-shared key)
-5. UUIDv7 primary keys prevent insert collisions across machines
+1. `smugglr broadcast` joins the multicast group and, each interval, multicasts a `primary_key -> content_hash` digest of every synced table -- the heartbeat.
+2. A node that hears a digest covering rows it lacks (or hashes differently) multicasts a request for exactly those rows.
+3. Whoever holds them multicasts the rows; every listener applies idempotently, so one answer converges the whole group. Last-received-wins on divergence -- UUIDv7 keys make concurrent divergence rare, no CRDTs.
+4. Late joiners and partition rejoins converge through the same heartbeat -- no special case.
+5. All traffic is XChaCha20-Poly1305 encrypted with the pre-shared key. Lost packets are safe: applying a row twice is a no-op and the next heartbeat re-reconciles.
+
+This is masterless and peer-symmetric -- no primary, no leader, and no TCP between LAN peers. (Cross-process and cross-subnet sync, where multicast can't reach, use the separate TCP framing path.)
 
 ### Broadcast configuration
 

--- a/crates/smugglr-core/Cargo.toml
+++ b/crates/smugglr-core/Cargo.toml
@@ -25,6 +25,7 @@ native = [
     "dep:chacha20poly1305",
     "dep:rand",
     "dep:libc",
+    "dep:socket2",
 ]
 
 [dependencies]
@@ -71,3 +72,7 @@ rand = { version = "0.9", optional = true }
 
 # Unix process checking (PID lock)
 libc = { version = "0.2", optional = true }
+
+# Multicast socket setup (SO_REUSEADDR/SO_REUSEPORT, group join)
+# "all" feature exposes set_reuse_port on unix.
+socket2 = { version = "0.5", features = ["all"], optional = true }

--- a/crates/smugglr-core/src/broadcast.rs
+++ b/crates/smugglr-core/src/broadcast.rs
@@ -23,8 +23,12 @@ use tokio::net::UdpSocket;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
-/// Protocol version for announcement packets. Bump on breaking changes.
-const PROTOCOL_VERSION: u8 = 1;
+/// Protocol version for UDP packets. Bump on breaking wire changes.
+///
+/// v2 introduced the masterless multicast gossip envelope (`multicast::Msg`:
+/// `Digest`/`Want`/`Delta`). v1 nodes (which only spoke bare `Announcement`)
+/// version-skip a v2 node and vice versa -- there is no cross-version sync.
+pub(crate) const PROTOCOL_VERSION: u8 = 2;
 
 /// Default UDP port for broadcast discovery.
 pub const DEFAULT_PORT: u16 = 31337;
@@ -494,7 +498,7 @@ pub fn hash_db_path(path: &str) -> String {
 const MAX_UDP_PAYLOAD: usize = 65507;
 
 /// Conservative packet size to avoid IP fragmentation on most networks.
-const SAFE_PACKET_SIZE: usize = 1400;
+pub(crate) const SAFE_PACKET_SIZE: usize = 1400;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DeltaPacket {

--- a/crates/smugglr-core/src/lib.rs
+++ b/crates/smugglr-core/src/lib.rs
@@ -25,6 +25,8 @@ pub mod daemon;
 #[cfg(feature = "native")]
 pub mod local;
 #[cfg(feature = "native")]
+pub mod multicast;
+#[cfg(feature = "native")]
 pub mod plugin;
 #[cfg(feature = "native")]
 pub mod snapshot;

--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -1,0 +1,779 @@
+//! Masterless multicast gossip sync -- the LAN broadcast shape.
+//!
+//! Spec (`vault/site/homepage.md` -> "LAN broadcast semantics"):
+//!
+//! - **Masterless / peer-symmetric.** Every node runs the identical loop; there
+//!   is no coordinator and no client/server distinction.
+//! - **Membership = key possession.** All datagrams are XChaCha20-Poly1305
+//!   sealed with a shared key (see [`crate::broadcast::maybe_encrypt`]); holding
+//!   the key is the only access control. `db_path_hash` further scopes a node to
+//!   one logical database, so unrelated DBs sharing a key+group do not merge.
+//! - **Idempotent apply / last-received-wins.** An incoming row is applied with
+//!   `INSERT OR REPLACE`; applying the same row twice is a no-op, so lost
+//!   datagrams are safe. On same-PK divergence the received row wins.
+//! - **Heartbeat reconciliation.** Each node periodically multicasts a
+//!   `primary_key -> content_hash` [`Digest`](Body::Digest) for every syncable
+//!   table. A peer that hears a digest covering rows it lacks (or hashes
+//!   differently) multicasts a [`Want`](Body::Want); whoever holds those rows
+//!   answers with a [`Delta`](Body::Delta). Late joiners and partition rejoins
+//!   converge through the same path with no special case.
+//!
+//! ## v0.1 boundaries (named, per the smugglr conflict doctrine -- do not hide)
+//!
+//! - **Concurrent same-PK divergence resolves silently** (last-received-wins, no
+//!   vector clocks/CRDTs). UUIDv7 PKs make this rare; the single-writer-per-row
+//!   workload makes it rarer. Visible-conflict / strict-replay is v0.2.
+//! - **Deletes** ride the live [`Delta`](Body::Delta) `deletes` list only. The
+//!   heartbeat advertises *presence*, so an absent PK is indistinguishable from
+//!   not-yet-received -- the digest reconciles upserts/divergence, not deletions.
+//!   Tombstone propagation is v0.2.
+//! - **Schema is the user's.** smugglr syncs rows, never DDL; a row for a table
+//!   that does not exist locally is dropped with a warning.
+
+use crate::broadcast::{
+    maybe_decrypt, maybe_encrypt, BroadcastConfig, DeltaPacket, ReplayGuard, DEFAULT_PORT,
+    PROTOCOL_VERSION, SAFE_PACKET_SIZE,
+};
+use crate::config::Config;
+use crate::datasource::DataSource;
+use crate::error::{Result, SyncError};
+use crate::local::LocalDb;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::Mutex;
+use tracing::{debug, warn};
+
+/// Default administratively-scoped IPv4 multicast group for smugglr gossip.
+///
+/// 239.0.0.0/8 is the IPv4 "Administratively Scoped" block (RFC 2365): routed
+/// within an organization, never onto the public internet.
+pub const DEFAULT_GROUP: Ipv4Addr = Ipv4Addr::new(239, 255, 43, 21);
+
+/// Receive buffer: the largest datagram we will accept (one full UDP payload).
+const RECV_BUF: usize = 65_536;
+
+/// A `primary_key -> content_hash` advertisement for one table (one datagram).
+///
+/// Large tables are chunked across several parts; each part is processed and
+/// answered independently (no reassembly), so a lost part only delays the rows
+/// it covered until the next heartbeat.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DigestPacket {
+    pub source_id: String,
+    pub seq: u64,
+    pub part: u16,
+    pub total_parts: u16,
+    pub table: String,
+    /// `primary_key -> content_hash` for this node's rows in `table` (this chunk).
+    pub hashes: HashMap<String, String>,
+}
+
+/// A request for specific rows the sender is missing or holds a differing hash
+/// for. Answered by any node that holds them, over multicast, so every listener
+/// converges from a single answer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WantPacket {
+    pub source_id: String,
+    pub table: String,
+    /// Primary keys the sender wants pulled.
+    pub pks: Vec<String>,
+}
+
+/// The gossip payload carried inside a sealed datagram.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "t")]
+pub enum Body {
+    Digest(DigestPacket),
+    Want(WantPacket),
+    Delta(DeltaPacket),
+}
+
+/// A versioned, DB-scoped gossip datagram. Serialized to JSON, then sealed with
+/// the shared key before it hits the wire.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Msg {
+    pub version: u8,
+    /// Scopes the message to one logical database (see module docs).
+    pub db_path_hash: String,
+    pub body: Body,
+}
+
+impl Msg {
+    fn new(db_path_hash: String, body: Body) -> Self {
+        Self {
+            version: PROTOCOL_VERSION,
+            db_path_hash,
+            body,
+        }
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec(self).map_err(|e| SyncError::Broadcast(format!("msg serialize: {e}")))
+    }
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        serde_json::from_slice(data)
+            .map_err(|e| SyncError::Broadcast(format!("msg deserialize: {e}")))
+    }
+}
+
+/// Why a received datagram was dropped without effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IgnoreReason {
+    /// Our own multicast, looped back.
+    SelfOrigin,
+    /// Sequence already seen (replay guard).
+    Replay,
+    /// Table not in this node's sync set.
+    Table,
+    /// A different logical database (db_path_hash mismatch).
+    OtherDb,
+    /// Protocol version mismatch.
+    Version,
+    /// Could not decrypt with our key.
+    Undecryptable,
+    /// Decrypted bytes did not parse as a `Msg`.
+    Malformed,
+}
+
+/// Outcome of handling one received datagram. Returned for logging and tests.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GossipEvent {
+    /// A digest part was processed; `wanted` rows were requested via a `Want`.
+    Digest { table: String, wanted: usize },
+    /// A `Want` was answered by multicasting `rows` rows.
+    Served { table: String, rows: usize },
+    /// A delta was applied; `rows` rows changed locally.
+    Applied { table: String, rows: usize },
+    /// Dropped without effect; see [`IgnoreReason`].
+    Ignored(IgnoreReason),
+}
+
+/// Split a `primary_key -> content_hash` map into datagram-sized digest parts
+/// (`part`/`total_parts` set, `seq` left 0 for the caller to assign).
+///
+/// Mirrors [`crate::broadcast::split_delta`]'s sizing and seq convention: entries
+/// accumulate until the serialized packet would exceed [`SAFE_PACKET_SIZE`], then
+/// a new part starts. The caller stamps a unique seq per part so the replay guard
+/// sees one monotonic sequence per source.
+pub fn split_digest(
+    source_id: &str,
+    table: &str,
+    hashes: HashMap<String, String>,
+) -> Result<Vec<DigestPacket>> {
+    let mk = || DigestPacket {
+        source_id: source_id.to_string(),
+        seq: 0,
+        part: 0,
+        total_parts: 1,
+        table: table.to_string(),
+        hashes: HashMap::new(),
+    };
+
+    if hashes.is_empty() {
+        return Ok(vec![mk()]);
+    }
+
+    let mut parts: Vec<DigestPacket> = Vec::new();
+    let mut current = mk();
+
+    for (pk, hash) in hashes {
+        current.hashes.insert(pk.clone(), hash.clone());
+        // Measure with the envelope so we stay under the wire limit end-to-end.
+        let probe = Msg::new(String::new(), Body::Digest(current.clone())).to_bytes()?;
+        if probe.len() > SAFE_PACKET_SIZE && current.hashes.len() > 1 {
+            current.hashes.remove(&pk);
+            parts.push(std::mem::replace(&mut current, mk()));
+            current.hashes.insert(pk, hash);
+        }
+    }
+    if !current.hashes.is_empty() {
+        parts.push(current);
+    }
+
+    let total = parts.len() as u16;
+    for (i, p) in parts.iter_mut().enumerate() {
+        p.part = i as u16;
+        p.total_parts = total;
+    }
+    Ok(parts)
+}
+
+/// The pks a node should pull given a peer's advertised `hashes`: those the peer
+/// has that we **lack** or hold a **differing** content hash for.
+pub fn want_set(
+    peer_hashes: &HashMap<String, String>,
+    local_hashes: &HashMap<String, String>,
+) -> Vec<String> {
+    peer_hashes
+        .iter()
+        .filter(|(pk, h)| match local_hashes.get(*pk) {
+            Some(local) => local != *h, // present but differs -> pull
+            None => true,               // absent locally -> pull
+        })
+        .map(|(pk, _)| pk.clone())
+        .collect()
+}
+
+/// Bind a UDP socket joined to `group:port` and ready for masterless gossip.
+///
+/// `SO_REUSEADDR` + `SO_REUSEPORT` let multiple nodes share the port on one host
+/// (needed for tests and co-located instances). `multicast_loop` is on so
+/// same-host peers hear each other; self-origin datagrams are filtered by
+/// `source_id`/`instance_id` in [`Gossip::handle`].
+fn bind_multicast(port: u16, group: Ipv4Addr) -> Result<UdpSocket> {
+    use socket2::{Domain, Protocol, Socket, Type};
+
+    fn io(what: &'static str) -> impl Fn(std::io::Error) -> SyncError {
+        move |e| SyncError::Broadcast(format!("{what}: {e}"))
+    }
+
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).map_err(io("socket"))?;
+    sock.set_reuse_address(true).map_err(io("SO_REUSEADDR"))?;
+    #[cfg(unix)]
+    sock.set_reuse_port(true).map_err(io("SO_REUSEPORT"))?;
+    sock.set_nonblocking(true).map_err(io("nonblocking"))?;
+
+    let bind = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port);
+    sock.bind(&bind.into()).map_err(io("bind"))?;
+    sock.join_multicast_v4(&group, &Ipv4Addr::UNSPECIFIED)
+        .map_err(io("join_multicast_v4"))?;
+    sock.set_multicast_loop_v4(true).map_err(io("loop_v4"))?;
+
+    let std_sock: std::net::UdpSocket = sock.into();
+    UdpSocket::from_std(std_sock).map_err(io("from_std"))
+}
+
+/// A masterless gossip node: one multicast socket plus the identical
+/// broadcast/listen loop every peer runs.
+pub struct Gossip {
+    socket: Arc<UdpSocket>,
+    dest: SocketAddrV4,
+    instance_id: String,
+    db_path_hash: String,
+    key: Option<[u8; 32]>,
+    seq: Arc<AtomicU64>,
+    replay: Arc<Mutex<ReplayGuard>>,
+}
+
+impl Gossip {
+    /// Join the multicast group for `config`'s database and prepare to gossip.
+    pub async fn bind(
+        broadcast: &BroadcastConfig,
+        db_path_hash: String,
+        group: Ipv4Addr,
+    ) -> Result<Self> {
+        let port = if broadcast.port == 0 {
+            DEFAULT_PORT
+        } else {
+            broadcast.port
+        };
+        let socket = bind_multicast(port, group)?;
+        Ok(Self {
+            socket: Arc::new(socket),
+            dest: SocketAddrV4::new(group, port),
+            instance_id: broadcast.resolve_instance_id(),
+            db_path_hash,
+            key: broadcast.encryption_key()?,
+            seq: Arc::new(AtomicU64::new(0)),
+            replay: Arc::new(Mutex::new(ReplayGuard::new())),
+        })
+    }
+
+    fn next_seq(&self) -> u64 {
+        self.seq.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// This node's `primary_key -> content_hash` map for `table`.
+    async fn row_hashes(
+        &self,
+        local: &LocalDb,
+        config: &Config,
+        table: &str,
+    ) -> Result<HashMap<String, String>> {
+        Ok(local
+            .get_row_metadata(
+                table,
+                &config.sync.timestamp_column,
+                &config.sync.exclude_columns,
+            )
+            .await?
+            .into_iter()
+            .map(|(pk, m)| (pk, m.content_hash))
+            .collect())
+    }
+
+    /// Seal a message body into an on-the-wire datagram (JSON + AEAD).
+    fn seal(&self, body: Body) -> Result<Vec<u8>> {
+        let plain = Msg::new(self.db_path_hash.clone(), body).to_bytes()?;
+        maybe_encrypt(&plain, &self.key)
+    }
+
+    /// Seal and multicast a batch of bodies to the group.
+    async fn emit(&self, bodies: Vec<Body>) -> Result<()> {
+        for body in bodies {
+            let sealed = self.seal(body)?;
+            self.socket
+                .send_to(&sealed, self.dest)
+                .await
+                .map_err(|e| SyncError::Broadcast(format!("multicast send: {e}")))?;
+        }
+        Ok(())
+    }
+
+    /// Build the digest datagrams for one heartbeat: a `primary_key ->
+    /// content_hash` advertisement, chunked, for every syncable table.
+    pub async fn digest_bodies(&self, local: &LocalDb, config: &Config) -> Result<Vec<Body>> {
+        let tables: Vec<String> = local
+            .list_tables()
+            .await?
+            .into_iter()
+            .filter(|t| config.should_sync_table(t))
+            .collect();
+
+        let mut bodies = Vec::new();
+        for table in &tables {
+            let hashes = self.row_hashes(local, config, table).await?;
+            for mut part in split_digest(&self.instance_id, table, hashes)? {
+                part.seq = self.next_seq();
+                bodies.push(Body::Digest(part));
+            }
+        }
+        Ok(bodies)
+    }
+
+    /// Multicast a content-hash digest for every syncable table -- one heartbeat.
+    /// Returns the number of digest datagrams sent.
+    pub async fn broadcast_digests(&self, local: &LocalDb, config: &Config) -> Result<usize> {
+        let bodies = self.digest_bodies(local, config).await?;
+        let n = bodies.len();
+        self.emit(bodies).await?;
+        Ok(n)
+    }
+
+    /// Build delta datagrams for `rows` of `table` (a live write or a `Want`
+    /// answer), each part given a unique seq so the replay guard dedupes.
+    fn delta_bodies(
+        &self,
+        table: &str,
+        upserts: Vec<HashMap<String, serde_json::Value>>,
+        deletes: Vec<String>,
+    ) -> Result<Vec<Body>> {
+        let parts = crate::broadcast::split_delta(&self.instance_id, 0, table, upserts, deletes)?;
+        Ok(parts
+            .into_iter()
+            .map(|mut part| {
+                part.seq = self.next_seq();
+                Body::Delta(part)
+            })
+            .collect())
+    }
+
+    /// Multicast `rows` of `table` as a delta. Returns rows sent.
+    pub async fn broadcast_delta(
+        &self,
+        table: &str,
+        upserts: Vec<HashMap<String, serde_json::Value>>,
+        deletes: Vec<String>,
+    ) -> Result<usize> {
+        let rows = upserts.len();
+        let bodies = self.delta_bodies(table, upserts, deletes)?;
+        self.emit(bodies).await?;
+        Ok(rows)
+    }
+
+    /// Receive one datagram, act on it, and multicast any response.
+    ///
+    /// This is the whole peer-symmetric loop body: a `Digest` we hear may make us
+    /// send a `Want`; a `Want` we hear may make us send a `Delta`; a `Delta` we
+    /// hear we apply idempotently.
+    pub async fn recv_and_handle(&self, local: &LocalDb, config: &Config) -> Result<GossipEvent> {
+        let mut buf = vec![0u8; RECV_BUF];
+        let (n, _addr) = self
+            .socket
+            .recv_from(&mut buf)
+            .await
+            .map_err(|e| SyncError::Broadcast(format!("multicast recv: {e}")))?;
+        let (event, out) = self.handle(&buf[..n], local, config).await?;
+        self.emit(out).await?;
+        Ok(event)
+    }
+
+    /// Decode, validate, and decide on one raw datagram. Returns the local effect
+    /// plus any datagrams to multicast in response. Pure of socket I/O so the
+    /// full protocol is testable deterministically (see tests).
+    pub async fn handle(
+        &self,
+        datagram: &[u8],
+        local: &LocalDb,
+        config: &Config,
+    ) -> Result<(GossipEvent, Vec<Body>)> {
+        let none = Vec::new();
+        let plain = match maybe_decrypt(datagram, &self.key)? {
+            Some(p) => p,
+            None => return Ok((GossipEvent::Ignored(IgnoreReason::Undecryptable), none)),
+        };
+        let msg = match Msg::from_bytes(&plain) {
+            Ok(m) => m,
+            Err(_) => return Ok((GossipEvent::Ignored(IgnoreReason::Malformed), none)),
+        };
+        if msg.version != PROTOCOL_VERSION {
+            return Ok((GossipEvent::Ignored(IgnoreReason::Version), none));
+        }
+        if msg.db_path_hash != self.db_path_hash {
+            return Ok((GossipEvent::Ignored(IgnoreReason::OtherDb), none));
+        }
+
+        match msg.body {
+            Body::Digest(d) => self.on_digest(d, local, config).await,
+            Body::Want(w) => self.on_want(w, local, config).await,
+            Body::Delta(d) => self.on_delta(d, local, config).await,
+        }
+    }
+
+    async fn on_digest(
+        &self,
+        d: DigestPacket,
+        local: &LocalDb,
+        config: &Config,
+    ) -> Result<(GossipEvent, Vec<Body>)> {
+        if d.source_id == self.instance_id {
+            return Ok((GossipEvent::Ignored(IgnoreReason::SelfOrigin), Vec::new()));
+        }
+        if !self.replay.lock().await.check(&d.source_id, d.seq) {
+            return Ok((GossipEvent::Ignored(IgnoreReason::Replay), Vec::new()));
+        }
+        if !config.should_sync_table(&d.table) {
+            return Ok((GossipEvent::Ignored(IgnoreReason::Table), Vec::new()));
+        }
+
+        let local_hashes = match self.row_hashes(local, config, &d.table).await {
+            Ok(h) => h,
+            // No local view (e.g. the table is absent on a late joiner) -> treat
+            // as empty so we want everything the peer advertises.
+            Err(e) => {
+                debug!("no local hashes for '{}' ({}); treating as empty", d.table, e);
+                HashMap::new()
+            }
+        };
+
+        let want = want_set(&d.hashes, &local_hashes);
+        let wanted = want.len();
+        let out = if want.is_empty() {
+            Vec::new()
+        } else {
+            vec![Body::Want(WantPacket {
+                source_id: self.instance_id.clone(),
+                table: d.table.clone(),
+                pks: want,
+            })]
+        };
+        Ok((GossipEvent::Digest { table: d.table, wanted }, out))
+    }
+
+    async fn on_want(
+        &self,
+        w: WantPacket,
+        local: &LocalDb,
+        config: &Config,
+    ) -> Result<(GossipEvent, Vec<Body>)> {
+        if w.source_id == self.instance_id {
+            return Ok((GossipEvent::Ignored(IgnoreReason::SelfOrigin), Vec::new()));
+        }
+        if !config.should_sync_table(&w.table) || w.pks.is_empty() {
+            return Ok((GossipEvent::Ignored(IgnoreReason::Table), Vec::new()));
+        }
+        let rows = match local.get_rows(&w.table, &w.pks).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("cannot serve '{}': {}", w.table, e);
+                return Ok((GossipEvent::Served { table: w.table, rows: 0 }, Vec::new()));
+            }
+        };
+        if rows.is_empty() {
+            return Ok((GossipEvent::Served { table: w.table, rows: 0 }, Vec::new()));
+        }
+        let n = rows.len();
+        let out = self.delta_bodies(&w.table, rows, Vec::new())?;
+        Ok((GossipEvent::Served { table: w.table, rows: n }, out))
+    }
+
+    async fn on_delta(
+        &self,
+        d: DeltaPacket,
+        local: &LocalDb,
+        config: &Config,
+    ) -> Result<(GossipEvent, Vec<Body>)> {
+        if d.source_id == self.instance_id {
+            return Ok((GossipEvent::Ignored(IgnoreReason::SelfOrigin), Vec::new()));
+        }
+        if !self.replay.lock().await.check(&d.source_id, d.seq) {
+            return Ok((GossipEvent::Ignored(IgnoreReason::Replay), Vec::new()));
+        }
+        if !config.should_sync_table(&d.table) {
+            return Ok((GossipEvent::Ignored(IgnoreReason::Table), Vec::new()));
+        }
+
+        let mut changed = 0;
+        if !d.upserts.is_empty() {
+            match local.upsert_rows(&d.table, &d.upserts).await {
+                Ok(n) => changed += n,
+                // Schema is the user's; a row for a missing table is dropped.
+                Err(e) => warn!("drop delta for table '{}': {}", d.table, e),
+            }
+        }
+        if !d.deletes.is_empty() {
+            debug!(
+                "delta carries {} deletes for '{}' (live-path only in v0.1)",
+                d.deletes.len(),
+                d.table
+            );
+        }
+        Ok((GossipEvent::Applied { table: d.table, rows: changed }, Vec::new()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(db_path: &str) -> Config {
+        Config {
+            cloudflare_account_id: None,
+            cloudflare_api_token: None,
+            database_id: None,
+            local_db: Some(db_path.to_string()),
+            sync: crate::config::SyncConfig::default(),
+            stash: None,
+            target: Some(crate::config::TargetConfig::Sqlite {
+                database: "unused".to_string(),
+            }),
+            broadcast: None,
+        }
+    }
+
+    fn seed(path: &str, rows: &[(&str, &str)]) {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT, updated_at TEXT);",
+        )
+        .unwrap();
+        for (id, name) in rows {
+            conn.execute(
+                "INSERT INTO users VALUES (?1, ?2, '2026-01-01T00:00:00Z')",
+                [id, name],
+            )
+            .unwrap();
+        }
+    }
+
+    fn count(path: &str) -> i64 {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM users", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    fn name_of(path: &str, id: &str) -> Option<String> {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.query_row("SELECT name FROM users WHERE id = ?1", [id], |r| r.get(0))
+            .ok()
+    }
+
+    #[test]
+    fn msg_tag_roundtrip() {
+        for body in [
+            Body::Want(WantPacket {
+                source_id: "a".into(),
+                table: "users".into(),
+                pks: vec!["1".into()],
+            }),
+            Body::Digest(DigestPacket {
+                source_id: "a".into(),
+                seq: 7,
+                part: 0,
+                total_parts: 1,
+                table: "users".into(),
+                hashes: HashMap::from([("1".into(), "h".into())]),
+            }),
+        ] {
+            let msg = Msg::new("db".into(), body);
+            let bytes = msg.to_bytes().unwrap();
+            assert_eq!(Msg::from_bytes(&bytes).unwrap(), msg);
+        }
+    }
+
+    #[test]
+    fn want_set_lacks_and_differs() {
+        let peer = HashMap::from([
+            ("1".to_string(), "h1".to_string()),
+            ("2".to_string(), "h2".to_string()),
+            ("3".to_string(), "h3".to_string()),
+        ]);
+        let local = HashMap::from([
+            ("1".to_string(), "h1".to_string()), // identical -> skip
+            ("2".to_string(), "DIFFERENT".to_string()), // differ -> want
+            // 3 missing -> want
+        ]);
+        let mut got = want_set(&peer, &local);
+        got.sort();
+        assert_eq!(got, vec!["2".to_string(), "3".to_string()]);
+    }
+
+    #[test]
+    fn split_digest_chunks_large_maps() {
+        let big: HashMap<String, String> = (0..2000)
+            .map(|i| (format!("pk-{i:08}"), format!("hash-{i:016}")))
+            .collect();
+        let parts = split_digest("node", "users", big.clone()).unwrap();
+        assert!(parts.len() > 1, "2000 entries must span multiple datagrams");
+        // Each part fits the wire, parts are numbered 0..total, union is lossless.
+        let total = parts.len() as u16;
+        let mut nums = std::collections::HashSet::new();
+        let mut reunion = HashMap::new();
+        for p in &parts {
+            let sealed = Msg::new("db".into(), Body::Digest(p.clone()))
+                .to_bytes()
+                .unwrap();
+            assert!(sealed.len() <= SAFE_PACKET_SIZE, "part exceeds safe size");
+            assert_eq!(p.total_parts, total, "total_parts set on every part");
+            assert!(nums.insert(p.part), "part numbers must be unique");
+            reunion.extend(p.hashes.clone());
+        }
+        assert_eq!(reunion, big, "chunking must be lossless");
+    }
+
+    /// Bind two gossip nodes that share one logical DB but have distinct ids.
+    async fn two_nodes(
+        a_path: &str,
+        b_path: &str,
+    ) -> (Gossip, Config, LocalDb, Gossip, Config, LocalDb) {
+        let a_cfg = cfg(a_path);
+        let b_cfg = cfg(b_path);
+        let a_local = LocalDb::open(a_path).unwrap();
+        let b_local = LocalDb::open(b_path).unwrap();
+
+        let db_hash = crate::broadcast::hash_db_path("shared-logical-db");
+        let mut bc_a = BroadcastConfig::default();
+        bc_a.instance_id = Some("node-a".into());
+        let mut bc_b = bc_a.clone();
+        bc_b.instance_id = Some("node-b".into());
+
+        let group = Ipv4Addr::new(239, 255, 99, 88);
+        let a = Gossip::bind(&bc_a, db_hash.clone(), group).await.unwrap();
+        let b = Gossip::bind(&bc_b, db_hash, group).await.unwrap();
+        (a, a_cfg, a_local, b, b_cfg, b_local)
+    }
+
+    /// Deliver one body emitted by `sender` into `receiver` -- faithful wire
+    /// path (seal -> JSON+AEAD -> handle), no socket-delivery dependency.
+    async fn route(
+        sender: &Gossip,
+        body: Body,
+        receiver: &Gossip,
+        rlocal: &LocalDb,
+        rcfg: &Config,
+    ) -> (GossipEvent, Vec<Body>) {
+        let sealed = sender.seal(body).unwrap();
+        receiver.handle(&sealed, rlocal, rcfg).await.unwrap()
+    }
+
+    fn only(mut bodies: Vec<Body>) -> Body {
+        assert_eq!(bodies.len(), 1, "expected exactly one response body");
+        bodies.remove(0)
+    }
+
+    // The full masterless cycle: late joiner converges, divergent edit converges
+    // (received wins), and a replayed delta is dropped. Deterministic: every
+    // datagram is routed by hand, so this proves the protocol independent of
+    // whether the host actually delivers multicast.
+    #[tokio::test]
+    async fn masterless_convergence_late_joiner_and_idempotency() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+
+        // A holds Alice+Bob; B is an empty late joiner with the table only.
+        seed(&a_path, &[("1", "Alice"), ("2", "Bob")]);
+        seed(&b_path, &[]);
+        let (a, a_cfg, a_local, b, b_cfg, b_local) = two_nodes(&a_path, &b_path).await;
+
+        // 1) A heartbeats one digest part.
+        let mut digests = a.digest_bodies(&a_local, &a_cfg).await.unwrap();
+        assert_eq!(digests.len(), 1, "one digest part for a small table");
+        let digest = digests.remove(0);
+
+        // 2) B hears it and wants both rows.
+        let (ev, out) = route(&a, digest, &b, &b_local, &b_cfg).await;
+        assert!(matches!(ev, GossipEvent::Digest { wanted: 2, .. }), "got {ev:?}");
+        let want = only(out);
+
+        // 3) A hears the want and serves both rows.
+        let (ev, out) = route(&b, want, &a, &a_local, &a_cfg).await;
+        assert!(matches!(ev, GossipEvent::Served { rows: 2, .. }), "got {ev:?}");
+        let delta = only(out);
+
+        // 4) B hears the delta and applies -> converged.
+        let (ev, out) = route(&a, delta.clone(), &b, &b_local, &b_cfg).await;
+        assert!(matches!(ev, GossipEvent::Applied { rows: 2, .. }), "got {ev:?}");
+        assert!(out.is_empty());
+        assert_eq!(count(&b_path), 2, "late joiner B converged to A");
+        assert_eq!(name_of(&b_path, "1").as_deref(), Some("Alice"));
+
+        // 4b) Replaying the very same delta is dropped by the replay guard.
+        let (ev, _) = route(&a, delta, &b, &b_local, &b_cfg).await;
+        assert!(matches!(ev, GossipEvent::Ignored(IgnoreReason::Replay)), "got {ev:?}");
+
+        // 5) Divergent edit: A changes Alice, re-heartbeats; B pulls and the
+        //    received row wins.
+        {
+            let conn = rusqlite::Connection::open(&a_path).unwrap();
+            conn.execute("UPDATE users SET name = 'Alice2' WHERE id = '1'", [])
+                .unwrap();
+        }
+        let digest = only(a.digest_bodies(&a_local, &a_cfg).await.unwrap());
+        let (ev, out) = route(&a, digest, &b, &b_local, &b_cfg).await;
+        assert!(matches!(ev, GossipEvent::Digest { wanted: 1, .. }), "got {ev:?}");
+        let (_ev, out) = route(&b, only(out), &a, &a_local, &a_cfg).await;
+        let (ev, _) = route(&a, only(out), &b, &b_local, &b_cfg).await;
+        assert!(matches!(ev, GossipEvent::Applied { .. }), "got {ev:?}");
+        assert_eq!(
+            name_of(&b_path, "1").as_deref(),
+            Some("Alice2"),
+            "divergent row resolves last-received-wins"
+        );
+    }
+
+    // Live multicast smoke test: proves bind/join/send/recv over a real socket.
+    // #[ignore] because multicast loopback delivery is environment-dependent
+    // (interface selection, container netns, CI sandboxes). Run on real LAN
+    // hardware: `cargo test -p smugglr-core multicast -- --ignored`.
+    #[tokio::test]
+    #[ignore = "requires multicast-capable loopback; run on real hardware"]
+    async fn live_multicast_digest_delivers() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+        seed(&a_path, &[("1", "Alice")]);
+        seed(&b_path, &[]);
+        let (a, a_cfg, a_local, b, b_cfg, b_local) = two_nodes(&a_path, &b_path).await;
+
+        a.broadcast_digests(&a_local, &a_cfg).await.unwrap();
+        loop {
+            let ev = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                b.recv_and_handle(&b_local, &b_cfg),
+            )
+            .await
+            .expect("multicast recv timed out")
+            .expect("recv error");
+            if let GossipEvent::Digest { wanted, .. } = ev {
+                assert_eq!(wanted, 1, "B should want Alice over the wire");
+                break;
+            }
+        }
+    }
+}

--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -456,7 +456,10 @@ impl Gossip {
             // No local view (e.g. the table is absent on a late joiner) -> treat
             // as empty so we want everything the peer advertises.
             Err(e) => {
-                debug!("no local hashes for '{}' ({}); treating as empty", d.table, e);
+                debug!(
+                    "no local hashes for '{}' ({}); treating as empty",
+                    d.table, e
+                );
                 HashMap::new()
             }
         };
@@ -472,7 +475,13 @@ impl Gossip {
                 pks: want,
             })]
         };
-        Ok((GossipEvent::Digest { table: d.table, wanted }, out))
+        Ok((
+            GossipEvent::Digest {
+                table: d.table,
+                wanted,
+            },
+            out,
+        ))
     }
 
     async fn on_want(
@@ -491,15 +500,33 @@ impl Gossip {
             Ok(r) => r,
             Err(e) => {
                 warn!("cannot serve '{}': {}", w.table, e);
-                return Ok((GossipEvent::Served { table: w.table, rows: 0 }, Vec::new()));
+                return Ok((
+                    GossipEvent::Served {
+                        table: w.table,
+                        rows: 0,
+                    },
+                    Vec::new(),
+                ));
             }
         };
         if rows.is_empty() {
-            return Ok((GossipEvent::Served { table: w.table, rows: 0 }, Vec::new()));
+            return Ok((
+                GossipEvent::Served {
+                    table: w.table,
+                    rows: 0,
+                },
+                Vec::new(),
+            ));
         }
         let n = rows.len();
         let out = self.delta_bodies(&w.table, rows, Vec::new())?;
-        Ok((GossipEvent::Served { table: w.table, rows: n }, out))
+        Ok((
+            GossipEvent::Served {
+                table: w.table,
+                rows: n,
+            },
+            out,
+        ))
     }
 
     async fn on_delta(
@@ -533,7 +560,13 @@ impl Gossip {
                 d.table
             );
         }
-        Ok((GossipEvent::Applied { table: d.table, rows: changed }, Vec::new()))
+        Ok((
+            GossipEvent::Applied {
+                table: d.table,
+                rows: changed,
+            },
+            Vec::new(),
+        ))
     }
 }
 
@@ -558,10 +591,8 @@ mod tests {
 
     fn seed(path: &str, rows: &[(&str, &str)]) {
         let conn = rusqlite::Connection::open(path).unwrap();
-        conn.execute_batch(
-            "CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT, updated_at TEXT);",
-        )
-        .unwrap();
+        conn.execute_batch("CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT, updated_at TEXT);")
+            .unwrap();
         for (id, name) in rows {
             conn.execute(
                 "INSERT INTO users VALUES (?1, ?2, '2026-01-01T00:00:00Z')",
@@ -616,7 +647,7 @@ mod tests {
         let local = HashMap::from([
             ("1".to_string(), "h1".to_string()), // identical -> skip
             ("2".to_string(), "DIFFERENT".to_string()), // differ -> want
-            // 3 missing -> want
+                                                 // 3 missing -> want
         ]);
         let mut got = want_set(&peer, &local);
         got.sort();
@@ -657,10 +688,14 @@ mod tests {
         let b_local = LocalDb::open(b_path).unwrap();
 
         let db_hash = crate::broadcast::hash_db_path("shared-logical-db");
-        let mut bc_a = BroadcastConfig::default();
-        bc_a.instance_id = Some("node-a".into());
-        let mut bc_b = bc_a.clone();
-        bc_b.instance_id = Some("node-b".into());
+        let bc_a = BroadcastConfig {
+            instance_id: Some("node-a".into()),
+            ..Default::default()
+        };
+        let bc_b = BroadcastConfig {
+            instance_id: Some("node-b".into()),
+            ..Default::default()
+        };
 
         let group = Ipv4Addr::new(239, 255, 99, 88);
         let a = Gossip::bind(&bc_a, db_hash.clone(), group).await.unwrap();
@@ -708,24 +743,36 @@ mod tests {
 
         // 2) B hears it and wants both rows.
         let (ev, out) = route(&a, digest, &b, &b_local, &b_cfg).await;
-        assert!(matches!(ev, GossipEvent::Digest { wanted: 2, .. }), "got {ev:?}");
+        assert!(
+            matches!(ev, GossipEvent::Digest { wanted: 2, .. }),
+            "got {ev:?}"
+        );
         let want = only(out);
 
         // 3) A hears the want and serves both rows.
         let (ev, out) = route(&b, want, &a, &a_local, &a_cfg).await;
-        assert!(matches!(ev, GossipEvent::Served { rows: 2, .. }), "got {ev:?}");
+        assert!(
+            matches!(ev, GossipEvent::Served { rows: 2, .. }),
+            "got {ev:?}"
+        );
         let delta = only(out);
 
         // 4) B hears the delta and applies -> converged.
         let (ev, out) = route(&a, delta.clone(), &b, &b_local, &b_cfg).await;
-        assert!(matches!(ev, GossipEvent::Applied { rows: 2, .. }), "got {ev:?}");
+        assert!(
+            matches!(ev, GossipEvent::Applied { rows: 2, .. }),
+            "got {ev:?}"
+        );
         assert!(out.is_empty());
         assert_eq!(count(&b_path), 2, "late joiner B converged to A");
         assert_eq!(name_of(&b_path, "1").as_deref(), Some("Alice"));
 
         // 4b) Replaying the very same delta is dropped by the replay guard.
         let (ev, _) = route(&a, delta, &b, &b_local, &b_cfg).await;
-        assert!(matches!(ev, GossipEvent::Ignored(IgnoreReason::Replay)), "got {ev:?}");
+        assert!(
+            matches!(ev, GossipEvent::Ignored(IgnoreReason::Replay)),
+            "got {ev:?}"
+        );
 
         // 5) Divergent edit: A changes Alice, re-heartbeats; B pulls and the
         //    received row wins.
@@ -736,7 +783,10 @@ mod tests {
         }
         let digest = only(a.digest_bodies(&a_local, &a_cfg).await.unwrap());
         let (ev, out) = route(&a, digest, &b, &b_local, &b_cfg).await;
-        assert!(matches!(ev, GossipEvent::Digest { wanted: 1, .. }), "got {ev:?}");
+        assert!(
+            matches!(ev, GossipEvent::Digest { wanted: 1, .. }),
+            "got {ev:?}"
+        );
         let (_ev, out) = route(&b, only(out), &a, &a_local, &a_cfg).await;
         let (ev, _) = route(&a, only(out), &b, &b_local, &b_cfg).await;
         assert!(matches!(ev, GossipEvent::Applied { .. }), "got {ev:?}");

--- a/crates/smugglr/src/broadcast.rs
+++ b/crates/smugglr/src/broadcast.rs
@@ -1,27 +1,35 @@
-//! Broadcast daemon loop (CLI layer).
+//! Broadcast daemon loop (CLI layer) -- the LAN broadcast shape.
 //!
-//! The engine logic (peer discovery, delta protocol, TCP sync) lives in
-//! `smugglr_core::broadcast`. This module provides the daemon loop that
-//! ties it all together with signal handling and PID locking.
+//! `smugglr broadcast` is masterless multicast gossip: every node runs this
+//! identical loop, multicasting its content-hash digest and applying rows it
+//! hears, so two or two hundred nodes on a subnet converge automatically with no
+//! coordinator. The engine is `smugglr_core::multicast`.
+//!
+//! This is deliberately NOT the TCP path. TCP (`smugglr_core::broadcast`'s
+//! framed sync envelope, #90) is a different shape: cross-process and
+//! cross-subnet sync, where an embedder bridges what multicast cannot reach.
+//! Both shapes coexist; this daemon drives the multicast one.
 
-use smugglr_core::broadcast::{
-    broadcast_pid_lock_path, handle_sync_connection, hash_db_path, run_broadcast_once,
-    BroadcastConfig, Peer, PeerDiscovery, ReplayGuard,
-};
+use smugglr_core::broadcast::{broadcast_pid_lock_path, hash_db_path, BroadcastConfig};
 use smugglr_core::config::Config;
 use smugglr_core::daemon::PidLock;
-use smugglr_core::error::{Result, SyncError};
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use smugglr_core::error::Result;
+use smugglr_core::multicast::{Gossip, GossipEvent, DEFAULT_GROUP};
+use smugglr_core::LocalDb;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
 /// Run the broadcast daemon loop.
 ///
-/// Starts a TCP sync server, discovers peers via UDP broadcast, and
-/// exchanges deltas on each interval tick. When `once` is true, runs
-/// a single cycle and exits. When `dry_run` is true, logs what would
-/// happen but does not apply deltas.
+/// Joins the multicast group, then runs the masterless gossip loop: a continuous
+/// listener applying inbound rows and answering pulls, plus a heartbeat that
+/// multicasts this node's `primary_key -> content_hash` digest each interval. A
+/// peer that hears a digest covering rows it lacks pulls them; whoever holds
+/// them multicasts the rows, so every listener converges from one answer.
+///
+/// - `once`: send a single heartbeat, converge briefly, then exit.
+/// - `dry_run`: report the digest this node would advertise; send/apply nothing.
 pub async fn run_broadcast(
     config: &Config,
     config_path: &std::path::Path,
@@ -37,125 +45,78 @@ pub async fn run_broadcast(
 
     let db_path_hash = hash_db_path(config.local_db_path());
     let instance_id = broadcast_config.resolve_instance_id();
-    let port = broadcast_config.port;
+    let interval_secs = broadcast_config.interval_secs;
 
     info!(
-        "Starting broadcast daemon (port: {}, interval: {}s, instance: {}, dry_run: {})",
-        port, broadcast_config.interval_secs, instance_id, dry_run
+        "Starting masterless multicast sync (group {}, port {}, interval {}s, instance {}, dry_run {})",
+        DEFAULT_GROUP, broadcast_config.port, interval_secs, instance_id, dry_run
     );
 
-    // Shared replay guard across TCP server and sync loop
-    let replay_guard = Arc::new(tokio::sync::Mutex::new(ReplayGuard::new()));
+    let local = Arc::new(LocalDb::open(config.local_db_path())?);
 
-    // Start TCP sync server in background
-    let tcp_config = config.clone();
-    let tcp_broadcast_config = broadcast_config.clone();
-    let tcp_db_path_hash = db_path_hash.clone();
-    let tcp_replay_guard = replay_guard.clone();
-    let tcp_addr: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port));
+    if dry_run {
+        // Advertise nothing, apply nothing -- just report what we would gossip.
+        let gossip = Gossip::bind(broadcast_config, db_path_hash, DEFAULT_GROUP).await?;
+        let bodies = gossip.digest_bodies(&local, config).await?;
+        info!(
+            "Dry run: would multicast {} digest datagram(s); not sending, not applying",
+            bodies.len()
+        );
+        return Ok(());
+    }
 
-    let tcp_listener = tokio::net::TcpListener::bind(tcp_addr).await.map_err(|e| {
-        SyncError::Broadcast(format!(
-            "TCP bind {}:{}: {}",
-            Ipv4Addr::UNSPECIFIED,
-            port,
-            e
-        ))
-    })?;
+    let gossip = Arc::new(Gossip::bind(broadcast_config, db_path_hash, DEFAULT_GROUP).await?);
 
-    info!("TCP sync server listening on port {}", port);
-
-    let server_handle = tokio::spawn(async move {
-        loop {
-            match tcp_listener.accept().await {
-                Ok((stream, addr)) => {
-                    debug!("Accepted TCP connection from {}", addr);
-                    if let Err(e) = handle_sync_connection(
-                        stream,
-                        &tcp_config,
-                        &tcp_broadcast_config,
-                        &tcp_db_path_hash,
-                        &tcp_replay_guard,
-                    )
-                    .await
-                    {
-                        warn!("Error handling sync connection from {}: {}", addr, e);
+    // Continuous listener. A masterless node keeps gossiping through transient
+    // errors, so a recv failure is logged, never fatal.
+    let recv_handle = {
+        let gossip = gossip.clone();
+        let local = local.clone();
+        let config = config.clone();
+        tokio::spawn(async move {
+            loop {
+                match gossip.recv_and_handle(&local, &config).await {
+                    Ok(GossipEvent::Applied { table, rows }) if rows > 0 => {
+                        info!("Applied {} row(s) to '{}'", rows, table)
                     }
-                }
-                Err(e) => {
-                    warn!("TCP accept error: {}", e);
+                    Ok(GossipEvent::Served { table, rows }) if rows > 0 => {
+                        debug!("Served {} row(s) of '{}'", rows, table)
+                    }
+                    Ok(_) => {}
+                    Err(e) => warn!("gossip recv: {}", e),
                 }
             }
-        }
-    });
+        })
+    };
 
-    let interval_secs = broadcast_config.interval_secs;
-    let mut tick_count: u64 = 0;
+    if once {
+        gossip.broadcast_digests(&local, config).await?;
+        info!("Single heartbeat sent; converging briefly...");
+        time::sleep(Duration::from_secs(interval_secs.clamp(1, 5))).await;
+        recv_handle.abort();
+        info!("Single cycle complete, exiting");
+        return Ok(());
+    }
+
+    let mut tick: u64 = 0;
     let mut interval = time::interval(Duration::from_secs(interval_secs));
-
     loop {
         tokio::select! {
             _ = interval.tick() => {
-                tick_count += 1;
-                info!("Broadcast tick #{}", tick_count);
-
-                if dry_run {
-                    // In dry_run mode, just discover peers and report
-                    let discovery = PeerDiscovery::new(
-                        broadcast_config.clone(),
-                        db_path_hash.clone(),
-                    ).await?;
-                    let listen_dur = Duration::from_secs(interval_secs.min(5));
-                    let peers = discovery.discover_once(listen_dur).await?;
-                    let compatible: Vec<&Peer> = peers
-                        .iter()
-                        .filter(|p| p.db_path_hash == db_path_hash)
-                        .collect();
-                    info!(
-                        "Tick #{} (dry run): {} peers discovered, {} compatible",
-                        tick_count, peers.len(), compatible.len()
-                    );
-                    for peer in &compatible {
-                        info!(
-                            "  Would sync with: {} at {}",
-                            peer.instance_id, peer.addr
-                        );
-                    }
-                } else {
-                    match run_broadcast_once(config, broadcast_config, &replay_guard).await {
-                        Ok(result) => {
-                            if result.rows_received > 0 || result.rows_sent > 0 {
-                                info!(
-                                    "Tick #{}: {} peers synced, {} rows received, {} rows sent",
-                                    tick_count, result.peers_synced,
-                                    result.rows_received, result.rows_sent
-                                );
-                            } else {
-                                info!(
-                                    "Tick #{}: {} peers discovered, no changes",
-                                    tick_count, result.peers_discovered
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            warn!("Broadcast tick #{} failed: {}", tick_count, e);
-                        }
-                    }
-                }
-
-                if once {
-                    info!("Single cycle complete, exiting");
-                    break;
+                tick += 1;
+                match gossip.broadcast_digests(&local, config).await {
+                    Ok(n) => info!("Heartbeat #{}: multicast {} digest datagram(s)", tick, n),
+                    Err(e) => warn!("Heartbeat #{} failed: {}", tick, e),
                 }
             }
             _ = signal::ctrl_c() => {
-                info!("Received shutdown signal. Stopping broadcast daemon.");
+                info!("Received shutdown signal. Stopping multicast sync.");
                 break;
             }
         }
     }
 
-    server_handle.abort();
-    info!("Broadcast daemon stopped after {} ticks", tick_count);
+    recv_handle.abort();
+    info!("Multicast sync stopped after {} heartbeat(s)", tick);
     Ok(())
 }

--- a/docs/plans/masterless-multicast-sync.md
+++ b/docs/plans/masterless-multicast-sync.md
@@ -1,0 +1,142 @@
+# Masterless multicast anti-entropy sync (v0.1)
+
+**Status:** building
+**Spec source of truth:** `vault/site/homepage.md` -> "LAN broadcast semantics"
+(the 7 bullets, reproduced below). The smugglr.dev copy is the contract; the
+current implementation diverges from it and that divergence is the bug.
+
+## The spec (canonical, do not paraphrase away)
+
+- **Masterless.** No primary, secondary, coordinator, or leader election. Every
+  node equal.
+- **Peer-symmetric.** Every node is both broadcaster and listener. No
+  client/server distinction.
+- **Membership = key possession.** The shared encryption key IS access control.
+  Have the key, you are on the network. Key rotation is how a machine leaves.
+- **Idempotent apply.** Incoming row compared to local content hash: new/different
+  -> upsert, identical -> skip. Apply-twice is a no-op, so **lost packets are safe**.
+- **Last-received-wins on divergence.** Same PK, different contents -> receiver
+  replaces local with incoming. UUIDv7 PKs make concurrent divergence rare. **No
+  vector clocks, no CRDTs.**
+- **Heartbeat reconciliation.** Every node periodically broadcasts a
+  **primary_key -> content_hash map for all rows it holds**. Peers compare against
+  local state and **pull any missing or differing rows**. Covers late joiners,
+  missed packets, partition rejoin.
+- **Encryption.** XChaCha20-Poly1305 AEAD, shared 256-bit key, unique per-datagram
+  nonce. User-managed key; smugglr reads it, never generates or stores it.
+
+The load-bearing consequence: "idempotent apply", "lost packets are safe", and
+"last-RECEIVED-wins" only make sense if **row data rides lossy UDP multicast**.
+TCP would make loss impossible and reception order deterministic, so those bullets
+would be meaningless. **The transport is UDP multicast, end to end. No TCP.**
+
+## Two shapes, not one transport (the correction)
+
+smugglr has multiple sync **shapes**; this work is about exactly one of them.
+
+- **LAN broadcast shape** (`smugglr broadcast`): masterless multicast gossip,
+  built here. Scales to 2 or 200 nodes on a subnet with no coordinator -- one
+  multicast send reaches every peer, so digest fan-out and row convergence are
+  O(N), not the O(N^2) of pairwise connections.
+- **Cross-process / cross-subnet shape** (#90 TCP framing envelope,
+  `handle_sync_connection`/`sync_with_peer`/`write_framed`): **retained, not
+  touched.** Multicast does not cross routers; TCP is how an embedder (e.g.
+  legion) bridges processes or subnets the multicast fabric cannot reach.
+
+The bug was never "TCP exists." It was that the LAN broadcast shape *claimed*
+masterless multicast but actually did **client-initiated pairwise TCP**
+(`run_broadcast_once` dumping full pk->hash maps to every peer) -- which cannot
+auto-sync 200 nodes. That pairwise-over-TCP behavior in the LAN daemon is what
+the multicast gossip replaces. The TCP primitives stay in `smugglr-core` for the
+cross-process shape.
+
+## Why the LAN fabric must be pure multicast (rows included)
+
+"Two or two hundred nodes all automatically synced" forces it: a single multicast
+datagram reaches the whole group, so a digest or a served row converges every
+peer at once. This is also why the spec insists on idempotent apply,
+lost-packets-safe, and last-received-wins -- those properties are only meaningful
+because the **rows themselves ride lossy UDP multicast**, not a reliable stream.
+
+## Target protocol (UDP multicast only)
+
+One multicast group (default `239.255.43.21:<port>`, configurable), all nodes
+join, all datagrams `maybe_encrypt`-wrapped with the shared key. Tagged envelope:
+
+```rust
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "t")]
+enum Msg {
+    Digest(DigestPacket), // pk -> content_hash map for a table (heartbeat)
+    Want(WantPacket),     // table + pks this node is missing/divergent on
+    Delta(DeltaPacket),   // rows (upserts + deletes); already exists
+}
+```
+
+Bumps wire `PROTOCOL_VERSION` 1 -> 2 (the UDP payload shape changes). v1 nodes
+(legion's pinned v0.2.1, #536) version-skip until they upgrade. Inherent to any
+real protocol here -- flagged to legion, noted in CHANGELOG.
+
+### Loops (identical on every node -- peer-symmetric)
+
+**Emit (heartbeat, every `interval_secs`):** for each syncable table, build
+pk->content_hash via `LocalDb::get_row_metadata`, chunk to `SAFE_PACKET_SIZE`
+(reuse the `split_delta` sizing), multicast each chunk as `Digest`.
+
+**Emit (live write):** on a local change, multicast the changed rows as `Delta`
+immediately (optimistic). Heartbeat reconciles anything lost.
+
+**Receive `Digest`:** reassemble peer chunks (replay-guard on source_id+seq).
+Compute want-set = pks the peer advertises that we **lack or hash-differ** on.
+Non-empty -> multicast `Want(table, pks)`.
+
+**Receive `Want`:** for pks we hold, multicast `Delta` with those rows. Multicast
+(not unicast) so every peer converges from one answer -- no client/server.
+
+**Receive `Delta`:** idempotent last-received-wins apply -- compare incoming row
+content hash to local; new/different -> upsert (replace), identical -> skip.
+Deletes applied from `Delta.deletes`.
+
+**Late joiner / partition rejoin:** empty/stale node hears the next `Digest`,
+every advertised pk diverges, it `Want`s and converges. Falls out of the loop, no
+special case.
+
+## What we reuse vs build
+
+Reuse (already present + tested): `DeltaPacket`, `split_delta`/`reassemble_delta`,
+`SequenceTracker`, `ReplayGuard`, `maybe_encrypt`/`maybe_decrypt`,
+`get_row_metadata`, `upsert_rows`.
+
+Build: multicast group join (replace 255.255.255.255 broadcast); `Msg` envelope +
+`DigestPacket`/`WantPacket`; the digest-chunk + want-set computation; the single
+multicast send/recv loop; idempotent last-received-wins apply path; wire into the
+daemon (`crates/smugglr/src/broadcast.rs`, the `run_broadcast_once` callers at
+:8 and :125 per `legion sym refs`).
+
+Keep, untouched: the TCP path -- `handle_sync_connection`, `sync_with_peer`,
+`write_framed`/`read_framed`, `SyncRequest`/`SyncResponse`. It is the
+cross-process/cross-subnet shape (#90), not part of the LAN fabric. The only LAN
+change is that `smugglr broadcast` stops doing pairwise-TCP and runs multicast
+gossip instead.
+
+## v0.1 limits (documented, not hidden)
+
+- **Deletes** propagate via the live `Delta.deletes` path only. The heartbeat
+  digest advertises presence, so it reconciles upserts/divergence, NOT deletions
+  (an absent pk is indistinguishable from not-yet-received). Tombstone propagation
+  = v0.2. Stated in README.
+- **Large tables** re-advertise the full pk->hash map each heartbeat. Merkle /
+  bucketed digests to skip unchanged state = v0.2.
+- **Unencrypted mode** exposes pk+hash+rows on the group (same as today's deltas).
+  Membership=key means running without a key = no membership control; warn.
+
+## Test plan (must pass before "done" -- no multi-machine claim)
+
+- Unit: `Msg` tag round-trip; `DigestPacket` split/reassemble; want-set
+  (lack/differ/identical); v1 version-skip; idempotent apply (apply-twice no-op);
+  last-received-wins replace.
+- Integration (loopback multicast, two `LocalDb`s on one group): A has rows B
+  lacks -> B converges within N heartbeats; mutate A row -> B converges; B joins
+  empty -> converges; drop/duplicate a Delta -> still converges (idempotency).
+- Multi-machine (cross-subnet, real Wi-Fi) needs Sean's hardware -- out of CI,
+  stated plainly, not implied.


### PR DESCRIPTION
Closes #133.

## Why

`smugglr broadcast` advertised masterless UDP multicast (smugglr.dev / vault homepage "LAN broadcast semantics") but never delivered it: the UDP socket carried only a bare existence `Announcement`, and rows moved via client-initiated **pairwise TCP** full-state sync. That is O(N^2) and cannot auto-sync 2-or-200 nodes. The promise was vaporware. This makes it real.

## What

New `smugglr_core::multicast`: one XChaCha20-sealed, db-scoped, replay-guarded multicast group. `Digest` (pk->content_hash heartbeat) -> `Want` -> `Delta`, one symmetric loop every node runs. A single multicast send reaches the whole group, so digest fan-out and row convergence are O(N); a served row converges every listener at once. Idempotent last-received-wins apply. Reuses the previously-stranded `split_delta`/`ReplayGuard`/`maybe_encrypt` plumbing. `smugglr broadcast` daemon rewired to the gossip loop.

## Two shapes, both intact

- **LAN broadcast = masterless multicast** (this PR). No TCP between LAN peers.
- **TCP framing (#90 cross-process/cross-subnet shape) = retained, untouched.** Multicast cannot cross routers; TCP bridges what it cannot reach. Its 3 integration tests still pass.

## Verification

- Deterministic protocol tests (real seal->handle wire path): convergence, late-joiner, divergent-edit (received-wins), replay-drop, digest chunking, want-set.
- 191 core + 11 CLI tests green; clippy clean (MSRV 1.75).
- Live-multicast smoke test `#[ignore]`'d -- delivery is environment-dependent. **Needs real-LAN hardware validation before release.**

## v0.1 boundaries (documented in-module)

- Concurrent same-PK divergence resolves silently (last-received-wins, no CRDT) -> v0.2 visible-conflict.
- Deletes via the live delta path only -> v0.2 tombstones.

## Breaking + release notes

- **UDP PROTOCOL_VERSION 1 -> 2.** v1 nodes version-skip v2. legion #536 must move to v0.4.0+ to speak v2.
- CHANGELOG entry is staged in the working tree's in-flight 0.4.0 section (kept out of this branch to avoid entangling release-prep). **Given the breaking wire bump, release owner decides 0.4.0 vs 0.5.0.**