### PR TITLE
fix(#133): scope masterless sync by key not path + fix LAN example

### DIFF
--- a/crates/smugglr-core/src/broadcast.rs
+++ b/crates/smugglr-core/src/broadcast.rs
@@ -25,10 +25,15 @@ use tracing::{debug, info, warn};
 
 /// Protocol version for UDP packets. Bump on breaking wire changes.
 ///
-/// v2 introduced the masterless multicast gossip envelope (`multicast::Msg`:
-/// `Digest`/`Want`/`Delta`). v1 nodes (which only spoke bare `Announcement`)
-/// version-skip a v2 node and vice versa -- there is no cross-version sync.
-pub(crate) const PROTOCOL_VERSION: u8 = 2;
+/// - v2 introduced the masterless multicast gossip envelope (`multicast::Msg`:
+///   `Digest`/`Want`/`Delta`).
+/// - v3 removed the `db_path_hash` field from that envelope: membership is the
+///   shared key + group, never the database's file path. v2 and v3 envelopes are
+///   incompatible, so the version is bumped (v2 was never released).
+///
+/// Nodes on different versions version-skip each other -- there is no
+/// cross-version sync.
+pub(crate) const PROTOCOL_VERSION: u8 = 3;
 
 /// Default UDP port for broadcast discovery.
 pub const DEFAULT_PORT: u16 = 31337;

--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -408,9 +408,15 @@ impl Gossip {
         config: &Config,
     ) -> Result<(GossipEvent, Vec<Body>)> {
         let none = Vec::new();
-        let plain = match maybe_decrypt(datagram, &self.key)? {
-            Some(p) => p,
-            None => return Ok((GossipEvent::Ignored(IgnoreReason::Undecryptable), none)),
+        // A datagram we cannot turn into plaintext is not ours: a foreign key
+        // (AEAD auth failure), a runt packet, or noise. Drop it as a clean,
+        // counted Ignored -- never an error -- so a different-keyed cluster
+        // sharing the LAN is silent, not a stream of recv-error logs.
+        let plain = match maybe_decrypt(datagram, &self.key) {
+            Ok(Some(p)) => p,
+            Ok(None) | Err(_) => {
+                return Ok((GossipEvent::Ignored(IgnoreReason::Undecryptable), none))
+            }
         };
         let msg = match Msg::from_bytes(&plain) {
             Ok(m) => m,
@@ -674,6 +680,17 @@ mod tests {
         a_path: &str,
         b_path: &str,
     ) -> (Gossip, Config, LocalDb, Gossip, Config, LocalDb) {
+        two_nodes_keyed(a_path, b_path, None, None).await
+    }
+
+    /// Like `two_nodes` but with explicit per-node encryption keys (hex), so
+    /// tests can exercise the sealed wire and cross-key isolation.
+    async fn two_nodes_keyed(
+        a_path: &str,
+        b_path: &str,
+        key_a: Option<&str>,
+        key_b: Option<&str>,
+    ) -> (Gossip, Config, LocalDb, Gossip, Config, LocalDb) {
         let a_cfg = cfg(a_path);
         let b_cfg = cfg(b_path);
         let a_local = LocalDb::open(a_path).unwrap();
@@ -681,10 +698,12 @@ mod tests {
 
         let bc_a = BroadcastConfig {
             instance_id: Some("node-a".into()),
+            secret: key_a.map(String::from),
             ..Default::default()
         };
         let bc_b = BroadcastConfig {
             instance_id: Some("node-b".into()),
+            secret: key_b.map(String::from),
             ..Default::default()
         };
 
@@ -786,6 +805,68 @@ mod tests {
             Some("Alice2"),
             "divergent row resolves last-received-wins"
         );
+    }
+
+    // Convergence over the ENCRYPTED wire: the same shared key on both nodes.
+    // Proves seal-on-A / decrypt-on-B round-trips real XChaCha20-Poly1305
+    // ciphertext -- the production path. The keyless convergence test above
+    // exercises only the plaintext passthrough.
+    #[tokio::test]
+    async fn keyed_convergence() {
+        let key = "ab".repeat(32); // 64 hex chars -> valid 256-bit key
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+        seed(&a_path, &[("1", "Alice"), ("2", "Bob")]);
+        seed(&b_path, &[]);
+        let (a, a_cfg, a_local, b, b_cfg, b_local) =
+            two_nodes_keyed(&a_path, &b_path, Some(&key), Some(&key)).await;
+
+        let digest = only(a.digest_bodies(&a_local, &a_cfg).await.unwrap());
+        let (ev, out) = route(&a, digest, &b, &b_local, &b_cfg).await;
+        assert!(
+            matches!(ev, GossipEvent::Digest { wanted: 2, .. }),
+            "got {ev:?}"
+        );
+        let (ev, out) = route(&b, only(out), &a, &a_local, &a_cfg).await;
+        assert!(
+            matches!(ev, GossipEvent::Served { rows: 2, .. }),
+            "got {ev:?}"
+        );
+        let (ev, _) = route(&a, only(out), &b, &b_local, &b_cfg).await;
+        assert!(
+            matches!(ev, GossipEvent::Applied { rows: 2, .. }),
+            "got {ev:?}"
+        );
+        assert_eq!(count(&b_path), 2, "encrypted convergence");
+        assert_eq!(name_of(&b_path, "1").as_deref(), Some("Alice"));
+    }
+
+    // Cross-key isolation -- the only isolation mechanism after db_path_hash was
+    // removed, so it is load-bearing. A datagram sealed with key K1 is dropped
+    // CLEANLY (Ignored(Undecryptable), never an error) by a node holding K2, and
+    // that node's data is untouched. If `handle` ever let the decrypt error
+    // propagate instead, `route`'s unwrap would panic here.
+    #[tokio::test]
+    async fn wrong_key_datagram_is_dropped() {
+        let k1 = "ab".repeat(32);
+        let k2 = "cd".repeat(32);
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+        seed(&a_path, &[("1", "Alice")]);
+        seed(&b_path, &[]);
+        let (a, a_cfg, a_local, b, b_cfg, b_local) =
+            two_nodes_keyed(&a_path, &b_path, Some(&k1), Some(&k2)).await;
+
+        let digest = only(a.digest_bodies(&a_local, &a_cfg).await.unwrap());
+        let (ev, out) = route(&a, digest, &b, &b_local, &b_cfg).await;
+        assert!(
+            matches!(ev, GossipEvent::Ignored(IgnoreReason::Undecryptable)),
+            "foreign-key datagram must drop cleanly, got {ev:?}"
+        );
+        assert!(out.is_empty());
+        assert_eq!(count(&b_path), 0, "foreign-key node must not converge");
     }
 
     // Live multicast smoke test: proves bind/join/send/recv over a real socket.

--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -6,8 +6,10 @@
 //!   is no coordinator and no client/server distinction.
 //! - **Membership = key possession.** All datagrams are XChaCha20-Poly1305
 //!   sealed with a shared key (see [`crate::broadcast::maybe_encrypt`]); holding
-//!   the key is the only access control. `db_path_hash` further scopes a node to
-//!   one logical database, so unrelated DBs sharing a key+group do not merge.
+//!   the key is the only access control. There is no path-, filename-, or
+//!   DB-identity scoping: two replicas of one logical database sync regardless of
+//!   where each stores its file. Isolate clusters on one LAN with distinct keys
+//!   (a foreign key's datagrams simply fail to decrypt and are dropped).
 //! - **Idempotent apply / last-received-wins.** An incoming row is applied with
 //!   `INSERT OR REPLACE`; applying the same row twice is a no-op, so lost
 //!   datagrams are safe. On same-PK divergence the received row wins.
@@ -92,21 +94,21 @@ pub enum Body {
     Delta(DeltaPacket),
 }
 
-/// A versioned, DB-scoped gossip datagram. Serialized to JSON, then sealed with
-/// the shared key before it hits the wire.
+/// A versioned gossip datagram. Serialized to JSON, then sealed with the shared
+/// key before it hits the wire. Membership is key possession: a node that can
+/// decrypt the datagram is on the network. There is no path- or filename-based
+/// scoping -- two replicas of one logical database sync regardless of where each
+/// stores its file. Run isolated clusters on the same LAN by using different keys.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Msg {
     pub version: u8,
-    /// Scopes the message to one logical database (see module docs).
-    pub db_path_hash: String,
     pub body: Body,
 }
 
 impl Msg {
-    fn new(db_path_hash: String, body: Body) -> Self {
+    fn new(body: Body) -> Self {
         Self {
             version: PROTOCOL_VERSION,
-            db_path_hash,
             body,
         }
     }
@@ -130,8 +132,6 @@ pub enum IgnoreReason {
     Replay,
     /// Table not in this node's sync set.
     Table,
-    /// A different logical database (db_path_hash mismatch).
-    OtherDb,
     /// Protocol version mismatch.
     Version,
     /// Could not decrypt with our key.
@@ -184,7 +184,7 @@ pub fn split_digest(
     for (pk, hash) in hashes {
         current.hashes.insert(pk.clone(), hash.clone());
         // Measure with the envelope so we stay under the wire limit end-to-end.
-        let probe = Msg::new(String::new(), Body::Digest(current.clone())).to_bytes()?;
+        let probe = Msg::new(Body::Digest(current.clone())).to_bytes()?;
         if probe.len() > SAFE_PACKET_SIZE && current.hashes.len() > 1 {
             current.hashes.remove(&pk);
             parts.push(std::mem::replace(&mut current, mk()));
@@ -254,19 +254,15 @@ pub struct Gossip {
     socket: Arc<UdpSocket>,
     dest: SocketAddrV4,
     instance_id: String,
-    db_path_hash: String,
     key: Option<[u8; 32]>,
     seq: Arc<AtomicU64>,
     replay: Arc<Mutex<ReplayGuard>>,
 }
 
 impl Gossip {
-    /// Join the multicast group for `config`'s database and prepare to gossip.
-    pub async fn bind(
-        broadcast: &BroadcastConfig,
-        db_path_hash: String,
-        group: Ipv4Addr,
-    ) -> Result<Self> {
+    /// Join the multicast group and prepare to gossip. Membership is the shared
+    /// key in `broadcast` -- any node that can decrypt is on the network.
+    pub async fn bind(broadcast: &BroadcastConfig, group: Ipv4Addr) -> Result<Self> {
         let port = if broadcast.port == 0 {
             DEFAULT_PORT
         } else {
@@ -277,7 +273,6 @@ impl Gossip {
             socket: Arc::new(socket),
             dest: SocketAddrV4::new(group, port),
             instance_id: broadcast.resolve_instance_id(),
-            db_path_hash,
             key: broadcast.encryption_key()?,
             seq: Arc::new(AtomicU64::new(0)),
             replay: Arc::new(Mutex::new(ReplayGuard::new())),
@@ -309,7 +304,7 @@ impl Gossip {
 
     /// Seal a message body into an on-the-wire datagram (JSON + AEAD).
     fn seal(&self, body: Body) -> Result<Vec<u8>> {
-        let plain = Msg::new(self.db_path_hash.clone(), body).to_bytes()?;
+        let plain = Msg::new(body).to_bytes()?;
         maybe_encrypt(&plain, &self.key)
     }
 
@@ -423,9 +418,6 @@ impl Gossip {
         };
         if msg.version != PROTOCOL_VERSION {
             return Ok((GossipEvent::Ignored(IgnoreReason::Version), none));
-        }
-        if msg.db_path_hash != self.db_path_hash {
-            return Ok((GossipEvent::Ignored(IgnoreReason::OtherDb), none));
         }
 
         match msg.body {
@@ -631,7 +623,7 @@ mod tests {
                 hashes: HashMap::from([("1".into(), "h".into())]),
             }),
         ] {
-            let msg = Msg::new("db".into(), body);
+            let msg = Msg::new(body);
             let bytes = msg.to_bytes().unwrap();
             assert_eq!(Msg::from_bytes(&bytes).unwrap(), msg);
         }
@@ -666,9 +658,7 @@ mod tests {
         let mut nums = std::collections::HashSet::new();
         let mut reunion = HashMap::new();
         for p in &parts {
-            let sealed = Msg::new("db".into(), Body::Digest(p.clone()))
-                .to_bytes()
-                .unwrap();
+            let sealed = Msg::new(Body::Digest(p.clone())).to_bytes().unwrap();
             assert!(sealed.len() <= SAFE_PACKET_SIZE, "part exceeds safe size");
             assert_eq!(p.total_parts, total, "total_parts set on every part");
             assert!(nums.insert(p.part), "part numbers must be unique");
@@ -677,7 +667,9 @@ mod tests {
         assert_eq!(reunion, big, "chunking must be lossless");
     }
 
-    /// Bind two gossip nodes that share one logical DB but have distinct ids.
+    /// Bind two gossip nodes with distinct instance ids on a test group. They
+    /// share no path or DB identity -- membership is purely the (implicit) key
+    /// plus group, which is the whole point of the fix.
     async fn two_nodes(
         a_path: &str,
         b_path: &str,
@@ -687,7 +679,6 @@ mod tests {
         let a_local = LocalDb::open(a_path).unwrap();
         let b_local = LocalDb::open(b_path).unwrap();
 
-        let db_hash = crate::broadcast::hash_db_path("shared-logical-db");
         let bc_a = BroadcastConfig {
             instance_id: Some("node-a".into()),
             ..Default::default()
@@ -698,8 +689,8 @@ mod tests {
         };
 
         let group = Ipv4Addr::new(239, 255, 99, 88);
-        let a = Gossip::bind(&bc_a, db_hash.clone(), group).await.unwrap();
-        let b = Gossip::bind(&bc_b, db_hash, group).await.unwrap();
+        let a = Gossip::bind(&bc_a, group).await.unwrap();
+        let b = Gossip::bind(&bc_b, group).await.unwrap();
         (a, a_cfg, a_local, b, b_cfg, b_local)
     }
 

--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -668,8 +668,8 @@ mod tests {
     }
 
     /// Bind two gossip nodes with distinct instance ids on a test group. They
-    /// share no path or DB identity -- membership is purely the (implicit) key
-    /// plus group, which is the whole point of the fix.
+    /// share no path or DB identity, so convergence proves sync is scoped by
+    /// group/key membership alone, never by file location.
     async fn two_nodes(
         a_path: &str,
         b_path: &str,

--- a/crates/smugglr/src/broadcast.rs
+++ b/crates/smugglr/src/broadcast.rs
@@ -10,7 +10,7 @@
 //! cross-subnet sync, where an embedder bridges what multicast cannot reach.
 //! Both shapes coexist; this daemon drives the multicast one.
 
-use smugglr_core::broadcast::{broadcast_pid_lock_path, hash_db_path, BroadcastConfig};
+use smugglr_core::broadcast::{broadcast_pid_lock_path, BroadcastConfig};
 use smugglr_core::config::Config;
 use smugglr_core::daemon::PidLock;
 use smugglr_core::error::Result;
@@ -43,7 +43,6 @@ pub async fn run_broadcast(
     let pid_path = broadcast_pid_lock_path(config_path);
     let _pid_lock = PidLock::acquire(&pid_path)?;
 
-    let db_path_hash = hash_db_path(config.local_db_path());
     let instance_id = broadcast_config.resolve_instance_id();
     let interval_secs = broadcast_config.interval_secs;
 
@@ -56,7 +55,7 @@ pub async fn run_broadcast(
 
     if dry_run {
         // Advertise nothing, apply nothing -- just report what we would gossip.
-        let gossip = Gossip::bind(broadcast_config, db_path_hash, DEFAULT_GROUP).await?;
+        let gossip = Gossip::bind(broadcast_config, DEFAULT_GROUP).await?;
         let bodies = gossip.digest_bodies(&local, config).await?;
         info!(
             "Dry run: would multicast {} digest datagram(s); not sending, not applying",
@@ -65,7 +64,7 @@ pub async fn run_broadcast(
         return Ok(());
     }
 
-    let gossip = Arc::new(Gossip::bind(broadcast_config, db_path_hash, DEFAULT_GROUP).await?);
+    let gossip = Arc::new(Gossip::bind(broadcast_config, DEFAULT_GROUP).await?);
 
     // Continuous listener. A masterless node keeps gossiping through transient
     // errors, so a recv failure is logged, never fatal.

--- a/docs/examples/cli-lan-broadcast/README.md
+++ b/docs/examples/cli-lan-broadcast/README.md
@@ -1,54 +1,82 @@
 # cli-lan-broadcast
 
-Two laptops on the same Wi-Fi network keep their SQLite databases in sync via UDP broadcast. No cloud, no S3, no relay -- peers discover each other and exchange encrypted deltas directly.
+Two (or two hundred) machines on the same LAN keep their SQLite databases in sync
+via masterless UDP multicast. No cloud, no relay, no coordinator: every node runs
+the identical loop, multicasts a `primary_key -> content_hash` digest of its
+tables, and pulls any rows it is missing. Rows ride multicast and apply
+idempotently, so one node's answer converges the whole group.
 
 ## Prerequisites
 
-- `smugglr` on both machines (same major version)
-- Both machines on the same subnet (typically: same Wi-Fi)
-- A shared 256-bit encryption key (a hex string both sides know)
-- Each machine has its own copy of the SQLite database file at the same path-relative-to-config
+- `smugglr` built from a version with multicast sync (`smugglr broadcast` runs
+  the masterless gossip loop). Build from source if your release predates it:
+  `cargo build --release -p smugglr`.
+- All machines on the same subnet (multicast does not cross routers/VLANs).
+- A shared 256-bit key (one hex string every node knows).
 
 ## Setup
 
-1. Generate a shared key once:
+1. Generate the shared key once and distribute it securely (do not commit it):
 
    ```sh
    openssl rand -hex 32
    ```
 
-   Distribute this securely to both machines. Don't put it in git.
-
 2. On each machine, copy `config.example.toml` to `config.toml` and:
-   - paste the same key into `[broadcast].encryption_key`
-   - point `local_db` at this machine's copy of the database
-   - leave the rest at defaults
+   - paste the same key into `[broadcast].secret` (this key IS the membership
+     check -- nodes with it sync, nodes without it can't decrypt and are ignored),
+   - set the same `[broadcast].port` on every node,
+   - point `local_db` at this machine's database. **The path does not need to
+     match across machines** -- sync is scoped by key, not by file location.
 
-3. Make sure UDP traffic on the broadcast port (default `47291`) isn't blocked by firewall.
+3. Create the table(s) you want synced on each machine (smugglr syncs rows, not
+   schema -- the table must exist on both, with a PRIMARY KEY):
+
+   ```sh
+   sqlite3 ./node.db "CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT, updated_at TEXT);"
+   ```
+
+4. Allow UDP on the broadcast port through the firewall (on macOS, click Allow
+   when prompted on first run).
 
 ## Run
 
 On each machine:
 
 ```sh
-smugglr daemon
+smugglr -c config.toml broadcast -v
 ```
 
-The daemon registers as a peer, listens for broadcast announcements from other smugglr peers, and exchanges deltas every time a row changes locally or arrives from a peer.
+You'll see it join the group and emit a heartbeat each interval:
 
-You can verify discovery with:
+```
+Starting masterless multicast sync (group 239.255.43.21, port 31337, ...)
+Heartbeat #1: multicast 1 digest datagram(s)
+```
+
+To preview what a node would advertise without sending or applying anything:
 
 ```sh
-smugglr daemon --output json | jq '.peers'
+smugglr -c config.toml broadcast --dry-run -v
 ```
 
 ## Expected behavior
 
-- Insert a row on machine A. Within a second, the same row appears on machine B.
-- Disconnect machine A from Wi-Fi, write more rows. Reconnect. Machine B catches up automatically; conflicts resolve per `conflict_resolution`.
+- Insert a row on machine A; within a few heartbeats it appears on machine B
+  (B logs `Applied 1 row(s)`). The reverse works identically -- every node both
+  broadcasts and listens.
+- A late joiner that starts empty hears the next heartbeat and converges to the
+  group's full state, no extra steps.
+- Drop a machine off the network, write rows, reconnect: it re-converges on the
+  next heartbeat. Lost packets are safe -- applying a row twice is a no-op.
 
 ## What this demonstrates
 
-- Offline-tolerant peer-to-peer sync. No central server, no internet required.
-- All broadcast payloads are encrypted with the shared key. Anyone on the LAN can see the announcement headers but not the row contents.
-- `uuid_v7_wins` conflict resolution is the recommended setting for master-master topologies because UUIDv7 PKs encode creation time -- newer writes deterministically win without a clock-sync requirement.
+- **Masterless, peer-symmetric sync.** No primary, no leader, no central server,
+  no internet required.
+- **Membership = key possession.** The shared key is the only access control and
+  the encryption key (XChaCha20-Poly1305, unique nonce per datagram). Run an
+  isolated cluster on the same LAN by using a different key.
+- **Last-received-wins on divergence.** Same primary key with different contents:
+  the received row replaces the local one. UUIDv7 PKs make concurrent divergence
+  on the same logical row rare; there are no CRDTs or vector clocks.

--- a/docs/examples/cli-lan-broadcast/config.example.toml
+++ b/docs/examples/cli-lan-broadcast/config.example.toml
@@ -1,21 +1,24 @@
 # cli-lan-broadcast example config.
 #
-# Copy to config.toml on each machine; the encryption_key MUST be identical
-# across peers. Generate one with: openssl rand -hex 32
+# Copy to config.toml on each machine. For nodes to sync, all that must match is:
+#   1. the same `secret` (the shared key IS membership + encryption), and
+#   2. the same `port`, on the same subnet.
+# File paths do NOT need to match -- membership is key possession, not location.
 
-local_db = "./shared.sqlite"
+local_db = "./node.db"
 
 [sync]
-tables = []
+tables = []                       # empty = sync all non-excluded tables
 exclude_tables = ["sqlite_sequence"]
 timestamp_column = "updated_at"
-# UUIDv7 PKs encode creation time, so newer writes win without clock sync.
-conflict_resolution = "uuid_v7_wins"
+# Skip large columns (embeddings, blobs) from sync payloads. Lives under [sync].
+exclude_columns = ["*_embedding", "vector"]
 
 [broadcast]
-# Hex-encoded 256-bit key. Identical on every peer.
-encryption_key = "REPLACE_WITH_OUTPUT_OF_openssl_rand_-hex_32"
-# Default UDP port for peer announcements.
-port = 47291
-# Skip large columns (embeddings, blobs) from broadcast payloads.
-exclude_columns = ["*_embedding", "vector"]
+# 256-bit key, hex-encoded (64 chars). MUST be byte-identical on every node.
+# Generate once and distribute securely: openssl rand -hex 32
+secret = "REPLACE_WITH_OUTPUT_OF_openssl_rand_-hex_32"
+# UDP port for the multicast group. Same on every node.
+port = 31337
+# How often each node multicasts its content-hash digest (the heartbeat).
+interval_secs = 5


### PR DESCRIPTION
Follow-up to #133 / PR #134. Two problems found while writing the node-setup runbook.

## 1. Masterless sync was scoped by file path (bug + spec violation)

The multicast envelope carried `db_path_hash = SHA256(local_db path string)` and dropped any datagram whose hash did not match. So two replicas of one logical database on different machines **silently failed to sync** unless their configured `local_db` paths were byte-identical -- which they almost never are across machines. This directly contradicts the spec ("**Membership = key possession** -- have the key, you're on the network") and breaks the core multi-machine use case the feature exists for.

**Fix:** remove `db_path_hash` from the multicast path entirely. Membership is now the shared key + multicast group: any node that can decrypt a datagram is on the network, wherever it stores its file. Isolate clusters on one LAN with distinct keys (foreign datagrams fail to decrypt and are dropped). Drops `IgnoreReason::OtherDb` and the plumbing through `Gossip::bind` and the daemon. The TCP cross-process shape keeps its own `db_path_hash` (separate shape, out of scope).

No protocol-version bump: v2 is unreleased, so no deployed node speaks the old envelope.

## 2. The cli-lan-broadcast example was broken

It said `smugglr daemon` (command is `broadcast`), used `[broadcast].encryption_key` (the field is `secret` -- serde silently ignored it, leaving the node **unencrypted**), misplaced `exclude_columns` under `[broadcast]`, and described the old pairwise-TCP model. Rewritten to the masterless multicast model with correct keys and a verify section. With scoping now key-based, the example no longer needs matching paths across machines.

## Verification

- 191 core + 11 CLI tests green; clippy clean (-D warnings); rustfmt clean.
- The masterless convergence test now binds two nodes that share **no** path/DB identity -- proving membership is key+group alone.

The old throwaway runbook is folded into the example; nothing else changes.