### PR TITLE
feat(#137): wire retry/backoff into the sync write path

### DIFF
--- a/crates/smugglr-core/src/batch.rs
+++ b/crates/smugglr-core/src/batch.rs
@@ -207,6 +207,7 @@ mod tests {
         let config = BatchConfig {
             batch_size: 3,
             max_statement_bytes: 100_000,
+            ..Default::default()
         };
 
         let batches = batch_rows(&rows, &columns, &config);
@@ -235,6 +236,7 @@ mod tests {
         let config = BatchConfig {
             batch_size: 100, // would allow 100, but param limit caps at 10
             max_statement_bytes: 100_000,
+            ..Default::default()
         };
 
         let batches = batch_rows(&rows, &columns, &config);
@@ -268,6 +270,7 @@ mod tests {
         let config = BatchConfig {
             batch_size: 100,
             max_statement_bytes: 100_000,
+            ..Default::default()
         };
 
         let batches = batch_rows(&rows, &columns, &config);
@@ -297,6 +300,7 @@ mod tests {
         let config = BatchConfig {
             batch_size: 100,
             max_statement_bytes: 100_000,
+            ..Default::default()
         };
 
         let batches = batch_rows(&rows, &columns, &config);
@@ -326,6 +330,7 @@ mod tests {
         let config = BatchConfig {
             batch_size: 100,
             max_statement_bytes: 2500, // Force multiple batches due to size
+            ..Default::default()
         };
 
         let batches = batch_rows(&rows, &columns, &config);
@@ -403,6 +408,7 @@ mod tests {
         let config = BatchConfig {
             batch_size: 100,
             max_statement_bytes: 1000, // Deliberately small
+            ..Default::default()
         };
 
         let batches = batch_rows(&rows, &columns, &config);

--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -243,6 +243,8 @@ pub struct BatchConfig {
     pub batch_size: usize,
     /// Maximum bytes per SQL statement
     pub max_statement_bytes: usize,
+    /// Retry policy for transient write failures
+    pub retry: RetryConfig,
 }
 
 impl Default for BatchConfig {
@@ -250,17 +252,18 @@ impl Default for BatchConfig {
         Self {
             batch_size: default_batch_size(),
             max_statement_bytes: default_max_statement_bytes(),
+            retry: RetryConfig::default(),
         }
     }
 }
 
 impl BatchConfig {
     /// Create BatchConfig from SyncConfig
-    #[allow(dead_code)]
     pub fn from_sync_config(sync: &SyncConfig) -> Self {
         Self {
             batch_size: sync.batch_size,
             max_statement_bytes: sync.max_statement_bytes,
+            retry: RetryConfig::from_sync_config(sync),
         }
     }
 }
@@ -310,7 +313,7 @@ pub enum ConflictResolution {
 }
 
 /// Retry configuration for D1 API calls
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct RetryConfig {
     /// Maximum number of retry attempts
     pub max_retries: u32,

--- a/crates/smugglr-core/src/sync.rs
+++ b/crates/smugglr-core/src/sync.rs
@@ -4,7 +4,7 @@
 //! any pair of data sources (local<->local, local<->D1, local<->S3, etc.)
 //! to sync using the same diff-and-apply engine.
 
-use crate::config::{column_excluded, BatchConfig, Config, ConflictResolution};
+use crate::config::{column_excluded, BatchConfig, Config, ConflictResolution, RetryConfig};
 use crate::datasource::DataSource;
 use crate::diff::{diff_table, DiffStats, TableDiff};
 use crate::error::Result;
@@ -103,8 +103,67 @@ fn strip_excluded_columns(
         .collect()
 }
 
-/// Transfer rows from one DataSource to another.
-///
+/// Delay (ms) before the next retry: the server's Retry-After if present (capped
+/// by `max_delay_ms` so a misbehaving server can't make us sleep unboundedly),
+/// otherwise the computed exponential backoff for `attempt`.
+#[cfg(feature = "native")]
+fn retry_delay_ms(err: &crate::error::SyncError, attempt: u32, retry: &RetryConfig) -> u64 {
+    err.retry_after_ms()
+        .map(|ms| ms.min(retry.max_delay_ms))
+        .unwrap_or_else(|| retry.delay_for_attempt(attempt))
+}
+
+/// Upsert one chunk into `dest`, retrying transient failures with exponential
+/// backoff. Permanent errors fail fast; transient errors (see
+/// [`crate::error::SyncError::is_retryable`]) retry up to `retry.max_retries`;
+/// exhaustion returns `RetryExhausted` (exit 3).
+#[cfg(feature = "native")]
+async fn upsert_with_retry<Dst: DataSource>(
+    dest: &Dst,
+    table: &str,
+    chunk: &[HashMap<String, serde_json::Value>],
+    retry: &RetryConfig,
+) -> Result<usize> {
+    use crate::error::SyncError;
+    let mut attempt: u32 = 0;
+    loop {
+        match dest.upsert_rows(table, chunk).await {
+            Ok(n) => return Ok(n),
+            Err(e) if e.is_retryable() && attempt < retry.max_retries => {
+                let delay = retry_delay_ms(&e, attempt, retry);
+                warn!(
+                    "Upsert to '{}' failed (attempt {}), retrying in {}ms: {}",
+                    table,
+                    attempt + 1,
+                    delay,
+                    e
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                attempt += 1;
+            }
+            Err(e) if e.is_retryable() => {
+                return Err(SyncError::RetryExhausted {
+                    attempts: attempt,
+                    last_error: e.to_string(),
+                });
+            }
+            Err(e) => return Err(e), // permanent -> fast fail
+        }
+    }
+}
+
+/// On WASM the engine upserts directly: retry/backoff for the browser is the JS
+/// autoSync layer's job, and there is no tokio timer in the wasm build.
+#[cfg(not(feature = "native"))]
+async fn upsert_with_retry<Dst: DataSource>(
+    dest: &Dst,
+    table: &str,
+    chunk: &[HashMap<String, serde_json::Value>],
+    _retry: &RetryConfig,
+) -> Result<usize> {
+    dest.upsert_rows(table, chunk).await
+}
+
 /// Fetches rows by primary key from `source`, then upserts into `dest`
 /// in chunks (sized by `batch_config.batch_size`) with progress reporting
 /// via the provided [`SyncProgress`] implementation.
@@ -133,7 +192,7 @@ async fn transfer_rows<Src: DataSource, Dst: DataSource>(
     let mut total = 0;
 
     for chunk in rows.chunks(batch_config.batch_size) {
-        let count = dest.upsert_rows(table, chunk).await?;
+        let count = upsert_with_retry(dest, table, chunk, &batch_config.retry).await?;
         total += count;
         progress.on_batch_complete(chunk.len());
     }
@@ -570,5 +629,155 @@ mod tests {
         assert_eq!(stripped[0].len(), 2);
         assert!(stripped[0].contains_key("id"));
         assert!(stripped[0].contains_key("title"));
+    }
+
+    // Retry/backoff is the native write path; the wasm variant passes through.
+    #[cfg(feature = "native")]
+    mod retry {
+        use super::super::upsert_with_retry;
+        use crate::config::RetryConfig;
+        use crate::datasource::{DataSource, RowMeta, TableInfo};
+        use crate::error::{Result, SyncError};
+        use serde_json::{json, Value};
+        use std::collections::HashMap;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        /// A dest whose `upsert_rows` fails `fails_before_success` times with a
+        /// transient (retryable) error, then succeeds -- or, if `permanent`,
+        /// always returns a non-retryable error. Counts calls.
+        struct FlakyDest {
+            fails_before_success: u32,
+            permanent: bool,
+            calls: AtomicU32,
+        }
+
+        impl DataSource for FlakyDest {
+            async fn list_tables(&self) -> Result<Vec<String>> {
+                Ok(vec![])
+            }
+            async fn table_info(&self, _t: &str) -> Result<TableInfo> {
+                Err(SyncError::TableNotFound("unused".into()))
+            }
+            async fn get_row_metadata(
+                &self,
+                _t: &str,
+                _ts: &str,
+                _ex: &[String],
+            ) -> Result<HashMap<String, RowMeta>> {
+                Ok(HashMap::new())
+            }
+            async fn get_rows(
+                &self,
+                _t: &str,
+                _pks: &[String],
+            ) -> Result<Vec<HashMap<String, Value>>> {
+                Ok(vec![])
+            }
+            async fn upsert_rows(
+                &self,
+                _t: &str,
+                rows: &[HashMap<String, Value>],
+            ) -> Result<usize> {
+                let n = rows.len();
+                let call = self.calls.fetch_add(1, Ordering::SeqCst);
+                if self.permanent {
+                    return Err(SyncError::BadRequest {
+                        status: 400,
+                        message: "bad sql".into(),
+                    });
+                }
+                if call < self.fails_before_success {
+                    return Err(SyncError::ServerError {
+                        status: 503,
+                        message: "unavailable".into(),
+                    });
+                }
+                Ok(n)
+            }
+            async fn row_count(&self, _t: &str) -> Result<usize> {
+                Ok(0)
+            }
+        }
+
+        fn fast_retry(max_retries: u32) -> RetryConfig {
+            RetryConfig {
+                max_retries,
+                initial_delay_ms: 1,
+                max_delay_ms: 5,
+                backoff_multiplier: 2.0,
+            }
+        }
+
+        fn one_chunk() -> Vec<HashMap<String, Value>> {
+            vec![HashMap::from([("id".to_string(), json!("1"))])]
+        }
+
+        #[tokio::test]
+        async fn retries_transient_then_succeeds() {
+            let dest = FlakyDest {
+                fails_before_success: 2,
+                permanent: false,
+                calls: AtomicU32::new(0),
+            };
+            let n = upsert_with_retry(&dest, "t", &one_chunk(), &fast_retry(5))
+                .await
+                .unwrap();
+            assert_eq!(n, 1);
+            assert_eq!(
+                dest.calls.load(Ordering::SeqCst),
+                3,
+                "2 failures + 1 success"
+            );
+        }
+
+        #[tokio::test]
+        async fn exhaustion_returns_retry_exhausted_exit_3() {
+            let dest = FlakyDest {
+                fails_before_success: 100,
+                permanent: false,
+                calls: AtomicU32::new(0),
+            };
+            let err = upsert_with_retry(&dest, "t", &one_chunk(), &fast_retry(2))
+                .await
+                .unwrap_err();
+            assert!(matches!(err, SyncError::RetryExhausted { attempts: 2, .. }));
+            assert_eq!(err.exit_code(), 3);
+            assert_eq!(dest.calls.load(Ordering::SeqCst), 3, "initial + 2 retries");
+        }
+
+        #[test]
+        fn retry_after_is_capped_by_max_delay() {
+            use super::super::retry_delay_ms;
+            let retry = fast_retry(5); // max_delay_ms = 5
+                                       // A hostile/buggy server asking for a 24h Retry-After is capped.
+            let rl = SyncError::RateLimited {
+                retry_after: Some(86_400),
+            };
+            assert_eq!(retry_delay_ms(&rl, 0, &retry), 5);
+            // Without a server hint, computed backoff is used (delay_for_attempt(0)).
+            let se = SyncError::ServerError {
+                status: 503,
+                message: "x".into(),
+            };
+            assert_eq!(retry_delay_ms(&se, 0, &retry), retry.delay_for_attempt(0));
+        }
+
+        #[tokio::test]
+        async fn permanent_error_fails_fast_no_retry() {
+            let dest = FlakyDest {
+                fails_before_success: 0,
+                permanent: true,
+                calls: AtomicU32::new(0),
+            };
+            let err = upsert_with_retry(&dest, "t", &one_chunk(), &fast_retry(5))
+                .await
+                .unwrap_err();
+            assert!(matches!(err, SyncError::BadRequest { .. }));
+            assert_eq!(
+                dest.calls.load(Ordering::SeqCst),
+                1,
+                "no retry on permanent error"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #137.

The retry config was parsed but **inert** -- the write path had no retry loop, so the README/how-it-works "automatic retries with exponential backoff" claim was vaporware and `RetryExhausted` (exit 3) was unreachable. This wires it up.

## What
- `BatchConfig` carries a `RetryConfig` (`from_sync_config`), threaded to the upsert site already present in `transfer_rows`.
- `upsert_with_retry` (native): transient errors (`is_retryable`: 429 / 5xx / timeouts) retry up to `max_retries` with exponential backoff; permanent errors (4xx / D1Api / bad SQL) fast-fail; exhaustion -> `RetryExhausted` (exit 3). The server's `Retry-After` is honored but **capped by `max_delay_ms`** so a misbehaving server can't make a sync sleep unboundedly (added in review). The wasm variant passes through -- browser retries are the JS autoSync layer's job, and there's no tokio timer in the wasm build.

## Review
A code-review pass confirmed correct attempt counting (no off-by-one), clean native/wasm cfg split (verified `--no-default-features` builds + lints clean), and correct transient/permanent classification. It flagged the uncapped `Retry-After` (unbounded sleep) -- fixed by capping at `max_delay_ms`, with the delay logic extracted to a pure `retry_delay_ms` helper and unit-tested.

## Tests
retries-then-succeeds; exhaustion -> RetryExhausted(exit 3); permanent fast-fail (single call, no retry); Retry-After cap (pure, no timing). 197 core tests green; clippy -D warnings clean; fmt clean.

The README "Automatic retries" line is now backed by executing code. Unblocks shingle #74 (how-it-works backoff prose).