### PR TITLE
fix(#140): plugin lookup searches ~/.smugglr not ~/.smuggler

### DIFF
--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -47,7 +47,7 @@ pub enum TargetConfig {
     Sqlite { database: String },
     /// External plugin adapter
     Plugin {
-        /// Plugin name (resolved from ~/.smugglr/plugins/smuggler-{name} or $PATH)
+        /// Plugin name (resolved from ~/.smugglr/plugins/smugglr-{name} or $PATH)
         name: Option<String>,
         /// Explicit path to plugin binary
         path: Option<String>,

--- a/crates/smugglr-core/src/plugin.rs
+++ b/crates/smugglr-core/src/plugin.rs
@@ -325,17 +325,18 @@ impl DataSource for PluginDataSource {
     }
 }
 
+/// Directory under `$HOME` where smugglr looks for plugin binaries.
+///
+/// Single source of truth so the path we search and the path we name in errors
+/// cannot drift apart -- that drift was bug #140 (the join said `.smuggler`
+/// while the error message said `.smugglr`).
+const PLUGIN_HOME_SUBDIR: &str = ".smugglr/plugins";
+
 /// Resolve a plugin name to its binary path.
 ///
 /// Search order:
 /// 1. `~/.smugglr/plugins/smugglr-{name}`
 /// 2. `smugglr-{name}` on `$PATH`
-/// Directory under `$HOME` where smugglr looks for plugin binaries. Single
-/// source of truth so the path we search and the path we name in errors cannot
-/// drift apart (that drift was bug #140: the join said `.smuggler`, the message
-/// said `.smugglr`).
-const PLUGIN_HOME_SUBDIR: &str = ".smugglr/plugins";
-
 pub fn resolve_plugin_path(name: &str) -> Result<PathBuf> {
     let binary_name = format!("smugglr-{}", name);
 

--- a/crates/smugglr-core/src/plugin.rs
+++ b/crates/smugglr-core/src/plugin.rs
@@ -330,14 +330,19 @@ impl DataSource for PluginDataSource {
 /// Search order:
 /// 1. `~/.smugglr/plugins/smugglr-{name}`
 /// 2. `smugglr-{name}` on `$PATH`
+/// Directory under `$HOME` where smugglr looks for plugin binaries. Single
+/// source of truth so the path we search and the path we name in errors cannot
+/// drift apart (that drift was bug #140: the join said `.smuggler`, the message
+/// said `.smugglr`).
+const PLUGIN_HOME_SUBDIR: &str = ".smugglr/plugins";
+
 pub fn resolve_plugin_path(name: &str) -> Result<PathBuf> {
     let binary_name = format!("smugglr-{}", name);
 
     // Check ~/.smugglr/plugins/
     if let Ok(home) = std::env::var("HOME") {
         let candidate = PathBuf::from(home)
-            .join(".smugglr")
-            .join("plugins")
+            .join(PLUGIN_HOME_SUBDIR)
             .join(&binary_name);
         if candidate.is_file() {
             return Ok(candidate);
@@ -350,8 +355,8 @@ pub fn resolve_plugin_path(name: &str) -> Result<PathBuf> {
     }
 
     Err(SyncError::Plugin(format!(
-        "Plugin '{}' not found. Searched: ~/.smugglr/plugins/{}, $PATH/{}",
-        name, binary_name, binary_name
+        "Plugin '{}' not found. Searched: ~/{}/{}, $PATH/{}",
+        name, PLUGIN_HOME_SUBDIR, binary_name, binary_name
     )))
 }
 

--- a/crates/smugglr-core/src/plugin.rs
+++ b/crates/smugglr-core/src/plugin.rs
@@ -2,7 +2,7 @@
 //!
 //! Plugins are standalone binaries that implement the DataSource interface
 //! via JSON-RPC over stdin/stdout. This enables adapter development in any
-//! language without recompiling smuggler.
+//! language without recompiling smugglr.
 //!
 //! ## Protocol
 //!
@@ -328,15 +328,15 @@ impl DataSource for PluginDataSource {
 /// Resolve a plugin name to its binary path.
 ///
 /// Search order:
-/// 1. `~/.smugglr/plugins/smuggler-{name}`
-/// 2. `smuggler-{name}` on `$PATH`
+/// 1. `~/.smugglr/plugins/smugglr-{name}`
+/// 2. `smugglr-{name}` on `$PATH`
 pub fn resolve_plugin_path(name: &str) -> Result<PathBuf> {
     let binary_name = format!("smugglr-{}", name);
 
     // Check ~/.smugglr/plugins/
     if let Ok(home) = std::env::var("HOME") {
         let candidate = PathBuf::from(home)
-            .join(".smuggler")
+            .join(".smugglr")
             .join("plugins")
             .join(&binary_name);
         if candidate.is_file() {


### PR DESCRIPTION
Closes #140. resolve_plugin_path joined `.smuggler` (with an 'e') -- a plugin in the documented `~/.smugglr/plugins/` was never found, and the not-found error pointed at the directory the user used. Fixes the join + the stale `smuggler-`/"recompiling smuggler" doc slips (the binary prefix `smugglr-{name}` was already correct in code). Verified no sans-r `smuggler` remains in source; clippy/fmt/tests green. From the structural-debt audit.