### PR TITLE
fix(#141): WASM content-hash honors glob column excludes

### DIFF
--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -4,6 +4,7 @@
 //! instead of reqwest. Shares profile definitions with the native http-sql plugin.
 
 use sha2::{Digest, Sha256};
+use smugglr_core::config::column_excluded;
 use smugglr_core::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
 use smugglr_core::error::{Result, SyncError};
 use smugglr_core::profile::{AuthFormat, Profile};
@@ -254,7 +255,10 @@ impl FetchDataSource {
         result
     }
 
-    /// Content hash matching smugglr-core local.rs algorithm exactly.
+    /// Content hash matching smugglr-core local.rs exactly, including the
+    /// glob-pattern column exclusion (via `column_excluded`) -- exact-string
+    /// matching here would diverge from transfer-time stripping and produce
+    /// phantom `content_differs` for glob-excluded columns.
     fn content_hash(
         row: &HashMap<String, Value>,
         columns_in_order: &[String],
@@ -265,7 +269,7 @@ impl FetchDataSource {
         let mut hasher = Sha256::new();
         for col in columns_in_order {
             if timestamp_columns.contains(&col.as_str())
-                || exclude.iter().any(|e| e == col)
+                || column_excluded(col, exclude)
                 || col == timestamp_column
             {
                 continue;

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -7,6 +7,7 @@
 //! changes here.
 
 use sha2::{Digest, Sha256};
+use smugglr_core::config::column_excluded;
 use smugglr_core::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
 use smugglr_core::error::{Result, SyncError};
 use std::collections::HashMap;
@@ -132,7 +133,7 @@ impl LocalSqlDataSource {
         let mut hasher = Sha256::new();
         for col in columns_in_order {
             if timestamp_columns.contains(&col.as_str())
-                || exclude.iter().any(|e| e == col)
+                || column_excluded(col, exclude)
                 || col == timestamp_column
             {
                 continue;


### PR DESCRIPTION
Closes #141. Both WASM adapters hashed excluded columns by exact-string match while transfer-stripping + core use glob `column_excluded`. With a glob like `*_embedding`, the column was stripped from transfer but still hashed -> WASM hash != core hash -> phantom `content_differs` / endless re-syncs. Swapped both to `smugglr_core::config::column_excluded` (glob behavior host-tested in config.rs) and corrected the stale "matches core exactly" comment. wasm32 compiles + clippy clean; the crate is wasm32-only so behavioral coverage is the E2E job. From the structural-debt audit. (The WASM-adapter dedup #151 will consolidate these two copies into one.)