### PR TITLE
fix(#143): split_delta reserves wire-envelope headroom (no oversized sealed deltas)

### DIFF
--- a/crates/smugglr-core/src/broadcast.rs
+++ b/crates/smugglr-core/src/broadcast.rs
@@ -547,13 +547,22 @@ impl DeltaPacket {
     }
 }
 
+/// Split a delta into datagram-sized parts.
+///
+/// `reserve` is wire-envelope headroom (bytes) the caller will add AFTER this
+/// returns -- e.g. the multicast `Msg` JSON wrapper plus the XChaCha20 nonce+tag.
+/// Each part's bare serialized size is kept at or below `SAFE_PACKET_SIZE -
+/// reserve`, so the sealed datagram stays within the safe MTU. Pass 0 if the
+/// part goes on the wire as-is.
 pub fn split_delta(
     source_id: &str,
     seq: u64,
     table: &str,
     upserts: Vec<HashMap<String, serde_json::Value>>,
     deletes: Vec<String>,
+    reserve: usize,
 ) -> Result<Vec<DeltaPacket>> {
+    let limit = SAFE_PACKET_SIZE.saturating_sub(reserve);
     let mut base = DeltaPacket {
         version: PROTOCOL_VERSION,
         source_id: source_id.to_string(),
@@ -571,7 +580,7 @@ pub fn split_delta(
 
     base.upserts = upserts.clone();
     let serialized = base.to_bytes()?;
-    if serialized.len() <= SAFE_PACKET_SIZE {
+    if serialized.len() <= limit {
         return Ok(vec![base]);
     }
 
@@ -591,7 +600,7 @@ pub fn split_delta(
         current.upserts.push(row);
 
         let size = current.to_bytes()?.len();
-        if size > SAFE_PACKET_SIZE && current.upserts.len() > 1 {
+        if size > limit && current.upserts.len() > 1 {
             let overflow = current.upserts.pop().unwrap();
             packets.push(current);
 
@@ -992,7 +1001,8 @@ pub async fn handle_sync_connection(
             let rows = local.get_rows(&table_req.table, &missing_pks).await?;
             if !rows.is_empty() {
                 let seq = seq_tracker.next(&table_req.table);
-                let packets = split_delta(&instance_id, seq, &table_req.table, rows, Vec::new())?;
+                let packets =
+                    split_delta(&instance_id, seq, &table_req.table, rows, Vec::new(), 0)?;
                 deltas.extend(packets);
             }
         }
@@ -1423,7 +1433,7 @@ mod tests {
         let upserts = vec![make_row("1", "Alice"), make_row("2", "Bob")];
         let deletes = vec!["3".to_string()];
         let packets =
-            split_delta("machine-a", 1, "users", upserts.clone(), deletes.clone()).unwrap();
+            split_delta("machine-a", 1, "users", upserts.clone(), deletes.clone(), 0).unwrap();
         assert_eq!(packets.len(), 1);
         assert_eq!(packets[0].upserts.len(), 2);
         assert_eq!(packets[0].deletes.len(), 1);
@@ -1446,7 +1456,7 @@ mod tests {
             })
             .collect();
 
-        let packets = split_delta("machine-a", 5, "big_table", upserts, vec![]).unwrap();
+        let packets = split_delta("machine-a", 5, "big_table", upserts, vec![], 0).unwrap();
         assert!(packets.len() > 1, "should split into multiple packets");
 
         for p in &packets {
@@ -1472,7 +1482,7 @@ mod tests {
 
     #[test]
     fn test_split_delta_empty() {
-        let packets = split_delta("machine-a", 0, "empty_table", vec![], vec![]).unwrap();
+        let packets = split_delta("machine-a", 0, "empty_table", vec![], vec![], 0).unwrap();
         assert_eq!(packets.len(), 1);
         assert!(packets[0].is_empty());
     }
@@ -1556,7 +1566,7 @@ mod tests {
 
         let original_count = upserts.len();
         let packets =
-            split_delta("machine-a", 7, "data", upserts, vec!["del1".to_string()]).unwrap();
+            split_delta("machine-a", 7, "data", upserts, vec!["del1".to_string()], 0).unwrap();
         assert!(packets.len() > 1);
 
         let reassembled = reassemble_delta(&packets).unwrap();

--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -58,6 +58,12 @@ pub const DEFAULT_GROUP: Ipv4Addr = Ipv4Addr::new(239, 255, 43, 21);
 /// Receive buffer: the largest datagram we will accept (one full UDP payload).
 const RECV_BUF: usize = 65_536;
 
+/// Wire headroom reserved when chunking deltas for multicast: the `Msg` JSON
+/// wrapper (`{"version":N,"body":{"t":"Delta",...}}`, a fixed ~35 bytes) plus the
+/// XChaCha20-Poly1305 nonce+tag (40 bytes). Conservative, so a sealed `Delta`
+/// datagram never exceeds [`SAFE_PACKET_SIZE`].
+const DELTA_WIRE_RESERVE: usize = 128;
+
 /// A `primary_key -> content_hash` advertisement for one table (one datagram).
 ///
 /// Large tables are chunked across several parts; each part is processed and
@@ -358,7 +364,14 @@ impl Gossip {
         upserts: Vec<HashMap<String, serde_json::Value>>,
         deletes: Vec<String>,
     ) -> Result<Vec<Body>> {
-        let parts = crate::broadcast::split_delta(&self.instance_id, 0, table, upserts, deletes)?;
+        let parts = crate::broadcast::split_delta(
+            &self.instance_id,
+            0,
+            table,
+            upserts,
+            deletes,
+            DELTA_WIRE_RESERVE,
+        )?;
         Ok(parts
             .into_iter()
             .map(|mut part| {
@@ -867,6 +880,43 @@ mod tests {
         );
         assert!(out.is_empty());
         assert_eq!(count(&b_path), 0, "foreign-key node must not converge");
+    }
+
+    // Regression for the AEAD-envelope-overhead bug (#143): a delta chunked for
+    // multicast, once SEALED (Msg wrapper + XChaCha20 nonce+tag), must stay
+    // within SAFE_PACKET_SIZE. split_delta reserves DELTA_WIRE_RESERVE for it;
+    // with a key set the seal adds the full 40-byte AEAD overhead.
+    #[tokio::test]
+    async fn keyed_delta_parts_stay_under_mtu_when_sealed() {
+        let key = "ab".repeat(32);
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+        seed(&a_path, &[]);
+        seed(&b_path, &[]);
+        let (a, _ac, _al, _b, _bc, _bl) =
+            two_nodes_keyed(&a_path, &b_path, Some(&key), Some(&key)).await;
+
+        // Enough rows to force multiple delta parts.
+        let rows: Vec<HashMap<String, serde_json::Value>> = (0..400)
+            .map(|i| {
+                HashMap::from([
+                    ("id".to_string(), serde_json::json!(format!("pk-{i:020}"))),
+                    ("data".to_string(), serde_json::json!("x".repeat(40))),
+                ])
+            })
+            .collect();
+        let bodies = a.delta_bodies("users", rows, Vec::new()).unwrap();
+        assert!(bodies.len() > 1, "rows should span multiple delta parts");
+        for body in bodies {
+            let sealed = a.seal(body).unwrap();
+            assert!(
+                sealed.len() <= SAFE_PACKET_SIZE,
+                "sealed delta part is {} bytes, exceeds SAFE_PACKET_SIZE {}",
+                sealed.len(),
+                SAFE_PACKET_SIZE
+            );
+        }
     }
 
     // Live multicast smoke test: proves bind/join/send/recv over a real socket.


### PR DESCRIPTION
Closes #143. `split_delta` chunked against SAFE_PACKET_SIZE measuring the BARE DeltaPacket, but multicast wraps each part in a `Msg` (~33B) + XChaCha20 nonce/tag (+40B) -- so a near-boundary delta exceeded the safe MTU once sealed. (`split_digest` already handled this; `split_delta` didn't.) Added a `reserve: usize` param (effective limit = SAFE_PACKET_SIZE - reserve); multicast passes `DELTA_WIRE_RESERVE = 128` (>= the ~73B real overhead), TCP/tests pass 0 (unchanged). Regression test: a 400-row keyed delta now seals all parts <= SAFE_PACKET_SIZE (26/27 were ~1426B before). Review verified the reserve math, saturating_sub safety, and that the test is non-vacuous. 204 tests green. From the structural-debt audit.