### PR TITLE
chore(#146): remove dead code + stale allows/comments across smugglr-core

### DIFF
--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -169,32 +169,6 @@ impl Default for SyncConfig {
     }
 }
 
-impl SyncConfig {
-    /// Check if a column name should be excluded from sync.
-    ///
-    /// Supports simple glob patterns:
-    /// - `*_embedding` matches columns ending with `_embedding`
-    /// - `embedding_*` matches columns starting with `embedding_`
-    /// - `*embed*` matches columns containing `embed`
-    /// - `vector` matches the exact column name `vector`
-    #[allow(dead_code)]
-    pub fn should_exclude_column(&self, column: &str) -> bool {
-        self.exclude_columns
-            .iter()
-            .any(|pattern| column_glob_match(pattern, column))
-    }
-
-    /// Filter a list of column names, removing excluded ones.
-    #[allow(dead_code)]
-    pub fn filter_columns<'a>(&self, columns: &[&'a str]) -> Vec<&'a str> {
-        columns
-            .iter()
-            .filter(|c| !self.should_exclude_column(c))
-            .copied()
-            .collect()
-    }
-}
-
 /// Check if a column name matches any exclusion pattern in the given list.
 pub fn column_excluded(column: &str, patterns: &[String]) -> bool {
     patterns
@@ -336,7 +310,6 @@ impl Default for RetryConfig {
     }
 }
 
-#[allow(dead_code)]
 impl RetryConfig {
     /// Create RetryConfig from SyncConfig settings.
     ///
@@ -579,12 +552,6 @@ impl Config {
 
         // Otherwise sync all non-excluded tables
         true
-    }
-
-    /// Get retry configuration from sync settings
-    #[allow(dead_code)]
-    pub fn retry_config(&self) -> RetryConfig {
-        RetryConfig::from_sync_config(&self.sync)
     }
 }
 
@@ -949,17 +916,6 @@ mod tests {
     }
 
     #[test]
-    fn test_config_retry_config() {
-        let mut config = test_config_d1();
-        config.sync.max_retries = 10;
-        config.sync.initial_retry_delay_ms = 500;
-
-        let retry = config.retry_config();
-        assert_eq!(retry.max_retries, 10);
-        assert_eq!(retry.initial_delay_ms, 500);
-    }
-
-    #[test]
     fn test_parse_toml_sqlite_target() {
         let toml_str = r#"
 local_db = "game.db"
@@ -1013,94 +969,6 @@ local_db = "game.db"
     // -- Column exclusion tests --
 
     #[test]
-    fn test_column_exclusion_pattern_matching() {
-        // Suffix: "*_embedding" matches "title_embedding" but not "embedding_title"
-        let sync = SyncConfig {
-            exclude_columns: vec!["*_embedding".to_string()],
-            ..Default::default()
-        };
-        assert!(sync.should_exclude_column("title_embedding"));
-        assert!(sync.should_exclude_column("content_embedding"));
-        assert!(!sync.should_exclude_column("embedding_title"));
-        assert!(!sync.should_exclude_column("title"));
-
-        // Prefix: "embedding_*" matches "embedding_title" but not "title_embedding"
-        let sync = SyncConfig {
-            exclude_columns: vec!["embedding_*".to_string()],
-            ..Default::default()
-        };
-        assert!(sync.should_exclude_column("embedding_title"));
-        assert!(sync.should_exclude_column("embedding_content"));
-        assert!(!sync.should_exclude_column("title_embedding"));
-
-        // Exact: "vector" matches "vector" but not "vector_data" or "my_vector"
-        let sync = SyncConfig {
-            exclude_columns: vec!["vector".to_string()],
-            ..Default::default()
-        };
-        assert!(sync.should_exclude_column("vector"));
-        assert!(!sync.should_exclude_column("vector_data"));
-        assert!(!sync.should_exclude_column("my_vector"));
-    }
-
-    #[test]
-    fn test_column_exclusion_contains_pattern() {
-        let sync = SyncConfig {
-            exclude_columns: vec!["*embed*".to_string()],
-            ..Default::default()
-        };
-        assert!(sync.should_exclude_column("title_embedding"));
-        assert!(sync.should_exclude_column("embedding_title"));
-        assert!(sync.should_exclude_column("embed"));
-        assert!(!sync.should_exclude_column("vector"));
-    }
-
-    #[test]
-    fn test_column_exclusion_multiple_patterns() {
-        let sync = SyncConfig {
-            exclude_columns: vec![
-                "*_embedding".to_string(),
-                "vector".to_string(),
-                "blob_*".to_string(),
-            ],
-            ..Default::default()
-        };
-        assert!(sync.should_exclude_column("title_embedding"));
-        assert!(sync.should_exclude_column("vector"));
-        assert!(sync.should_exclude_column("blob_data"));
-        assert!(!sync.should_exclude_column("title"));
-        assert!(!sync.should_exclude_column("name"));
-    }
-
-    #[test]
-    fn test_empty_exclusion_syncs_all() {
-        let sync = SyncConfig::default();
-        assert!(!sync.should_exclude_column("anything"));
-        assert!(!sync.should_exclude_column("title_embedding"));
-        assert!(!sync.should_exclude_column("vector"));
-    }
-
-    #[test]
-    fn test_column_exclusion_wildcard_all() {
-        let sync = SyncConfig {
-            exclude_columns: vec!["*".to_string()],
-            ..Default::default()
-        };
-        assert!(sync.should_exclude_column("anything"));
-    }
-
-    #[test]
-    fn test_filter_columns() {
-        let sync = SyncConfig {
-            exclude_columns: vec!["*_embedding".to_string(), "vector".to_string()],
-            ..Default::default()
-        };
-        let cols = vec!["id", "name", "title_embedding", "vector", "description"];
-        let filtered = sync.filter_columns(&cols);
-        assert_eq!(filtered, vec!["id", "name", "description"]);
-    }
-
-    #[test]
     fn test_column_excluded_standalone() {
         let patterns = vec!["*_embedding".to_string(), "blob_*".to_string()];
         assert!(column_excluded("title_embedding", &patterns));
@@ -1122,9 +990,10 @@ exclude_columns = ["*_embedding", "vector"]
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.sync.exclude_columns.len(), 2);
-        assert!(config.sync.should_exclude_column("title_embedding"));
-        assert!(config.sync.should_exclude_column("vector"));
-        assert!(!config.sync.should_exclude_column("name"));
+        let patterns = &config.sync.exclude_columns;
+        assert!(column_excluded("title_embedding", patterns));
+        assert!(column_excluded("vector", patterns));
+        assert!(!column_excluded("name", patterns));
     }
 
     #[test]

--- a/crates/smugglr-core/src/datasource.rs
+++ b/crates/smugglr-core/src/datasource.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 /// Table schema information
 #[derive(Debug, Clone)]
 pub struct TableInfo {
-    #[allow(dead_code)]
+    /// Exists for wire/serialization parity with the plugin's `WireTableInfo`.
     pub name: String,
     pub columns: Vec<ColumnInfo>,
     pub primary_key: Vec<String>,
@@ -31,7 +31,7 @@ pub struct ColumnInfo {
 /// A row with its primary key and optional timestamp
 #[derive(Debug, Clone)]
 pub struct RowMeta {
-    #[allow(dead_code)]
+    /// Exists for wire/serialization parity with the plugin's `WireRowMeta`.
     pub pk_value: String,
     pub updated_at: Option<String>,
     pub content_hash: String,
@@ -63,21 +63,6 @@ pub trait DataSource: Sync {
         &self,
         table: &str,
     ) -> impl std::future::Future<Output = Result<TableInfo>> + MaybeSend;
-
-    /// Check if a table has a specific column.
-    ///
-    /// Default implementation delegates to `table_info`.
-    #[allow(dead_code)]
-    fn has_column(
-        &self,
-        table: &str,
-        column: &str,
-    ) -> impl std::future::Future<Output = Result<bool>> + MaybeSend {
-        async move {
-            let info = self.table_info(table).await?;
-            Ok(info.columns.iter().any(|c| c.name == column))
-        }
-    }
 
     /// Get row metadata for change detection.
     ///

--- a/crates/smugglr-core/src/diff.rs
+++ b/crates/smugglr-core/src/diff.rs
@@ -117,24 +117,6 @@ impl TableDiff {
         rows
     }
 
-    /// Get rows to delete from remote (for push)
-    /// Reserved for full sync mode
-    #[allow(dead_code)]
-    pub fn rows_to_delete_remote(&self) -> Vec<String> {
-        // Rows that only exist in remote but not in local
-        // This is only for full sync mode, not incremental
-        vec![]
-    }
-
-    /// Get rows to delete from local (for pull)
-    /// Reserved for full sync mode
-    #[allow(dead_code)]
-    pub fn rows_to_delete_local(&self) -> Vec<String> {
-        // Rows that only exist in local but not in remote
-        // This is only for full sync mode, not incremental
-        vec![]
-    }
-
     /// Compute aggregate diff statistics (counts only).
     pub fn stats(&self) -> DiffStats {
         DiffStats {
@@ -265,94 +247,9 @@ pub async fn diff_table<A: DataSource, B: DataSource>(
     Ok(diff)
 }
 
-/// Compare all tables
-/// Reserved for batch operations
-#[allow(dead_code)]
-pub async fn diff_all<A: DataSource, B: DataSource>(
-    local: &A,
-    remote: &B,
-    tables: &[String],
-    timestamp_column: &str,
-    exclude_columns: &[String],
-) -> Result<Vec<TableDiff>> {
-    let mut diffs = Vec::new();
-
-    for table in tables {
-        let diff = diff_table(local, remote, table, timestamp_column, exclude_columns).await?;
-        diffs.push(diff);
-    }
-
-    Ok(diffs)
-}
-
-/// Extract Unix millisecond timestamp from a UUIDv7 string.
-///
-/// Returns `None` if the string is not a valid UUIDv7 (version nibble must be `7`
-/// and the string must contain exactly 32 hex digits).
-#[allow(dead_code)]
-pub(crate) fn extract_uuidv7_timestamp(uuid_str: &str) -> Option<u64> {
-    let hex_str: String = uuid_str.chars().filter(|c| *c != '-').collect();
-    if hex_str.len() != 32 {
-        return None;
-    }
-
-    // Version nibble is the 13th hex char (index 12), must be '7'
-    if hex_str.as_bytes().get(12)? != &b'7' {
-        return None;
-    }
-
-    // First 12 hex chars are the 48-bit Unix ms timestamp
-    let ts_hex = &hex_str[..12];
-    let mut ts_bytes = [0u8; 8];
-    let decoded = hex::decode(ts_hex).ok()?;
-    ts_bytes[2..8].copy_from_slice(&decoded);
-    Some(u64::from_be_bytes(ts_bytes))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_uuidv7_timestamp_extraction() {
-        // Timestamp 0x018EC7E6_1A80 = 1713494400640 ms
-        let uuid = "018ec7e6-1a80-7000-8000-000000000000";
-        assert_eq!(extract_uuidv7_timestamp(uuid), Some(0x018e_c7e6_1a80));
-    }
-
-    #[test]
-    fn test_uuidv7_timestamp_extraction_no_hyphens() {
-        let uuid = "018ec7e61a8070008000000000000000";
-        assert_eq!(extract_uuidv7_timestamp(uuid), Some(0x018e_c7e6_1a80));
-    }
-
-    #[test]
-    fn test_uuidv7_version_detection_rejects_v4() {
-        let v4 = "550e8400-e29b-41d4-a716-446655440000";
-        assert!(extract_uuidv7_timestamp(v4).is_none());
-    }
-
-    #[test]
-    fn test_uuidv7_version_detection_accepts_v7() {
-        let v7 = "018ec7e6-1a80-7abc-8000-000000000001";
-        assert!(extract_uuidv7_timestamp(v7).is_some());
-    }
-
-    #[test]
-    fn test_non_uuid_string_returns_none() {
-        assert!(extract_uuidv7_timestamp("not-a-uuid").is_none());
-        assert!(extract_uuidv7_timestamp("").is_none());
-        assert!(extract_uuidv7_timestamp("12345").is_none());
-    }
-
-    #[test]
-    fn test_uuidv7_ordering() {
-        let earlier = "018ec7e6-1a80-7000-8000-000000000000";
-        let later = "018ec7e6-1a81-7000-8000-000000000000";
-        let ts_early = extract_uuidv7_timestamp(earlier).unwrap();
-        let ts_late = extract_uuidv7_timestamp(later).unwrap();
-        assert!(ts_late > ts_early);
-    }
 
     #[test]
     fn test_uuidv7_wins_push_includes_local_only_and_newer() {

--- a/crates/smugglr-core/src/local.rs
+++ b/crates/smugglr-core/src/local.rs
@@ -53,42 +53,6 @@ impl LocalDb {
         let tables = list_tables_inner(&conn)?;
         Ok(TableSchema::new(tables))
     }
-
-    /// Delete rows by primary key
-    #[allow(dead_code)]
-    pub fn delete_rows(&self, table: &str, pk_values: &[String]) -> Result<usize> {
-        if pk_values.is_empty() {
-            return Ok(0);
-        }
-
-        let conn = self.conn();
-        let info = table_info_inner(&conn, table)?;
-        let pk_cols = &info.primary_key;
-
-        let pk_expr = pk_cols
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(" || '|' || ");
-
-        let placeholders = pk_values.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-
-        let sql = format!(
-            "DELETE FROM \"{}\" WHERE {} IN ({})",
-            table, pk_expr, placeholders
-        );
-
-        debug!("Deleting {} rows from {}", pk_values.len(), table);
-
-        let params: Vec<&dyn rusqlite::ToSql> = pk_values
-            .iter()
-            .map(|v| v as &dyn rusqlite::ToSql)
-            .collect();
-
-        let count = conn.execute(&sql, params.as_slice())?;
-        info!("Deleted {} rows from {}", count, table);
-        Ok(count)
-    }
 }
 
 impl DataSource for LocalDb {
@@ -421,7 +385,7 @@ fn get_json_value(row: &Row, idx: usize) -> Result<JsonValue> {
         return Ok(v.map(JsonValue::from).unwrap_or(JsonValue::Null));
     }
     if let Ok(v) = row.get::<_, Option<Vec<u8>>>(idx) {
-        // Encode blobs as base64
+        // Encode blobs as hex
         return Ok(v
             .map(|b| JsonValue::String(hex::encode(b)))
             .unwrap_or(JsonValue::Null));

--- a/crates/smugglr-core/src/plugin.rs
+++ b/crates/smugglr-core/src/plugin.rs
@@ -61,8 +61,6 @@ struct RpcRequest<'a> {
 
 #[derive(Deserialize)]
 struct RpcResponse {
-    #[allow(dead_code)]
-    jsonrpc: String,
     result: Option<JsonValue>,
     error: Option<RpcError>,
     id: u64,

--- a/crates/smugglr-core/src/profile.rs
+++ b/crates/smugglr-core/src/profile.rs
@@ -23,7 +23,6 @@ pub struct Profile {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum AuthFormat {
     Bearer,
     Basic,

--- a/crates/smugglr-core/src/table.rs
+++ b/crates/smugglr-core/src/table.rs
@@ -82,36 +82,6 @@ impl TableSchema {
     pub fn validate(&self, name: &str) -> Result<ValidatedTableName> {
         ValidatedTableName::new(name, &self.tables)
     }
-
-    /// Check if a table name exists in the schema.
-    #[allow(dead_code)]
-    pub fn contains(&self, name: &str) -> bool {
-        self.tables.contains(name)
-    }
-
-    /// Get the number of tables in the schema.
-    #[allow(dead_code)]
-    pub fn len(&self) -> usize {
-        self.tables.len()
-    }
-
-    /// Check if the schema is empty.
-    #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool {
-        self.tables.is_empty()
-    }
-
-    /// Get an iterator over all table names.
-    #[allow(dead_code)]
-    pub fn iter(&self) -> impl Iterator<Item = &String> {
-        self.tables.iter()
-    }
-
-    /// Get the underlying set of table names (for ValidatedTableName::new).
-    #[allow(dead_code)]
-    pub fn tables(&self) -> &HashSet<String> {
-        &self.tables
-    }
 }
 
 #[cfg(test)]
@@ -175,25 +145,8 @@ mod tests {
     }
 
     #[test]
-    fn schema_contains() {
-        let schema = test_schema();
-        assert!(schema.contains("users"));
-        assert!(schema.contains("posts"));
-        assert!(!schema.contains("nonexistent"));
-    }
-
-    #[test]
-    fn schema_len() {
-        let schema = test_schema();
-        assert_eq!(schema.len(), 3);
-        assert!(!schema.is_empty());
-    }
-
-    #[test]
     fn empty_schema() {
         let schema = TableSchema::new(Vec::<String>::new());
-        assert!(schema.is_empty());
-        assert_eq!(schema.len(), 0);
         assert!(schema.validate("anything").is_err());
     }
 


### PR DESCRIPTION
Closes #146. 342 LOC of genuinely-dead code removed (verified no non-test callers), so the lints work again: config (should_exclude_column/filter_columns/Config::retry_config + stale RetryConfig allow), diff (rows_to_delete_*, diff_all, extract_uuidv7_timestamp -- unfinished feature), local (delete_rows; fixed 'base64'->'hex' blob comment), datasource (has_column; kept TableInfo.name/RowMeta.pk_value as public wire-parity fields w/ doc notes), table (dead TableSchema accessors), profile (stale AuthFormat allow), plugin (dead RpcResponse.jsonrpc field).

Left for their own open PRs to avoid conflict: TableDiff.table allow (#144), plugin .smuggler dir fix (#140). build/test(188 core + 11 CLI)/clippy -D warnings/fmt clean; wasm32 compiles. From the structural-debt audit.