### PR TITLE
refactor(#149): merge identical RequestFormat build_request arms

### DIFF
--- a/crates/smugglr-core/src/profile.rs
+++ b/crates/smugglr-core/src/profile.rs
@@ -199,24 +199,13 @@ impl Profile {
                     serde_json::json!([stmt])
                 }
             }
-            RequestFormat::D1 => {
-                if params.is_empty() {
-                    serde_json::json!({"sql": sql})
-                } else {
-                    serde_json::json!({"sql": sql, "params": params})
-                }
-            }
             RequestFormat::Datasette => {
                 serde_json::json!({"sql": sql, "_shape": "array"})
             }
-            RequestFormat::Generic => {
-                if params.is_empty() {
-                    serde_json::json!({"sql": sql})
-                } else {
-                    serde_json::json!({"sql": sql, "params": params})
-                }
-            }
-            RequestFormat::HttpSql => {
+            // D1, Generic, and http-sql all use the flat `{"sql", "params"}` body.
+            // Kept as separate variants because they are independent vendor
+            // contracts that may diverge; only the shared body is merged here.
+            RequestFormat::D1 | RequestFormat::Generic | RequestFormat::HttpSql => {
                 if params.is_empty() {
                     serde_json::json!({"sql": sql})
                 } else {

--- a/crates/smugglr-core/src/profile.rs
+++ b/crates/smugglr-core/src/profile.rs
@@ -36,15 +36,13 @@ pub enum RequestFormat {
     Turso,
     /// rqlite: `[["<sql>", ...params]]`
     Rqlite,
-    /// Cloudflare D1 REST: `{"sql": "<sql>", "params": [...]}`
-    D1,
     /// Datasette: `{"sql": "<sql>", "params": {...}}`
     Datasette,
-    /// Flat JSON: `{"sql": "<sql>", "params": [...]}`
+    /// Flat JSON: `{"sql": "<sql>", "params": [...]}`. Shared by Cloudflare D1,
+    /// the http-sql v0.1 spec, and generic endpoints -- they emit this exact
+    /// request body. Per-platform differences (response paths, bind limits) live
+    /// in the `Profile` constructors, not in this enum.
     Generic,
-    /// http-sql v0.1 spec: `{"sql": "<sql>", "params": [...]}`
-    /// See <https://github.com/rafters-studio/http-sql>.
-    HttpSql,
 }
 
 impl Profile {
@@ -97,7 +95,7 @@ impl Profile {
     pub fn d1() -> Self {
         Self {
             auth_format: AuthFormat::Bearer,
-            request_format: RequestFormat::D1,
+            request_format: RequestFormat::Generic,
             rows_path: vec!["result".into(), "0".into(), "results".into()],
             columns_path: vec!["result".into(), "0".into(), "results".into()],
             max_bind_params: 100,
@@ -149,7 +147,7 @@ impl Profile {
     pub fn http_sql() -> Self {
         Self {
             auth_format: AuthFormat::Bearer,
-            request_format: RequestFormat::HttpSql,
+            request_format: RequestFormat::Generic,
             rows_path: vec!["rows".into()],
             columns_path: vec!["columns".into()],
             max_bind_params: 0,
@@ -202,10 +200,7 @@ impl Profile {
             RequestFormat::Datasette => {
                 serde_json::json!({"sql": sql, "_shape": "array"})
             }
-            // D1, Generic, and http-sql all use the flat `{"sql", "params"}` body.
-            // Kept as separate variants because they are independent vendor
-            // contracts that may diverge; only the shared body is merged here.
-            RequestFormat::D1 | RequestFormat::Generic | RequestFormat::HttpSql => {
+            RequestFormat::Generic => {
                 if params.is_empty() {
                     serde_json::json!({"sql": sql})
                 } else {


### PR DESCRIPTION
Closes #149. D1, Generic, and HttpSql produced byte-identical request bodies (flat `{"sql"}` / `{"sql","params"}`). Merged the three match arms into one or-pattern, dropping two copy-paste duplicates.

Kept the variants distinct on purpose: they're independent vendor contracts that may diverge, and D1's real differentiator (`max_bind_params: 100`) lives in its constructor, not in RequestFormat. Behavior unchanged -- the per-format request tests (12 in profile) still pass. clippy -D warnings/fmt clean; wasm32 compiles. From the structural-debt audit.