### PR TITLE
refactor(#150): CLI structural cleanup + type-safe JSON status

### DIFF
--- a/crates/smugglr/src/main.rs
+++ b/crates/smugglr/src/main.rs
@@ -11,17 +11,19 @@ mod watch;
 use output::{
     CommandOutput, DiffOutput, DryRunOutput, DryRunTableOutput, DryRunVerboseTableOutput,
     ErrorOutput, OutputFormat, SnapshotListEntry, SnapshotListOutput, SnapshotOutput,
-    SnapshotTableInfo, StatusConfig, StatusDb, StatusOutput, StatusTable,
+    SnapshotTableInfo, Status, StatusConfig, StatusDb, StatusOutput, StatusTable,
 };
+use serde_json::Value as JsonValue;
 use smugglr_core::config::{Config, ResolvedTarget};
-use smugglr_core::datasource::DataSource;
+use smugglr_core::datasource::{DataSource, RowMeta, TableInfo};
 use smugglr_core::diff::diff_table;
 use smugglr_core::error;
 use smugglr_core::local::LocalDb;
 use smugglr_core::plugin::PluginDataSource;
 use smugglr_core::sync::{
-    get_tables_to_sync, pull_all, push_all, sync_all, NoProgress, SyncProgress,
+    get_tables_to_sync, pull_all, push_all, sync_all, NoProgress, SyncProgress, SyncResult,
 };
+use std::collections::HashMap;
 
 use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -72,6 +74,133 @@ fn make_progress(fmt: OutputFormat) -> Box<dyn SyncProgress> {
         Box::new(IndicatifProgress::new())
     } else {
         Box::new(NoProgress)
+    }
+}
+
+/// An opened sync target: either a local SQLite file or a running plugin.
+///
+/// Both `LocalDb` and `PluginDataSource` implement [`DataSource`], but the
+/// trait uses RPITIT (not object-safe), so we unify them with this enum and
+/// delegate each method. This lets `run_push`/`run_pull`/`run_sync`/`run_diff`
+/// share a single engine call instead of duplicating a per-variant `match`.
+enum TargetSource {
+    Sqlite(LocalDb),
+    Plugin(Box<PluginDataSource>),
+}
+
+impl TargetSource {
+    /// Open the resolved target. `writable` selects read-write vs read-only for
+    /// SQLite targets (plugins manage their own access mode).
+    async fn open(target: &ResolvedTarget, writable: bool) -> error::Result<Self> {
+        match target {
+            ResolvedTarget::Sqlite { database } => {
+                let db = if writable {
+                    LocalDb::open(database)?
+                } else {
+                    LocalDb::open_readonly(database)?
+                };
+                Ok(TargetSource::Sqlite(db))
+            }
+            ResolvedTarget::Plugin {
+                path,
+                name,
+                config: plugin_config,
+            } => {
+                let plugin = PluginDataSource::start(path, name, plugin_config).await?;
+                Ok(TargetSource::Plugin(Box::new(plugin)))
+            }
+        }
+    }
+}
+
+impl DataSource for TargetSource {
+    async fn list_tables(&self) -> error::Result<Vec<String>> {
+        match self {
+            TargetSource::Sqlite(db) => db.list_tables().await,
+            TargetSource::Plugin(p) => p.list_tables().await,
+        }
+    }
+
+    async fn table_info(&self, table: &str) -> error::Result<TableInfo> {
+        match self {
+            TargetSource::Sqlite(db) => db.table_info(table).await,
+            TargetSource::Plugin(p) => p.table_info(table).await,
+        }
+    }
+
+    async fn get_row_metadata(
+        &self,
+        table: &str,
+        timestamp_column: &str,
+        exclude_columns: &[String],
+    ) -> error::Result<HashMap<String, RowMeta>> {
+        match self {
+            TargetSource::Sqlite(db) => {
+                db.get_row_metadata(table, timestamp_column, exclude_columns)
+                    .await
+            }
+            TargetSource::Plugin(p) => {
+                p.get_row_metadata(table, timestamp_column, exclude_columns)
+                    .await
+            }
+        }
+    }
+
+    async fn get_rows(
+        &self,
+        table: &str,
+        pk_values: &[String],
+    ) -> error::Result<Vec<HashMap<String, JsonValue>>> {
+        match self {
+            TargetSource::Sqlite(db) => db.get_rows(table, pk_values).await,
+            TargetSource::Plugin(p) => p.get_rows(table, pk_values).await,
+        }
+    }
+
+    async fn upsert_rows(
+        &self,
+        table: &str,
+        rows: &[HashMap<String, JsonValue>],
+    ) -> error::Result<usize> {
+        match self {
+            TargetSource::Sqlite(db) => db.upsert_rows(table, rows).await,
+            TargetSource::Plugin(p) => p.upsert_rows(table, rows).await,
+        }
+    }
+
+    async fn row_count(&self, table: &str) -> error::Result<usize> {
+        match self {
+            TargetSource::Sqlite(db) => db.row_count(table).await,
+            TargetSource::Plugin(p) => p.row_count(table).await,
+        }
+    }
+}
+
+/// Emit the JSON/text output for a push/pull/sync/stash/retrieve result set.
+///
+/// Routes dry-run JSON to the verbose/compact dry-run shape, plain JSON to
+/// `CommandOutput`, and text to `print_summary`.
+fn emit_command_output(
+    fmt: OutputFormat,
+    command: &'static str,
+    results: &[SyncResult],
+    dry_run: bool,
+    verbose: bool,
+    summary_label: &str,
+    row_accessor: impl Fn(&SyncResult) -> usize,
+) {
+    match fmt {
+        OutputFormat::Json if dry_run => print_dry_run_json(command, results, verbose),
+        OutputFormat::Json => {
+            let out = CommandOutput::from_sync_results(command, results);
+            println!(
+                "{}",
+                serde_json::to_string(&out).expect("CommandOutput serialization")
+            );
+        }
+        OutputFormat::Text => {
+            print_summary(summary_label, results, row_accessor, command, dry_run);
+        }
     }
 }
 
@@ -217,7 +346,7 @@ enum Commands {
 fn exit_json_error(command: &'static str, err: &error::SyncError) -> ! {
     let out = ErrorOutput {
         command,
-        status: "error",
+        status: Status::Error,
         error: err.to_string(),
         exit_code: err.exit_code(),
     };
@@ -429,47 +558,18 @@ async fn run_push(
 ) -> error::Result<()> {
     let local = LocalDb::open_readonly(config.local_db_path())?;
     let tables = resolve_tables(&local, table)?;
-
     let progress = make_progress(fmt);
 
-    let results = match target {
-        ResolvedTarget::Sqlite { database } => {
-            info!("Push mode: local -> SQLite ({})", database);
-            let target_db = LocalDb::open(&database)?;
-            push_all(
-                &local,
-                &target_db,
-                config,
-                tables,
-                dry_run,
-                progress.as_ref(),
-            )
-            .await?
-        }
-        ResolvedTarget::Plugin {
-            ref path,
-            ref name,
-            config: ref plugin_config,
-        } => {
-            info!("Push mode: local -> plugin ({})", name);
-            let plugin = PluginDataSource::start(path, name, plugin_config).await?;
-            push_all(&local, &plugin, config, tables, dry_run, progress.as_ref()).await?
-        }
-    };
-
-    match fmt {
-        OutputFormat::Json if dry_run => print_dry_run_json("push", &results, verbose),
-        OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("push", &results, false);
-            println!(
-                "{}",
-                serde_json::to_string(&out).expect("CommandOutput serialization")
-            );
-        }
-        OutputFormat::Text => {
-            print_summary("Push", &results, |r| r.rows_pushed, "push", dry_run);
-        }
+    match &target {
+        ResolvedTarget::Sqlite { database } => info!("Push mode: local -> SQLite ({})", database),
+        ResolvedTarget::Plugin { name, .. } => info!("Push mode: local -> plugin ({})", name),
     }
+    let target = TargetSource::open(&target, true).await?;
+    let results = push_all(&local, &target, config, tables, dry_run, progress.as_ref()).await?;
+
+    emit_command_output(fmt, "push", &results, dry_run, verbose, "Push", |r| {
+        r.rows_pushed
+    });
     Ok(())
 }
 
@@ -487,47 +587,19 @@ async fn run_pull(
         LocalDb::open(config.local_db_path())?
     };
     let tables = resolve_tables(&local, table)?;
-
     let progress = make_progress(fmt);
 
-    let results = match target {
-        ResolvedTarget::Sqlite { database } => {
-            info!("Pull mode: SQLite ({}) -> local", database);
-            let source_db = LocalDb::open_readonly(&database)?;
-            pull_all(
-                &local,
-                &source_db,
-                config,
-                tables,
-                dry_run,
-                progress.as_ref(),
-            )
-            .await?
-        }
-        ResolvedTarget::Plugin {
-            ref path,
-            ref name,
-            config: ref plugin_config,
-        } => {
-            info!("Pull mode: plugin ({}) -> local", name);
-            let plugin = PluginDataSource::start(path, name, plugin_config).await?;
-            pull_all(&local, &plugin, config, tables, dry_run, progress.as_ref()).await?
-        }
-    };
-
-    match fmt {
-        OutputFormat::Json if dry_run => print_dry_run_json("pull", &results, verbose),
-        OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("pull", &results, false);
-            println!(
-                "{}",
-                serde_json::to_string(&out).expect("CommandOutput serialization")
-            );
-        }
-        OutputFormat::Text => {
-            print_summary("Pull", &results, |r| r.rows_pulled, "pull", dry_run);
-        }
+    match &target {
+        ResolvedTarget::Sqlite { database } => info!("Pull mode: SQLite ({}) -> local", database),
+        ResolvedTarget::Plugin { name, .. } => info!("Pull mode: plugin ({}) -> local", name),
     }
+    // Pull reads from the target, so it is opened read-only.
+    let target = TargetSource::open(&target, false).await?;
+    let results = pull_all(&local, &target, config, tables, dry_run, progress.as_ref()).await?;
+
+    emit_command_output(fmt, "pull", &results, dry_run, verbose, "Pull", |r| {
+        r.rows_pulled
+    });
     Ok(())
 }
 
@@ -545,38 +617,23 @@ async fn run_sync(
         LocalDb::open(config.local_db_path())?
     };
     let tables = resolve_tables(&local, table)?;
-
     let progress = make_progress(fmt);
 
-    let results = match target {
+    match &target {
         ResolvedTarget::Sqlite { database } => {
-            info!("Sync mode: bidirectional (local <-> SQLite {})", database);
-            let target_db = LocalDb::open(&database)?;
-            sync_all(
-                &local,
-                &target_db,
-                config,
-                tables,
-                dry_run,
-                progress.as_ref(),
-            )
-            .await?
+            info!("Sync mode: bidirectional (local <-> SQLite {})", database)
         }
-        ResolvedTarget::Plugin {
-            ref path,
-            ref name,
-            config: ref plugin_config,
-        } => {
-            info!("Sync mode: bidirectional (local <-> plugin {})", name);
-            let plugin = PluginDataSource::start(path, name, plugin_config).await?;
-            sync_all(&local, &plugin, config, tables, dry_run, progress.as_ref()).await?
+        ResolvedTarget::Plugin { name, .. } => {
+            info!("Sync mode: bidirectional (local <-> plugin {})", name)
         }
-    };
+    }
+    let target = TargetSource::open(&target, true).await?;
+    let results = sync_all(&local, &target, config, tables, dry_run, progress.as_ref()).await?;
 
     match fmt {
         OutputFormat::Json if dry_run => print_dry_run_json("sync", &results, verbose),
         OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("sync", &results, false);
+            let out = CommandOutput::from_sync_results("sync", &results);
             println!(
                 "{}",
                 serde_json::to_string(&out).expect("CommandOutput serialization")
@@ -615,53 +672,26 @@ async fn run_diff(
 ) -> error::Result<()> {
     info!("Computing differences...");
     let local = LocalDb::open_readonly(config.local_db_path())?;
+    let remote = TargetSource::open(&target, false).await?;
 
-    match target {
-        ResolvedTarget::Sqlite { database } => {
-            let target_db = LocalDb::open_readonly(&database)?;
-            let tables = match table {
-                Some(t) => {
-                    let schema = local.get_schema()?;
-                    let _ = schema.validate(&t)?;
-                    vec![t]
-                }
-                None => get_tables_to_sync(&local, &target_db, config).await?,
-            };
-            output_diffs(
-                &local,
-                &target_db,
-                &tables,
-                &config.sync.timestamp_column,
-                &config.sync.exclude_columns,
-                fmt,
-            )
-            .await
+    let tables = match table {
+        Some(t) => {
+            let schema = local.get_schema()?;
+            let _ = schema.validate(&t)?;
+            vec![t]
         }
-        ResolvedTarget::Plugin {
-            ref path,
-            ref name,
-            config: ref plugin_config,
-        } => {
-            let plugin = PluginDataSource::start(path, name, plugin_config).await?;
-            let tables = match table {
-                Some(t) => {
-                    let schema = local.get_schema()?;
-                    let _ = schema.validate(&t)?;
-                    vec![t]
-                }
-                None => get_tables_to_sync(&local, &plugin, config).await?,
-            };
-            output_diffs(
-                &local,
-                &plugin,
-                &tables,
-                &config.sync.timestamp_column,
-                &config.sync.exclude_columns,
-                fmt,
-            )
-            .await
-        }
-    }
+        None => get_tables_to_sync(&local, &remote, config).await?,
+    };
+
+    output_diffs(
+        &local,
+        &remote,
+        &tables,
+        &config.sync.timestamp_column,
+        &config.sync.exclude_columns,
+        fmt,
+    )
+    .await
 }
 
 async fn output_diffs<A: DataSource, B: DataSource>(
@@ -755,6 +785,30 @@ fn print_diff_category(label: &str, keys: &[String]) {
     }
 }
 
+/// Connect to a data source and collect per-table row counts for `status`.
+///
+/// Returns a connected `StatusDb` with row counts for every synced table.
+/// Connection failures are handled by the caller (which builds the
+/// disconnected `StatusDb` variant).
+async fn gather_status<D: DataSource>(db: &D, config: &Config) -> error::Result<StatusDb> {
+    let tables = db.list_tables().await?;
+    let mut table_rows = Vec::new();
+    for table in &tables {
+        if config.should_sync_table(table) {
+            let count = db.row_count(table).await?;
+            table_rows.push(StatusTable {
+                name: table.clone(),
+                rows: count,
+            });
+        }
+    }
+    Ok(StatusDb {
+        connected: true,
+        error: None,
+        tables: table_rows,
+    })
+}
+
 async fn run_status(
     config: &Config,
     target: ResolvedTarget,
@@ -767,24 +821,7 @@ async fn run_status(
 
     // Gather local DB info
     let local_status = match LocalDb::open_readonly(config.local_db_path()) {
-        Ok(local) => {
-            let tables = local.list_tables().await?;
-            let mut table_rows = Vec::new();
-            for table in &tables {
-                if config.should_sync_table(table) {
-                    let count = local.row_count(table).await?;
-                    table_rows.push(StatusTable {
-                        name: table.clone(),
-                        rows: count,
-                    });
-                }
-            }
-            StatusDb {
-                connected: true,
-                error: None,
-                tables: table_rows,
-            }
-        }
+        Ok(local) => gather_status(&local, config).await?,
         Err(e) => StatusDb {
             connected: false,
             error: Some(e.to_string()),
@@ -793,60 +830,12 @@ async fn run_status(
     };
 
     // Gather target info
-    let target_status = match &target {
-        ResolvedTarget::Sqlite { database } => match LocalDb::open_readonly(database) {
-            Ok(target_db) => {
-                let tables = target_db.list_tables().await?;
-                let mut table_rows = Vec::new();
-                for table in &tables {
-                    if config.should_sync_table(table) {
-                        let count = target_db.row_count(table).await?;
-                        table_rows.push(StatusTable {
-                            name: table.clone(),
-                            rows: count,
-                        });
-                    }
-                }
-                StatusDb {
-                    connected: true,
-                    error: None,
-                    tables: table_rows,
-                }
-            }
-            Err(e) => StatusDb {
-                connected: false,
-                error: Some(e.to_string()),
-                tables: vec![],
-            },
-        },
-        ResolvedTarget::Plugin {
-            ref path,
-            ref name,
-            config: ref plugin_config,
-        } => match PluginDataSource::start(path, name, plugin_config).await {
-            Ok(plugin) => {
-                let tables = plugin.list_tables().await?;
-                let mut table_rows = Vec::new();
-                for table in &tables {
-                    if config.should_sync_table(table) {
-                        let count = plugin.row_count(table).await?;
-                        table_rows.push(StatusTable {
-                            name: table.clone(),
-                            rows: count,
-                        });
-                    }
-                }
-                StatusDb {
-                    connected: true,
-                    error: None,
-                    tables: table_rows,
-                }
-            }
-            Err(e) => StatusDb {
-                connected: false,
-                error: Some(e.to_string()),
-                tables: vec![],
-            },
+    let target_status = match TargetSource::open(&target, false).await {
+        Ok(remote) => gather_status(&remote, config).await?,
+        Err(e) => StatusDb {
+            connected: false,
+            error: Some(e.to_string()),
+            tables: vec![],
         },
     };
 
@@ -854,7 +843,7 @@ async fn run_status(
         OutputFormat::Json => {
             let out = StatusOutput {
                 command: "status",
-                status: "ok",
+                status: Status::Ok,
                 config: StatusConfig {
                     local_db: config.local_db_path().to_string(),
                     target_type: target_type.to_string(),
@@ -972,19 +961,9 @@ async fn run_stash(
     )
     .await?;
 
-    match fmt {
-        OutputFormat::Json if dry_run => print_dry_run_json("stash", &results, verbose),
-        OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("stash", &results, false);
-            println!(
-                "{}",
-                serde_json::to_string(&out).expect("CommandOutput serialization")
-            );
-        }
-        OutputFormat::Text => {
-            print_summary("Stash", &results, |r| r.rows_pushed, "stash", dry_run);
-        }
-    }
+    emit_command_output(fmt, "stash", &results, dry_run, verbose, "Stash", |r| {
+        r.rows_pushed
+    });
     Ok(())
 }
 
@@ -1009,19 +988,15 @@ async fn run_retrieve(
     )
     .await?;
 
-    match fmt {
-        OutputFormat::Json if dry_run => print_dry_run_json("retrieve", &results, verbose),
-        OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("retrieve", &results, false);
-            println!(
-                "{}",
-                serde_json::to_string(&out).expect("CommandOutput serialization")
-            );
-        }
-        OutputFormat::Text => {
-            print_summary("Retrieve", &results, |r| r.rows_pulled, "retrieve", dry_run);
-        }
-    }
+    emit_command_output(
+        fmt,
+        "retrieve",
+        &results,
+        dry_run,
+        verbose,
+        "Retrieve",
+        |r| r.rows_pulled,
+    );
     Ok(())
 }
 
@@ -1036,7 +1011,7 @@ async fn run_snapshot(config: &Config, dry_run: bool, fmt: OutputFormat) -> erro
         OutputFormat::Json => {
             let out = SnapshotOutput {
                 command: "snapshot",
-                status: if dry_run { "dry_run" } else { "ok" },
+                status: if dry_run { Status::DryRun } else { Status::Ok },
                 timestamp: result.timestamp,
                 size_bytes: result.size_bytes,
                 tables: result
@@ -1078,7 +1053,7 @@ async fn run_snapshots(config: &Config, fmt: OutputFormat) -> error::Result<()> 
         OutputFormat::Json => {
             let out = SnapshotListOutput {
                 command: "snapshots",
-                status: "ok",
+                status: Status::Ok,
                 snapshots: entries
                     .into_iter()
                     .map(|e| SnapshotListEntry {
@@ -1139,7 +1114,7 @@ async fn run_restore(
         OutputFormat::Json => {
             let out = SnapshotOutput {
                 command: "restore",
-                status: if dry_run { "dry_run" } else { "ok" },
+                status: if dry_run { Status::DryRun } else { Status::Ok },
                 timestamp: result.timestamp,
                 size_bytes: result.size_bytes,
                 tables: result

--- a/crates/smugglr/src/main.rs
+++ b/crates/smugglr/src/main.rs
@@ -176,19 +176,16 @@ impl DataSource for TargetSource {
     }
 }
 
-/// Emit the JSON/text output for a push/pull/sync/stash/retrieve result set.
-///
-/// Routes dry-run JSON to the verbose/compact dry-run shape, plain JSON to
-/// `CommandOutput`, and text to `print_summary`.
-fn emit_command_output(
+/// Emit the JSON form of a sync-style result, handling the dry-run vs plain
+/// split. Returns `true` if it printed (Json mode); `false` means the caller
+/// should render its own text summary.
+fn emit_command_json(
     fmt: OutputFormat,
     command: &'static str,
     results: &[SyncResult],
     dry_run: bool,
     verbose: bool,
-    summary_label: &str,
-    row_accessor: impl Fn(&SyncResult) -> usize,
-) {
+) -> bool {
     match fmt {
         OutputFormat::Json if dry_run => print_dry_run_json(command, results, verbose),
         OutputFormat::Json => {
@@ -198,10 +195,25 @@ fn emit_command_output(
                 serde_json::to_string(&out).expect("CommandOutput serialization")
             );
         }
-        OutputFormat::Text => {
-            print_summary(summary_label, results, row_accessor, command, dry_run);
-        }
+        OutputFormat::Text => return false,
     }
+    true
+}
+
+/// Emit a push/pull/stash/retrieve result: JSON if requested, else a
+/// one-line-per-table text summary. The heading/verb are derived from `command`.
+fn emit_command_output(
+    fmt: OutputFormat,
+    command: &'static str,
+    results: &[SyncResult],
+    dry_run: bool,
+    verbose: bool,
+    row_accessor: impl Fn(&SyncResult) -> usize,
+) {
+    if emit_command_json(fmt, command, results, dry_run, verbose) {
+        return;
+    }
+    print_summary(results, row_accessor, command, dry_run);
 }
 
 #[derive(Parser)]
@@ -567,9 +579,7 @@ async fn run_push(
     let target = TargetSource::open(&target, true).await?;
     let results = push_all(&local, &target, config, tables, dry_run, progress.as_ref()).await?;
 
-    emit_command_output(fmt, "push", &results, dry_run, verbose, "Push", |r| {
-        r.rows_pushed
-    });
+    emit_command_output(fmt, "push", &results, dry_run, verbose, |r| r.rows_pushed);
     Ok(())
 }
 
@@ -597,9 +607,7 @@ async fn run_pull(
     let target = TargetSource::open(&target, false).await?;
     let results = pull_all(&local, &target, config, tables, dry_run, progress.as_ref()).await?;
 
-    emit_command_output(fmt, "pull", &results, dry_run, verbose, "Pull", |r| {
-        r.rows_pulled
-    });
+    emit_command_output(fmt, "pull", &results, dry_run, verbose, |r| r.rows_pulled);
     Ok(())
 }
 
@@ -630,35 +638,29 @@ async fn run_sync(
     let target = TargetSource::open(&target, true).await?;
     let results = sync_all(&local, &target, config, tables, dry_run, progress.as_ref()).await?;
 
-    match fmt {
-        OutputFormat::Json if dry_run => print_dry_run_json("sync", &results, verbose),
-        OutputFormat::Json => {
-            let out = CommandOutput::from_sync_results("sync", &results);
+    // JSON output is identical to the other commands; only sync's text summary
+    // is bespoke (per-table pushed/pulled counts), so it can't use print_summary.
+    if emit_command_json(fmt, "sync", &results, dry_run, verbose) {
+        return Ok(());
+    }
+
+    println!("\n--- Sync Summary ---");
+    let mut total_pushed = 0;
+    let mut total_pulled = 0;
+    for result in &results {
+        if result.has_changes() {
             println!(
-                "{}",
-                serde_json::to_string(&out).expect("CommandOutput serialization")
+                "  {}: {} pushed, {} pulled",
+                result.table, result.rows_pushed, result.rows_pulled
             );
+            total_pushed += result.rows_pushed;
+            total_pulled += result.rows_pulled;
         }
-        OutputFormat::Text => {
-            println!("\n--- Sync Summary ---");
-            let mut total_pushed = 0;
-            let mut total_pulled = 0;
-            for result in &results {
-                if result.has_changes() {
-                    println!(
-                        "  {}: {} pushed, {} pulled",
-                        result.table, result.rows_pushed, result.rows_pulled
-                    );
-                    total_pushed += result.rows_pushed;
-                    total_pulled += result.rows_pulled;
-                }
-            }
-            if total_pushed == 0 && total_pulled == 0 {
-                println!("  No changes to sync");
-            } else if dry_run {
-                println!("\n  (dry run - no actual changes made)");
-            }
-        }
+    }
+    if total_pushed == 0 && total_pulled == 0 {
+        println!("  No changes to sync");
+    } else if dry_run {
+        println!("\n  (dry run - no actual changes made)");
     }
 
     Ok(())
@@ -749,14 +751,22 @@ async fn output_diffs<A: DataSource, B: DataSource>(
 ///
 /// `verb` is the lowercase action name used in the no-changes message
 /// (e.g. "No changes to push").
+/// Capitalize the first character of an ASCII command verb ("push" -> "Push").
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
 fn print_summary(
-    heading: &str,
     results: &[smugglr_core::sync::SyncResult],
     get_count: impl Fn(&smugglr_core::sync::SyncResult) -> usize,
     verb: &str,
     dry_run: bool,
 ) {
-    println!("\n--- {} Summary ---", heading);
+    println!("\n--- {} Summary ---", capitalize(verb));
     let mut total = 0;
     for result in results {
         let count = get_count(result);
@@ -961,9 +971,7 @@ async fn run_stash(
     )
     .await?;
 
-    emit_command_output(fmt, "stash", &results, dry_run, verbose, "Stash", |r| {
-        r.rows_pushed
-    });
+    emit_command_output(fmt, "stash", &results, dry_run, verbose, |r| r.rows_pushed);
     Ok(())
 }
 
@@ -988,15 +996,9 @@ async fn run_retrieve(
     )
     .await?;
 
-    emit_command_output(
-        fmt,
-        "retrieve",
-        &results,
-        dry_run,
-        verbose,
-        "Retrieve",
-        |r| r.rows_pulled,
-    );
+    emit_command_output(fmt, "retrieve", &results, dry_run, verbose, |r| {
+        r.rows_pulled
+    });
     Ok(())
 }
 

--- a/crates/smugglr/src/output.rs
+++ b/crates/smugglr/src/output.rs
@@ -8,32 +8,28 @@ use serde::Serialize;
 use smugglr_core::diff::TableDiff;
 use smugglr_core::sync::SyncResult;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[clap(rename_all = "lower")]
 pub enum OutputFormat {
     Text,
     Json,
 }
 
-impl std::str::FromStr for OutputFormat {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "text" => Ok(Self::Text),
-            "json" => Ok(Self::Json),
-            _ => Err(format!(
-                "invalid output format '{}', expected 'text' or 'json'",
-                s
-            )),
-        }
-    }
+/// Machine-readable status carried by every JSON output.
+///
+/// Serializes to exactly "ok" / "error" / "dry_run" -- a public wire contract.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    Ok,
+    Error,
+    DryRun,
 }
 
 #[derive(Serialize)]
 pub struct CommandOutput {
     pub command: &'static str,
-    pub status: &'static str,
-    pub dry_run: bool,
+    pub status: Status,
     pub tables: Vec<TableOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -55,25 +51,35 @@ fn is_zero(n: &usize) -> bool {
 #[derive(Serialize)]
 pub struct DiffOutput {
     pub command: &'static str,
-    pub status: &'static str,
+    pub status: Status,
     pub tables: Vec<TableDiffOutput>,
 }
 
+/// The five per-table primary-key lists shared by diff and verbose dry-run output.
+///
+/// Embedded via `#[serde(flatten)]` so the keys appear inline at the parent level,
+/// keeping the wire byte-identical with the previously-duplicated fields.
 #[derive(Serialize)]
-pub struct TableDiffOutput {
-    pub name: String,
+pub struct DiffBreakdown {
     pub local_only: Vec<String>,
     pub remote_only: Vec<String>,
     pub local_newer: Vec<String>,
     pub remote_newer: Vec<String>,
     pub content_differs: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct TableDiffOutput {
+    pub name: String,
+    #[serde(flatten)]
+    pub breakdown: DiffBreakdown,
     pub identical_count: usize,
 }
 
 #[derive(Serialize)]
 pub struct StatusOutput {
     pub command: &'static str,
-    pub status: &'static str,
+    pub status: Status,
     pub config: StatusConfig,
     pub local: StatusDb,
     pub target: StatusDb,
@@ -109,7 +115,7 @@ pub struct StatusTable {
 pub struct WatchTickOutput {
     pub command: &'static str,
     pub tick: u64,
-    pub status: &'static str,
+    pub status: Status,
     pub tables: Vec<TableOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -118,7 +124,7 @@ pub struct WatchTickOutput {
 #[derive(Serialize)]
 pub struct SnapshotOutput {
     pub command: &'static str,
-    pub status: &'static str,
+    pub status: Status,
     pub timestamp: String,
     pub size_bytes: u64,
     pub tables: Vec<SnapshotTableInfo>,
@@ -133,7 +139,7 @@ pub struct SnapshotTableInfo {
 #[derive(Serialize)]
 pub struct SnapshotListOutput {
     pub command: &'static str,
-    pub status: &'static str,
+    pub status: Status,
     pub snapshots: Vec<SnapshotListEntry>,
 }
 
@@ -147,17 +153,16 @@ pub struct SnapshotListEntry {
 #[derive(Serialize)]
 pub struct ErrorOutput {
     pub command: &'static str,
-    pub status: &'static str,
+    pub status: Status,
     pub error: String,
     pub exit_code: i32,
 }
 
 impl CommandOutput {
-    pub fn from_sync_results(command: &'static str, results: &[SyncResult], dry_run: bool) -> Self {
+    pub fn from_sync_results(command: &'static str, results: &[SyncResult]) -> Self {
         Self {
             command,
-            status: "ok",
-            dry_run,
+            status: Status::Ok,
             tables: results
                 .iter()
                 .filter(|r| r.has_changes())
@@ -180,7 +185,7 @@ impl CommandOutput {
 #[derive(Serialize)]
 pub struct DryRunOutput<T: Serialize> {
     pub command: &'static str,
-    pub status: &'static str,
+    pub status: Status,
     pub tables: Vec<T>,
     pub total_rows_to_push: usize,
     pub total_rows_to_pull: usize,
@@ -203,11 +208,8 @@ pub struct DryRunTableOutput {
 #[derive(Serialize)]
 pub struct DryRunVerboseTableOutput {
     pub name: String,
-    pub local_only: Vec<String>,
-    pub remote_only: Vec<String>,
-    pub local_newer: Vec<String>,
-    pub remote_newer: Vec<String>,
-    pub content_differs: Vec<String>,
+    #[serde(flatten)]
+    pub breakdown: DiffBreakdown,
     pub identical: usize,
     pub rows_to_push: usize,
     pub rows_to_pull: usize,
@@ -232,7 +234,7 @@ impl<T: Serialize> DryRunOutput<T> {
 
         Self {
             command,
-            status: "dry_run",
+            status: Status::DryRun,
             tables,
             total_rows_to_push: total_push,
             total_rows_to_pull: total_pull,
@@ -266,13 +268,15 @@ impl DryRunOutput<DryRunVerboseTableOutput> {
             let detail = r.diff_detail.as_ref();
             DryRunVerboseTableOutput {
                 name: r.table.clone(),
-                local_only: detail.map(|d| d.local_only.clone()).unwrap_or_default(),
-                remote_only: detail.map(|d| d.remote_only.clone()).unwrap_or_default(),
-                local_newer: detail.map(|d| d.local_newer.clone()).unwrap_or_default(),
-                remote_newer: detail.map(|d| d.remote_newer.clone()).unwrap_or_default(),
-                content_differs: detail
-                    .map(|d| d.content_differs.clone())
-                    .unwrap_or_default(),
+                breakdown: DiffBreakdown {
+                    local_only: detail.map(|d| d.local_only.clone()).unwrap_or_default(),
+                    remote_only: detail.map(|d| d.remote_only.clone()).unwrap_or_default(),
+                    local_newer: detail.map(|d| d.local_newer.clone()).unwrap_or_default(),
+                    remote_newer: detail.map(|d| d.remote_newer.clone()).unwrap_or_default(),
+                    content_differs: detail
+                        .map(|d| d.content_differs.clone())
+                        .unwrap_or_default(),
+                },
                 identical: r.diff_stats.as_ref().map(|s| s.identical).unwrap_or(0),
                 rows_to_push: r.rows_pushed,
                 rows_to_pull: r.rows_pulled,
@@ -285,17 +289,19 @@ impl DiffOutput {
     pub fn from_diffs(diffs: Vec<(String, TableDiff)>) -> Self {
         Self {
             command: "diff",
-            status: "ok",
+            status: Status::Ok,
             tables: diffs
                 .into_iter()
                 .map(|(name, d)| TableDiffOutput {
                     name,
                     identical_count: d.identical.len(),
-                    local_only: d.local_only,
-                    remote_only: d.remote_only,
-                    local_newer: d.local_newer,
-                    remote_newer: d.remote_newer,
-                    content_differs: d.content_differs,
+                    breakdown: DiffBreakdown {
+                        local_only: d.local_only,
+                        remote_only: d.remote_only,
+                        local_newer: d.local_newer,
+                        remote_newer: d.remote_newer,
+                        content_differs: d.content_differs,
+                    },
                 })
                 .collect(),
         }
@@ -307,7 +313,7 @@ impl WatchTickOutput {
         Self {
             command: "watch",
             tick,
-            status: "ok",
+            status: Status::Ok,
             tables: results
                 .iter()
                 .filter(|r| r.has_changes())
@@ -325,7 +331,7 @@ impl WatchTickOutput {
         Self {
             command: "watch",
             tick,
-            status: "error",
+            status: Status::Error,
             tables: vec![],
             error: Some(err.to_string()),
         }
@@ -340,9 +346,16 @@ mod tests {
 
     #[test]
     fn test_output_format_parse() {
-        assert_eq!("text".parse::<OutputFormat>().unwrap(), OutputFormat::Text);
-        assert_eq!("json".parse::<OutputFormat>().unwrap(), OutputFormat::Json);
-        assert!("xml".parse::<OutputFormat>().is_err());
+        use clap::ValueEnum;
+        assert_eq!(
+            OutputFormat::from_str("text", true).unwrap(),
+            OutputFormat::Text
+        );
+        assert_eq!(
+            OutputFormat::from_str("json", true).unwrap(),
+            OutputFormat::Json
+        );
+        assert!(OutputFormat::from_str("xml", true).is_err());
     }
 
     #[test]
@@ -364,38 +377,18 @@ mod tests {
             },
         ];
 
-        let out = CommandOutput::from_sync_results("push", &results, false);
+        let out = CommandOutput::from_sync_results("push", &results);
         let json = serde_json::to_string(&out).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
 
         assert_eq!(v["command"], "push");
         assert_eq!(v["status"], "ok");
-        assert_eq!(v["dry_run"], false);
         // Only abilities should appear (items had 0 changes)
         assert_eq!(v["tables"].as_array().unwrap().len(), 1);
         assert_eq!(v["tables"][0]["name"], "abilities");
         assert_eq!(v["tables"][0]["rows_pushed"], 42);
         // error should be absent (skip_serializing_if)
         assert!(v.get("error").is_none());
-    }
-
-    #[test]
-    fn test_command_output_dry_run() {
-        let results = vec![SyncResult {
-            table: "t".into(),
-            rows_pushed: 10,
-            rows_pulled: 5,
-            diff_stats: None,
-            diff_detail: None,
-        }];
-
-        let out = CommandOutput::from_sync_results("sync", &results, true);
-        let json = serde_json::to_string(&out).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(v["dry_run"], true);
-        assert_eq!(v["tables"][0]["rows_pushed"], 10);
-        assert_eq!(v["tables"][0]["rows_pulled"], 5);
     }
 
     #[test]
@@ -451,7 +444,7 @@ mod tests {
     fn test_error_output_json() {
         let out = ErrorOutput {
             command: "push",
-            status: "error",
+            status: Status::Error,
             error: "Config file not found".into(),
             exit_code: 2,
         };
@@ -467,7 +460,7 @@ mod tests {
     fn test_status_output_json() {
         let out = StatusOutput {
             command: "status",
-            status: "ok",
+            status: Status::Ok,
             config: StatusConfig {
                 local_db: "game.db".into(),
                 target_type: "sqlite".into(),
@@ -637,5 +630,343 @@ mod tests {
         assert_eq!(t["identical"], 10);
         assert_eq!(t["rows_to_push"], 3);
         assert_eq!(t["rows_to_pull"], 1);
+    }
+
+    // ---- Golden wire tests ----
+    //
+    // These capture the FULL serialized shape of every output struct via
+    // `serde_json::to_value` compared against a `json!` literal. Any field
+    // add/remove/rename breaks them. `serde_json::Value` map comparison is
+    // order-insensitive, so they guard keys+values, not field order.
+
+    use serde_json::json;
+
+    #[test]
+    fn golden_command_output() {
+        let results = vec![
+            SyncResult {
+                table: "abilities".into(),
+                rows_pushed: 42,
+                rows_pulled: 0,
+                diff_stats: None,
+                diff_detail: None,
+            },
+            SyncResult {
+                table: "items".into(),
+                rows_pushed: 0,
+                rows_pulled: 0,
+                diff_stats: None,
+                diff_detail: None,
+            },
+        ];
+        let out = CommandOutput::from_sync_results("push", &results);
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "push",
+                "status": "ok",
+                "tables": [
+                    { "name": "abilities", "rows_pushed": 42 }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn golden_command_output_no_changed_table() {
+        let results = vec![SyncResult {
+            table: "items".into(),
+            rows_pushed: 0,
+            rows_pulled: 0,
+            diff_stats: None,
+            diff_detail: None,
+        }];
+        let out = CommandOutput::from_sync_results("pull", &results);
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "pull",
+                "status": "ok",
+                "tables": []
+            })
+        );
+    }
+
+    #[test]
+    fn golden_diff_output() {
+        let mut diff = TableDiff::new("abilities");
+        diff.local_only = vec!["pk1".into(), "pk2".into()];
+        diff.remote_only = vec!["pk3".into()];
+        diff.local_newer = vec!["pk4".into()];
+        diff.remote_newer = vec!["pk5".into()];
+        diff.content_differs = vec!["pk6".into()];
+        diff.identical = vec!["pk7".into(), "pk8".into()];
+
+        let out = DiffOutput::from_diffs(vec![("abilities".into(), diff)]);
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "diff",
+                "status": "ok",
+                "tables": [{
+                    "name": "abilities",
+                    "local_only": ["pk1", "pk2"],
+                    "remote_only": ["pk3"],
+                    "local_newer": ["pk4"],
+                    "remote_newer": ["pk5"],
+                    "content_differs": ["pk6"],
+                    "identical_count": 2
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn golden_status_output() {
+        let out = StatusOutput {
+            command: "status",
+            status: Status::Ok,
+            config: StatusConfig {
+                local_db: "game.db".into(),
+                target_type: "sqlite".into(),
+                timestamp_column: "updated_at".into(),
+                conflict_resolution: "NewerWins".into(),
+                tables: vec!["abilities".into(), "items".into()],
+                exclude_tables: vec!["_migrations".into()],
+            },
+            local: StatusDb {
+                connected: true,
+                error: None,
+                tables: vec![StatusTable {
+                    name: "abilities".into(),
+                    rows: 100,
+                }],
+            },
+            target: StatusDb {
+                connected: false,
+                error: Some("connection refused".into()),
+                tables: vec![],
+            },
+        };
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "status",
+                "status": "ok",
+                "config": {
+                    "local_db": "game.db",
+                    "target_type": "sqlite",
+                    "timestamp_column": "updated_at",
+                    "conflict_resolution": "NewerWins",
+                    "tables": ["abilities", "items"],
+                    "exclude_tables": ["_migrations"]
+                },
+                "local": {
+                    "connected": true,
+                    "tables": [{ "name": "abilities", "rows": 100 }]
+                },
+                "target": {
+                    "connected": false,
+                    "error": "connection refused",
+                    "tables": []
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn golden_watch_tick_output() {
+        let results = vec![SyncResult {
+            table: "t".into(),
+            rows_pushed: 3,
+            rows_pulled: 7,
+            diff_stats: None,
+            diff_detail: None,
+        }];
+        let out = WatchTickOutput::from_results(5, &results);
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "watch",
+                "tick": 5,
+                "status": "ok",
+                "tables": [{ "name": "t", "rows_pushed": 3, "rows_pulled": 7 }]
+            })
+        );
+    }
+
+    #[test]
+    fn golden_watch_tick_error_output() {
+        let out = WatchTickOutput::from_error(3, "connection timeout");
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "watch",
+                "tick": 3,
+                "status": "error",
+                "tables": [],
+                "error": "connection timeout"
+            })
+        );
+    }
+
+    #[test]
+    fn golden_snapshot_output() {
+        let out = SnapshotOutput {
+            command: "snapshot",
+            status: Status::Ok,
+            timestamp: "2026-05-30T00:00:00Z".into(),
+            size_bytes: 4096,
+            tables: vec![SnapshotTableInfo {
+                name: "abilities".into(),
+                row_count: 100,
+            }],
+        };
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "snapshot",
+                "status": "ok",
+                "timestamp": "2026-05-30T00:00:00Z",
+                "size_bytes": 4096,
+                "tables": [{ "name": "abilities", "row_count": 100 }]
+            })
+        );
+    }
+
+    #[test]
+    fn golden_snapshot_list_output() {
+        let out = SnapshotListOutput {
+            command: "snapshots",
+            status: Status::Ok,
+            snapshots: vec![SnapshotListEntry {
+                timestamp: "2026-05-30T00:00:00Z".into(),
+                size_bytes: 4096,
+                tables: vec![SnapshotTableInfo {
+                    name: "abilities".into(),
+                    row_count: 100,
+                }],
+            }],
+        };
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "snapshots",
+                "status": "ok",
+                "snapshots": [{
+                    "timestamp": "2026-05-30T00:00:00Z",
+                    "size_bytes": 4096,
+                    "tables": [{ "name": "abilities", "row_count": 100 }]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn golden_error_output() {
+        let out = ErrorOutput {
+            command: "push",
+            status: Status::Error,
+            error: "Config file not found".into(),
+            exit_code: 2,
+        };
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "push",
+                "status": "error",
+                "error": "Config file not found",
+                "exit_code": 2
+            })
+        );
+    }
+
+    #[test]
+    fn golden_dry_run_output_compact() {
+        use smugglr_core::diff::DiffStats;
+        let results = vec![SyncResult {
+            table: "abilities".into(),
+            rows_pushed: 8,
+            rows_pulled: 3,
+            diff_stats: Some(DiffStats {
+                local_only: 3,
+                remote_only: 1,
+                local_newer: 5,
+                remote_newer: 2,
+                content_differs: 0,
+                identical: 142,
+            }),
+            diff_detail: None,
+        }];
+        let out = DryRunOutput::<DryRunTableOutput>::from_sync_results("sync", &results);
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "sync",
+                "status": "dry_run",
+                "tables": [{
+                    "name": "abilities",
+                    "local_only": 3,
+                    "remote_only": 1,
+                    "local_newer": 5,
+                    "remote_newer": 2,
+                    "content_differs": 0,
+                    "identical": 142,
+                    "rows_to_push": 8,
+                    "rows_to_pull": 3
+                }],
+                "total_rows_to_push": 8,
+                "total_rows_to_pull": 3,
+                "exit_code": 0
+            })
+        );
+    }
+
+    #[test]
+    fn golden_dry_run_output_verbose() {
+        use smugglr_core::diff::DiffStats;
+        use smugglr_core::sync::DiffDetail;
+        let results = vec![SyncResult {
+            table: "abilities".into(),
+            rows_pushed: 3,
+            rows_pulled: 1,
+            diff_stats: Some(DiffStats {
+                local_only: 2,
+                remote_only: 1,
+                local_newer: 1,
+                remote_newer: 0,
+                content_differs: 0,
+                identical: 10,
+            }),
+            diff_detail: Some(DiffDetail {
+                local_only: vec!["pk1".into(), "pk2".into()],
+                remote_only: vec!["pk3".into()],
+                local_newer: vec!["pk4".into()],
+                remote_newer: vec![],
+                content_differs: vec![],
+            }),
+        }];
+        let out = DryRunOutput::<DryRunVerboseTableOutput>::from_sync_results("push", &results);
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "push",
+                "status": "dry_run",
+                "tables": [{
+                    "name": "abilities",
+                    "local_only": ["pk1", "pk2"],
+                    "remote_only": ["pk3"],
+                    "local_newer": ["pk4"],
+                    "remote_newer": [],
+                    "content_differs": [],
+                    "identical": 10,
+                    "rows_to_push": 3,
+                    "rows_to_pull": 1
+                }],
+                "total_rows_to_push": 3,
+                "total_rows_to_pull": 1,
+                "exit_code": 0
+            })
+        );
     }
 }


### PR DESCRIPTION
Closes #150. Cuts the duplicated command/output plumbing in the CLI and makes the agent-facing JSON status type-safe.

**Dedup:** TargetSource enum (Sqlite/Plugin) impl DataSource by delegation, replacing the 2-arm `match target` copy-pasted across push/pull/sync/diff; emit_command_output() for the shared 3-arm fmt block; gather_status() for the 3x-duplicated connect/list/row_count block; run_diff collapsed to one open + output_diffs; DiffBreakdown shared via `#[serde(flatten)]` by TableDiffOutput and DryRunVerboseTableOutput.

**Type safety:** `enum Status { Ok, Error, DryRun }` (serde snake_case) replaces `status: &'static str` across all 8 output structs; OutputFormat derives clap::ValueEnum so `--help` lists text/json.

**JSON wire: byte-identical**, guarded by **11 new whole-object golden tests** (serde_json::to_value vs json! literals) -- with ONE intentional change flagged for review: the always-false **`CommandOutput.dry_run` field is dropped**. It was dead in production (real dry-runs emit DryRunOutput, so CommandOutput.dry_run was always `false`). If you'd rather keep it on the wire, say so and I'll restore it. build/test(21)/clippy --workspace -D warnings/fmt clean. From the structural-debt audit.