### PR TITLE
refactor(#151): dedup the two WASM adapters into adapter_common

### DIFF
--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -1,0 +1,142 @@
+//! Shared pure helpers for the wasm DataSource adapters.
+//!
+//! Both `FetchDataSource` (HTTP SQL) and `LocalSqlDataSource` (JS executor)
+//! need the same SQL-string building, row reshaping, and content hashing.
+//! These functions are self-free (no adapter state) so they live here once
+//! and are called from both adapters as `adapter_common::<fn>`.
+
+use sha2::{Digest, Sha256};
+use smugglr_core::config::column_excluded;
+use smugglr_core::datasource::RowMeta;
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+/// Reshape positional result rows into per-row column->value maps.
+pub(crate) fn rows_to_maps(columns: &[String], rows: &[Vec<Value>]) -> Vec<HashMap<String, Value>> {
+    rows.iter()
+        .map(|row| {
+            columns
+                .iter()
+                .zip(row.iter())
+                .map(|(col, val)| (col.clone(), val.clone()))
+                .collect()
+        })
+        .collect()
+}
+
+/// Build a SQLite expression that casts primary key columns to TEXT.
+///
+/// For single-column PKs this is `CAST("col" AS TEXT)`. For composite PKs
+/// the parts are joined with `|` to produce a stable string form matching
+/// the rest of smugglr's primary key encoding.
+pub(crate) fn build_pk_text_expr(primary_key: &[String]) -> String {
+    if primary_key.len() == 1 {
+        format!("CAST(\"{}\" AS TEXT)", primary_key[0])
+    } else {
+        primary_key
+            .iter()
+            .map(|k| format!("CAST(\"{}\" AS TEXT)", k))
+            .collect::<Vec<_>>()
+            .join(" || '|' || ")
+    }
+}
+
+/// Convert result rows (each with a synthetic `__pk` column) into RowMeta
+/// entries keyed by primary key. Used by both full-scan and incremental
+/// metadata fetches.
+pub(crate) fn row_maps_to_metadata(
+    maps: &[HashMap<String, Value>],
+    column_order: &[String],
+    timestamp_column: &str,
+    exclude_columns: &[String],
+) -> HashMap<String, RowMeta> {
+    let mut result = HashMap::with_capacity(maps.len());
+    for row in maps {
+        let pk = row
+            .get("__pk")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let updated_at = row
+            .get(timestamp_column)
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let content_hash = content_hash(row, column_order, exclude_columns, timestamp_column);
+
+        result.insert(
+            pk.clone(),
+            RowMeta {
+                pk_value: pk,
+                updated_at,
+                content_hash,
+            },
+        );
+    }
+    result
+}
+
+/// Content hash matching smugglr-core local.rs exactly, including the
+/// glob-pattern column exclusion (via `column_excluded`) -- exact-string
+/// matching here would diverge from transfer-time stripping and produce
+/// phantom `content_differs` for glob-excluded columns.
+pub(crate) fn content_hash(
+    row: &HashMap<String, Value>,
+    columns_in_order: &[String],
+    exclude: &[String],
+    timestamp_column: &str,
+) -> String {
+    let timestamp_columns = ["updated_at", "created_at"];
+    let mut hasher = Sha256::new();
+    for col in columns_in_order {
+        if timestamp_columns.contains(&col.as_str())
+            || column_excluded(col, exclude)
+            || col == timestamp_column
+        {
+            continue;
+        }
+        if let Some(val) = row.get(col) {
+            match val {
+                Value::Null => {}
+                Value::String(s) => hasher.update(s.as_bytes()),
+                Value::Number(n) => hasher.update(n.to_string().as_bytes()),
+                Value::Bool(b) => hasher.update(if *b { "1" } else { "0" }.as_bytes()),
+                other => hasher.update(other.to_string().as_bytes()),
+            }
+        }
+        hasher.update(b"|");
+    }
+    hex::encode(hasher.finalize())
+}
+
+/// Build an `INSERT OR REPLACE` batch statement plus its flattened params.
+pub(crate) fn generate_batch_sql(
+    table: &str,
+    columns: &[String],
+    rows: &[HashMap<String, Value>],
+) -> (String, Vec<Value>) {
+    let col_list = columns
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let row_placeholder = format!("({})", vec!["?"; columns.len()].join(", "));
+    let all_placeholders = vec![row_placeholder.as_str(); rows.len()].join(", ");
+
+    let sql = format!(
+        "INSERT OR REPLACE INTO \"{}\" ({}) VALUES {}",
+        table, col_list, all_placeholders
+    );
+
+    let params: Vec<Value> = rows
+        .iter()
+        .flat_map(|row| {
+            columns
+                .iter()
+                .map(|c| row.get(c).cloned().unwrap_or(Value::Null))
+        })
+        .collect();
+
+    (sql, params)
+}

--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -7,10 +7,57 @@
 
 use sha2::{Digest, Sha256};
 use smugglr_core::config::column_excluded;
-use smugglr_core::datasource::RowMeta;
+use smugglr_core::datasource::{ColumnInfo, RowMeta, TableInfo};
 use std::collections::HashMap;
 
 use serde_json::Value;
+
+/// Parse the rows of a `PRAGMA table_info(...)` result into a [`TableInfo`].
+///
+/// Shared by both adapters, which differ only in how they obtain the
+/// `(columns, rows)` pair: `LocalSqlDataSource` via `run()`, `FetchDataSource`
+/// via `execute()` + `extract_columns`/`extract_rows`.
+pub(crate) fn parse_table_info(table: &str, columns: &[String], rows: &[Vec<Value>]) -> TableInfo {
+    let name_idx = columns.iter().position(|c| c == "name").unwrap_or(1);
+    let type_idx = columns.iter().position(|c| c == "type").unwrap_or(2);
+    let notnull_idx = columns.iter().position(|c| c == "notnull").unwrap_or(3);
+    let pk_idx = columns.iter().position(|c| c == "pk").unwrap_or(5);
+
+    let mut col_infos = Vec::new();
+    let mut primary_key = Vec::new();
+
+    for row in rows {
+        let name = row
+            .get(name_idx)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let col_type = row
+            .get(type_idx)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let notnull = row.get(notnull_idx).and_then(|v| v.as_i64()).unwrap_or(0) != 0;
+        let pk = row.get(pk_idx).and_then(|v| v.as_i64()).unwrap_or(0) != 0;
+
+        if pk {
+            primary_key.push(name.clone());
+        }
+
+        col_infos.push(ColumnInfo {
+            name,
+            col_type,
+            notnull,
+            pk,
+        });
+    }
+
+    TableInfo {
+        name: table.to_string(),
+        columns: col_infos,
+        primary_key,
+    }
+}
 
 /// Reshape positional result rows into per-row column->value maps.
 pub(crate) fn rows_to_maps(columns: &[String], rows: &[Vec<Value>]) -> Vec<HashMap<String, Value>> {

--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -3,12 +3,12 @@
 //! Implements the DataSource trait from smugglr-core using web-sys fetch
 //! instead of reqwest. Shares profile definitions with the native http-sql plugin.
 
-use sha2::{Digest, Sha256};
-use smugglr_core::config::column_excluded;
 use smugglr_core::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
 use smugglr_core::error::{Result, SyncError};
 use smugglr_core::profile::{AuthFormat, Profile};
 use std::collections::HashMap;
+
+use crate::adapter_common;
 
 use serde_json::Value;
 use wasm_bindgen::JsCast;
@@ -191,103 +191,6 @@ impl FetchDataSource {
         Err(SyncError::Remote("columns not found in response".into()))
     }
 
-    fn rows_to_maps(&self, columns: &[String], rows: &[Vec<Value>]) -> Vec<HashMap<String, Value>> {
-        rows.iter()
-            .map(|row| {
-                columns
-                    .iter()
-                    .zip(row.iter())
-                    .map(|(col, val)| (col.clone(), val.clone()))
-                    .collect()
-            })
-            .collect()
-    }
-
-    /// Build a SQLite expression that casts primary key columns to TEXT.
-    ///
-    /// For single-column PKs this is `CAST("col" AS TEXT)`. For composite PKs
-    /// the parts are joined with `|` to produce a stable string form matching
-    /// the rest of smugglr's primary key encoding.
-    fn build_pk_text_expr(primary_key: &[String]) -> String {
-        if primary_key.len() == 1 {
-            format!("CAST(\"{}\" AS TEXT)", primary_key[0])
-        } else {
-            primary_key
-                .iter()
-                .map(|k| format!("CAST(\"{}\" AS TEXT)", k))
-                .collect::<Vec<_>>()
-                .join(" || '|' || ")
-        }
-    }
-
-    /// Convert result rows (each with a synthetic `__pk` column) into RowMeta
-    /// entries keyed by primary key. Used by both full-scan and incremental
-    /// metadata fetches.
-    fn row_maps_to_metadata(
-        maps: &[HashMap<String, Value>],
-        column_order: &[String],
-        timestamp_column: &str,
-        exclude_columns: &[String],
-    ) -> HashMap<String, RowMeta> {
-        let mut result = HashMap::with_capacity(maps.len());
-        for row in maps {
-            let pk = row
-                .get("__pk")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let updated_at = row
-                .get(timestamp_column)
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            let content_hash =
-                Self::content_hash(row, column_order, exclude_columns, timestamp_column);
-
-            result.insert(
-                pk.clone(),
-                RowMeta {
-                    pk_value: pk,
-                    updated_at,
-                    content_hash,
-                },
-            );
-        }
-        result
-    }
-
-    /// Content hash matching smugglr-core local.rs exactly, including the
-    /// glob-pattern column exclusion (via `column_excluded`) -- exact-string
-    /// matching here would diverge from transfer-time stripping and produce
-    /// phantom `content_differs` for glob-excluded columns.
-    fn content_hash(
-        row: &HashMap<String, Value>,
-        columns_in_order: &[String],
-        exclude: &[String],
-        timestamp_column: &str,
-    ) -> String {
-        let timestamp_columns = ["updated_at", "created_at"];
-        let mut hasher = Sha256::new();
-        for col in columns_in_order {
-            if timestamp_columns.contains(&col.as_str())
-                || column_excluded(col, exclude)
-                || col == timestamp_column
-            {
-                continue;
-            }
-            if let Some(val) = row.get(col) {
-                match val {
-                    Value::Null => {}
-                    Value::String(s) => hasher.update(s.as_bytes()),
-                    Value::Number(n) => hasher.update(n.to_string().as_bytes()),
-                    Value::Bool(b) => hasher.update(if *b { "1" } else { "0" }.as_bytes()),
-                    other => hasher.update(other.to_string().as_bytes()),
-                }
-            }
-            hasher.update(b"|");
-        }
-        hex::encode(hasher.finalize())
-    }
-
     /// Query row metadata for rows with `timestamp_column > since_timestamp`.
     ///
     /// Used by the incremental diff path to fetch only changed rows instead of
@@ -307,7 +210,7 @@ impl FetchDataSource {
             )));
         }
 
-        let pk_expr = Self::build_pk_text_expr(&info.primary_key);
+        let pk_expr = adapter_common::build_pk_text_expr(&info.primary_key);
         let column_order: Vec<String> = info.columns.iter().map(|c| c.name.clone()).collect();
         let sql = format!(
             "SELECT *, {} AS __pk FROM \"{}\" WHERE \"{}\" > ?",
@@ -317,9 +220,9 @@ impl FetchDataSource {
         let response = self.execute(&sql, &params).await?;
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
-        let maps = self.rows_to_maps(&columns, &rows);
+        let maps = adapter_common::rows_to_maps(&columns, &rows);
 
-        Ok(Self::row_maps_to_metadata(
+        Ok(adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
             timestamp_column,
@@ -345,37 +248,6 @@ impl FetchDataSource {
         } else {
             None
         }
-    }
-
-    fn generate_batch_sql(
-        table: &str,
-        columns: &[String],
-        rows: &[HashMap<String, Value>],
-    ) -> (String, Vec<Value>) {
-        let col_list = columns
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        let row_placeholder = format!("({})", vec!["?"; columns.len()].join(", "));
-        let all_placeholders = vec![row_placeholder.as_str(); rows.len()].join(", ");
-
-        let sql = format!(
-            "INSERT OR REPLACE INTO \"{}\" ({}) VALUES {}",
-            table, col_list, all_placeholders
-        );
-
-        let params: Vec<Value> = rows
-            .iter()
-            .flat_map(|row| {
-                columns
-                    .iter()
-                    .map(|c| row.get(c).cloned().unwrap_or(Value::Null))
-            })
-            .collect();
-
-        (sql, params)
     }
 }
 
@@ -461,15 +333,15 @@ impl DataSource for FetchDataSource {
             )));
         }
 
-        let pk_expr = Self::build_pk_text_expr(&info.primary_key);
+        let pk_expr = adapter_common::build_pk_text_expr(&info.primary_key);
         let column_order: Vec<String> = info.columns.iter().map(|c| c.name.clone()).collect();
         let sql = format!("SELECT *, {} AS __pk FROM \"{}\"", pk_expr, table);
         let response = self.execute(&sql, &[]).await?;
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
-        let maps = self.rows_to_maps(&columns, &rows);
+        let maps = adapter_common::rows_to_maps(&columns, &rows);
 
-        Ok(Self::row_maps_to_metadata(
+        Ok(adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
             timestamp_column,
@@ -487,7 +359,7 @@ impl DataSource for FetchDataSource {
         }
 
         let info = self.cached_table_info(table).await?;
-        let pk_expr = Self::build_pk_text_expr(&info.primary_key);
+        let pk_expr = adapter_common::build_pk_text_expr(&info.primary_key);
 
         let placeholders: Vec<String> = pk_values.iter().map(|_| "?".to_string()).collect();
         let params: Vec<Value> = pk_values.iter().map(|v| Value::String(v.clone())).collect();
@@ -501,7 +373,7 @@ impl DataSource for FetchDataSource {
         let response = self.execute(&sql, &params).await?;
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
-        Ok(self.rows_to_maps(&columns, &rows))
+        Ok(adapter_common::rows_to_maps(&columns, &rows))
     }
 
     async fn upsert_rows(&self, table: &str, rows: &[HashMap<String, Value>]) -> Result<usize> {
@@ -515,7 +387,7 @@ impl DataSource for FetchDataSource {
 
         let mut total = 0;
         for batch in rows.chunks(batch_size) {
-            let (sql, params) = Self::generate_batch_sql(table, &columns, batch);
+            let (sql, params) = adapter_common::generate_batch_sql(table, &columns, batch);
 
             self.execute(&sql, &params).await.map_err(|e| {
                 SyncError::Remote(format!(

--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -3,7 +3,7 @@
 //! Implements the DataSource trait from smugglr-core using web-sys fetch
 //! instead of reqwest. Shares profile definitions with the native http-sql plugin.
 
-use smugglr_core::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
+use smugglr_core::datasource::{DataSource, RowMeta, TableInfo};
 use smugglr_core::error::{Result, SyncError};
 use smugglr_core::profile::{AuthFormat, Profile};
 use std::collections::HashMap;
@@ -277,46 +277,7 @@ impl DataSource for FetchDataSource {
 
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
-
-        let name_idx = columns.iter().position(|c| c == "name").unwrap_or(1);
-        let type_idx = columns.iter().position(|c| c == "type").unwrap_or(2);
-        let notnull_idx = columns.iter().position(|c| c == "notnull").unwrap_or(3);
-        let pk_idx = columns.iter().position(|c| c == "pk").unwrap_or(5);
-
-        let mut col_infos = Vec::new();
-        let mut primary_key = Vec::new();
-
-        for row in &rows {
-            let name = row
-                .get(name_idx)
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let col_type = row
-                .get(type_idx)
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let notnull = row.get(notnull_idx).and_then(|v| v.as_i64()).unwrap_or(0) != 0;
-            let pk = row.get(pk_idx).and_then(|v| v.as_i64()).unwrap_or(0) != 0;
-
-            if pk {
-                primary_key.push(name.clone());
-            }
-
-            col_infos.push(ColumnInfo {
-                name,
-                col_type,
-                notnull,
-                pk,
-            });
-        }
-
-        Ok(TableInfo {
-            name: table.to_string(),
-            columns: col_infos,
-            primary_key,
-        })
+        Ok(adapter_common::parse_table_info(table, &columns, &rows))
     }
 
     async fn get_row_metadata(

--- a/crates/smugglr-wasm/src/lib.rs
+++ b/crates/smugglr-wasm/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![cfg(target_arch = "wasm32")]
 
+mod adapter_common;
 mod fetch_adapter;
 mod local_adapter;
 
@@ -779,7 +780,7 @@ impl Smugglr {
             )
         })?;
         let dry_run = dry_run.unwrap_or(false);
-        let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
+        let tables = get_sync_tables(&self.source, dest, &self.sync_config).await?;
         let conflict = self.sync_config.conflict_resolution;
         let batch_size = self.sync_config.batch_size;
 
@@ -787,7 +788,7 @@ impl Smugglr {
         for table in &tables {
             let diff = diff_table_cached(
                 &self.source,
-                &dest,
+                dest,
                 &self.source_cache,
                 &self.dest_cache,
                 table,
@@ -802,7 +803,7 @@ impl Smugglr {
             } else {
                 transfer_rows(
                     &self.source,
-                    &dest,
+                    dest,
                     table,
                     &to_push,
                     batch_size,
@@ -838,7 +839,7 @@ impl Smugglr {
             )
         })?;
         let dry_run = dry_run.unwrap_or(false);
-        let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
+        let tables = get_sync_tables(&self.source, dest, &self.sync_config).await?;
         let conflict = self.sync_config.conflict_resolution;
         let batch_size = self.sync_config.batch_size;
 
@@ -846,7 +847,7 @@ impl Smugglr {
         for table in &tables {
             let diff = diff_table_cached(
                 &self.source,
-                &dest,
+                dest,
                 &self.source_cache,
                 &self.dest_cache,
                 table,
@@ -860,7 +861,7 @@ impl Smugglr {
                 to_pull.len()
             } else {
                 let n = transfer_rows(
-                    &dest,
+                    dest,
                     &self.source,
                     table,
                     &to_pull,
@@ -901,7 +902,7 @@ impl Smugglr {
             )
         })?;
         let dry_run = dry_run.unwrap_or(false);
-        let tables = get_sync_tables(&self.source, &dest, &self.sync_config).await?;
+        let tables = get_sync_tables(&self.source, dest, &self.sync_config).await?;
         let conflict = self.sync_config.conflict_resolution;
         let batch_size = self.sync_config.batch_size;
 
@@ -909,7 +910,7 @@ impl Smugglr {
         for table in &tables {
             let diff = diff_table_cached(
                 &self.source,
-                &dest,
+                dest,
                 &self.source_cache,
                 &self.dest_cache,
                 table,
@@ -926,7 +927,7 @@ impl Smugglr {
             } else {
                 transfer_rows(
                     &self.source,
-                    &dest,
+                    dest,
                     table,
                     &to_push,
                     batch_size,
@@ -939,7 +940,7 @@ impl Smugglr {
                 to_pull.len()
             } else {
                 let n = transfer_rows(
-                    &dest,
+                    dest,
                     &self.source,
                     table,
                     &to_pull,

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -6,11 +6,11 @@
 //! better-sqlite3 (Node), official sqlite-wasm, or sql.js without
 //! changes here.
 
-use sha2::{Digest, Sha256};
-use smugglr_core::config::column_excluded;
 use smugglr_core::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
 use smugglr_core::error::{Result, SyncError};
 use std::collections::HashMap;
+
+use crate::adapter_common;
 
 use serde_json::Value;
 use wasm_bindgen::prelude::*;
@@ -68,90 +68,6 @@ impl LocalSqlDataSource {
             .map_err(|e| SyncError::Remote(format!("invalid executor result shape: {}", e)))
     }
 
-    fn rows_to_maps(&self, columns: &[String], rows: &[Vec<Value>]) -> Vec<HashMap<String, Value>> {
-        rows.iter()
-            .map(|row| {
-                columns
-                    .iter()
-                    .zip(row.iter())
-                    .map(|(col, val)| (col.clone(), val.clone()))
-                    .collect()
-            })
-            .collect()
-    }
-
-    fn build_pk_text_expr(primary_key: &[String]) -> String {
-        if primary_key.len() == 1 {
-            format!("CAST(\"{}\" AS TEXT)", primary_key[0])
-        } else {
-            primary_key
-                .iter()
-                .map(|k| format!("CAST(\"{}\" AS TEXT)", k))
-                .collect::<Vec<_>>()
-                .join(" || '|' || ")
-        }
-    }
-
-    fn row_maps_to_metadata(
-        maps: &[HashMap<String, Value>],
-        column_order: &[String],
-        timestamp_column: &str,
-        exclude_columns: &[String],
-    ) -> HashMap<String, RowMeta> {
-        let mut result = HashMap::with_capacity(maps.len());
-        for row in maps {
-            let pk = row
-                .get("__pk")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let updated_at = row
-                .get(timestamp_column)
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            let content_hash =
-                Self::content_hash(row, column_order, exclude_columns, timestamp_column);
-            result.insert(
-                pk.clone(),
-                RowMeta {
-                    pk_value: pk,
-                    updated_at,
-                    content_hash,
-                },
-            );
-        }
-        result
-    }
-
-    fn content_hash(
-        row: &HashMap<String, Value>,
-        columns_in_order: &[String],
-        exclude: &[String],
-        timestamp_column: &str,
-    ) -> String {
-        let timestamp_columns = ["updated_at", "created_at"];
-        let mut hasher = Sha256::new();
-        for col in columns_in_order {
-            if timestamp_columns.contains(&col.as_str())
-                || column_excluded(col, exclude)
-                || col == timestamp_column
-            {
-                continue;
-            }
-            if let Some(val) = row.get(col) {
-                match val {
-                    Value::Null => {}
-                    Value::String(s) => hasher.update(s.as_bytes()),
-                    Value::Number(n) => hasher.update(n.to_string().as_bytes()),
-                    Value::Bool(b) => hasher.update(if *b { "1" } else { "0" }.as_bytes()),
-                    other => hasher.update(other.to_string().as_bytes()),
-                }
-            }
-            hasher.update(b"|");
-        }
-        hex::encode(hasher.finalize())
-    }
-
     pub async fn get_row_metadata_since(
         &self,
         table: &str,
@@ -167,7 +83,7 @@ impl LocalSqlDataSource {
             )));
         }
 
-        let pk_expr = Self::build_pk_text_expr(&info.primary_key);
+        let pk_expr = adapter_common::build_pk_text_expr(&info.primary_key);
         let column_order: Vec<String> = info.columns.iter().map(|c| c.name.clone()).collect();
         let sql = format!(
             "SELECT *, {} AS __pk FROM \"{}\" WHERE \"{}\" > ?",
@@ -175,9 +91,9 @@ impl LocalSqlDataSource {
         );
         let params = vec![Value::String(since_timestamp.to_string())];
         let result = self.run(&sql, &params).await?;
-        let maps = self.rows_to_maps(&result.columns, &result.rows);
+        let maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
 
-        Ok(Self::row_maps_to_metadata(
+        Ok(adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
             timestamp_column,
@@ -195,37 +111,6 @@ impl LocalSqlDataSource {
             .unwrap()
             .insert(table.to_string(), info.clone());
         Ok(info)
-    }
-
-    fn generate_batch_sql(
-        table: &str,
-        columns: &[String],
-        rows: &[HashMap<String, Value>],
-    ) -> (String, Vec<Value>) {
-        let col_list = columns
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        let row_placeholder = format!("({})", vec!["?"; columns.len()].join(", "));
-        let all_placeholders = vec![row_placeholder.as_str(); rows.len()].join(", ");
-
-        let sql = format!(
-            "INSERT OR REPLACE INTO \"{}\" ({}) VALUES {}",
-            table, col_list, all_placeholders
-        );
-
-        let params: Vec<Value> = rows
-            .iter()
-            .flat_map(|row| {
-                columns
-                    .iter()
-                    .map(|c| row.get(c).cloned().unwrap_or(Value::Null))
-            })
-            .collect();
-
-        (sql, params)
     }
 }
 
@@ -318,13 +203,13 @@ impl DataSource for LocalSqlDataSource {
             )));
         }
 
-        let pk_expr = Self::build_pk_text_expr(&info.primary_key);
+        let pk_expr = adapter_common::build_pk_text_expr(&info.primary_key);
         let column_order: Vec<String> = info.columns.iter().map(|c| c.name.clone()).collect();
         let sql = format!("SELECT *, {} AS __pk FROM \"{}\"", pk_expr, table);
         let result = self.run(&sql, &[]).await?;
-        let maps = self.rows_to_maps(&result.columns, &result.rows);
+        let maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
 
-        Ok(Self::row_maps_to_metadata(
+        Ok(adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
             timestamp_column,
@@ -342,7 +227,7 @@ impl DataSource for LocalSqlDataSource {
         }
 
         let info = self.cached_table_info(table).await?;
-        let pk_expr = Self::build_pk_text_expr(&info.primary_key);
+        let pk_expr = adapter_common::build_pk_text_expr(&info.primary_key);
 
         let placeholders: Vec<String> = pk_values.iter().map(|_| "?".to_string()).collect();
         let params: Vec<Value> = pk_values.iter().map(|v| Value::String(v.clone())).collect();
@@ -354,7 +239,7 @@ impl DataSource for LocalSqlDataSource {
         );
 
         let result = self.run(&sql, &params).await?;
-        Ok(self.rows_to_maps(&result.columns, &result.rows))
+        Ok(adapter_common::rows_to_maps(&result.columns, &result.rows))
     }
 
     async fn upsert_rows(&self, table: &str, rows: &[HashMap<String, Value>]) -> Result<usize> {
@@ -362,7 +247,7 @@ impl DataSource for LocalSqlDataSource {
             return Ok(0);
         }
         let columns: Vec<String> = rows[0].keys().cloned().collect();
-        let (sql, params) = Self::generate_batch_sql(table, &columns, rows);
+        let (sql, params) = adapter_common::generate_batch_sql(table, &columns, rows);
         self.run(&sql, &params).await.map_err(|e| {
             SyncError::Remote(format!(
                 "batch upsert failed for table '{}' ({} rows): {}",

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -6,7 +6,7 @@
 //! better-sqlite3 (Node), official sqlite-wasm, or sql.js without
 //! changes here.
 
-use smugglr_core::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
+use smugglr_core::datasource::{DataSource, RowMeta, TableInfo};
 use smugglr_core::error::{Result, SyncError};
 use std::collections::HashMap;
 
@@ -143,50 +143,11 @@ impl DataSource for LocalSqlDataSource {
         let result = self
             .run(&format!("PRAGMA table_info('{}')", table), &[])
             .await?;
-
-        let name_idx = result.columns.iter().position(|c| c == "name").unwrap_or(1);
-        let type_idx = result.columns.iter().position(|c| c == "type").unwrap_or(2);
-        let notnull_idx = result
-            .columns
-            .iter()
-            .position(|c| c == "notnull")
-            .unwrap_or(3);
-        let pk_idx = result.columns.iter().position(|c| c == "pk").unwrap_or(5);
-
-        let mut col_infos = Vec::new();
-        let mut primary_key = Vec::new();
-
-        for row in &result.rows {
-            let name = row
-                .get(name_idx)
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let col_type = row
-                .get(type_idx)
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let notnull = row.get(notnull_idx).and_then(|v| v.as_i64()).unwrap_or(0) != 0;
-            let pk = row.get(pk_idx).and_then(|v| v.as_i64()).unwrap_or(0) != 0;
-
-            if pk {
-                primary_key.push(name.clone());
-            }
-
-            col_infos.push(ColumnInfo {
-                name,
-                col_type,
-                notnull,
-                pk,
-            });
-        }
-
-        Ok(TableInfo {
-            name: table.to_string(),
-            columns: col_infos,
-            primary_key,
-        })
+        Ok(adapter_common::parse_table_info(
+            table,
+            &result.columns,
+            &result.rows,
+        ))
     }
 
     async fn get_row_metadata(


### PR DESCRIPTION
Closes #151 (the WASM-adapter dedup portion). FetchDataSource and LocalSqlDataSource shared ~150 byte-identical lines; hoisted the five self-free helpers (rows_to_maps, build_pk_text_expr, row_maps_to_metadata, content_hash, generate_batch_sql) into a new adapter_common module as pub(crate) free fns. **Pure move -- hashes and SQL strings byte-identical to before.** cached_table_info stays per-adapter (reads adapter state). Net ~-145 LOC.

Two scope notes:
- The cross-crate pk_text_expr divergence I found (smugglr-core uses bare `"col"`; plugin + WASM use `CAST("col" AS TEXT)` + single-PK branch -- diverges for integer single-PKs) is **split out to #166** for a focused correctness PR. This PR does NOT change pk_text_expr behavior.
- Also fixes the 10 pre-existing `needless_borrow` lints in lib.rs (the lint half of #155) because #151's Done-When requires the wasm-target clippy `-D warnings` gate to pass, and those pre-existing lints (never caught by CI -- the #155 gap) blocked it.

**Stacked on #154 (#141)** so the hoisted content_hash already uses column_excluded; GitHub retargets to main once #141 merges. wasm build + wasm clippy + host clippy -D warnings + fmt clean. From the structural-debt audit.