### PR TITLE
chore: release 0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,3 +169,46 @@ jobs:
       - name: Publish
         run: npm publish --access=public --provenance
         working-directory: packages/smugglr
+
+      # Framework plugins. They build against the local `smugglr` package
+      # (`smugglr` devDep is `link:../smugglr`, built above), so they need no
+      # published smugglr and have no propagation-timing dependency. Each is a
+      # pure-tsc build; published after smugglr so a smugglr publish failure
+      # short-circuits before any plugin ships.
+      - name: Install @smugglr/zustand deps
+        run: pnpm install --frozen-lockfile
+        working-directory: packages/zustand-plugin
+
+      - name: Build @smugglr/zustand
+        run: pnpm build
+        working-directory: packages/zustand-plugin
+
+      - name: Publish @smugglr/zustand
+        working-directory: packages/zustand-plugin
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version already on npm, skipping"
+          else
+            npm publish --access=public --provenance
+          fi
+
+      - name: Install @smugglr/nanostores deps
+        run: pnpm install --frozen-lockfile
+        working-directory: packages/nanostores-plugin
+
+      - name: Build @smugglr/nanostores
+        run: pnpm build
+        working-directory: packages/nanostores-plugin
+
+      - name: Publish @smugglr/nanostores
+        working-directory: packages/nanostores-plugin
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version already on npm, skipping"
+          else
+            npm publish --access=public --provenance
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.4.0 (2026-05-30)
+
+Browser sync surface fills in. The npm package gets the four runtime affordances a real app needs (auto-sync, anonymous-first, auth rotation, right-to-erasure), the OPFS local-source path lands behind `wa-sqlite`, and a `table-changed` event lets reactive plugins react without polling. Two such plugins ship: `@smugglr/zustand` and `@smugglr/nanostores`. On the config side, `config.toml` gains `${VAR}` secret expansion and the documented retry/backoff now actually runs on the write path. A round of correctness fixes and a structural-debt cleanup round it out.
+
+### Added
+
+- **`autoSync` config** on `Smugglr.init()`: empty-state hydration on init plus sync-on-reconnect when the browser fires `online`. Multi-tab safe via `navigator.locks` (one tab runs, the rest wait). Exponential backoff with jitter on failure, capped at 5 min. No-op in Node. `s.stopAutoSync()` cancels the loop. (#113)
+- **Optional `dest` in `Smugglr.init()`**: omit `dest` to run with no network at all -- nothing leaves the device. `.push()` / `.sync()` throw with a clear error; `.diff()` still reports local rows. Foundation for the "let users try the app before signing up" flow. (#111)
+- **`updateAuth(token)` and `updateDest(dest)`** for runtime endpoint changes: rotate the dest auth token without re-initializing the WASM module or losing the metadata cache; replace the entire dest endpoint (URL, profile, token) for the anonymous -> account upgrade path. Source cache survives a dest swap. (#112)
+- **`eraseLocal()`** GDPR / right-to-erasure helper: empties every configured sync table on the local SQLite database and clears smugglr's in-memory caches. Schema and non-synced tables untouched; dest is not contacted (server-side erasure is the app's concern). (#117)
+- **`table-changed` reactive event**: subscribe via `s.on("table-changed", cb)`. Fires once per affected table after `pull` or `sync` completes the local write; `push` and `diff` never emit. Carries `{ table, changedPks, removedPks, source }`. The primitive that the framework binding plugins are built on. (#114)
+- **`@smugglr/zustand`** middleware: wraps a Zustand store, hydrates from a smugglr-managed SQLite table on init, and re-pulls on `table-changed`. (#115)
+- **`@smugglr/nanostores`** adapter: same shape for nanostores -- a writable atom backed by a smugglr table, kept fresh by sync events. (#116)
+- **Local SQLite DataSource for browser (OPFS)** via `wa-sqlite`: `Smugglr.init({ source: { type: "local", executor: createWaSqliteExecutor(...) }, ... })`. Real SQLite in the browser, content-hashed delta against any HTTP-SQL backend. Generic `SqlExecutor` contract -- better-sqlite3 in Node, sql.js, or your own works too. Playwright e2e suite covers the full local-OPFS path. (#97)
+- **Runnable examples set** under `docs/examples/`: CLI (D1, LAN broadcast), Node (server-to-D1, auto-sync), Rust (custom DataSource, tokio service), browser (OPFS + Turso, IndexedDB + Turso). Each runs as written from a fresh clone. (#119)
+- **Masterless multicast LAN sync**: `smugglr broadcast` is now true masterless UDP multicast gossip -- every node multicasts a `primary_key -> content_hash` digest, peers pull divergence, rows ride multicast and apply idempotently (last-received-wins), late joiners reconcile via the heartbeat. Two or two hundred nodes on a subnet converge with no coordinator (O(N), replacing the previous pairwise-TCP discovery+exchange). Membership is key possession: nodes with the shared key sync regardless of where each stores its database file (no path-based scoping). The delta wire-format primitives and peer-discovery types remain available as an embedder API. **Wire `PROTOCOL_VERSION` is 3; nodes on other versions version-skip.** v0.1 limits: concurrent same-PK divergence resolves silently (no CRDT); deletes via the live delta path only. (#133)
+- **`http-sql` target profile**: a built-in profile for any endpoint speaking the http-sql v0.1 spec (`{sql, params}` request, `{columns, rows}` response). Select with `profile = "http-sql"`; shared by the native plugin and the browser fetch adapter. (#131)
+- **`${VAR}` expansion in `config.toml`**: string values expand `${NAME}` and `${NAME:-default}` from the environment at load time, so secrets (D1 tokens, stash keys, the broadcast key) come from the environment instead of the file. Unset with no default errors with the variable named; `$$` escapes a literal `$`. Expansion runs post-parse on the TOML value tree, so a substituted secret can neither inject TOML structure nor leak into a parse error. (#136)
+- **Automatic retry with backoff on the write path**: transient upsert failures (HTTP 5xx / network / timeout) retry per `[sync]` config (`max_retries`, `initial_retry_delay_ms`, `max_retry_delay_ms`, `backoff_multiplier`); deterministic errors (4xx, bad SQL) fail fast; exhaustion exits 3. A server `Retry-After` is honored, capped by `max_retry_delay_ms`. (#137)
+
+### Changed
+
+- **WASM binary size**: release profile with `wasm-opt` cuts `smugglr_wasm_bg.wasm` from ~1.2 MB to ~277 KB compressed (~75% reduction). No API change. (#110)
+- **Removed the orphaned in-process TCP sync transport** (~955 LOC): it was never wired into a shipping command. LAN sync is masterless multicast (#133); the delta wire primitives and peer-discovery types stay as an embedder API. (#145)
+- Internal structural-debt cleanup across core, CLI, and the WASM adapters -- dead-code removal plus deduplication (config retry fields, snapshot structs, request-format arms, table-name validation, CLI command/output plumbing, shared WASM adapter helpers). No API or behavior change. (#146, #147, #148, #149, #150, #151, #152)
+
+### Fixed
+
+- Plugin lookup searches `~/.smugglr/plugins/` -- it was `~/.smuggler/` (a typo), which broke name-based plugin resolution. (#140)
+- WASM content-hash honors glob `exclude_columns` patterns (e.g. `*_embedding`), matching transfer-time stripping; previously only exact column names were excluded, so glob-excluded columns produced phantom `content_differs`. (#141)
+- WASM `conflict_resolution` errors on an unknown value instead of silently falling back to `local_wins` (which could sync the wrong direction). (#142)
+- Conflict-skip warnings (`newer_wins` / `uuid_v7_wins` with no usable tiebreaker) fire in every sync direction, once per table -- a pull-only run previously gave no warning. (#144)
+- Multicast deltas reserve wire-envelope + AEAD headroom when split, so a sealed delta part cannot exceed the safe datagram size. (#143)
+
+### Notes
+
+The 0.3.1 -> 0.3.3 patch releases were release-infrastructure only (crate metadata, npm README pointing at smugglr.dev, CI pnpm version + cache pins). No user-visible runtime changes.
+
 ## 0.3.0 (2026-04-11)
 
 The core engine no longer knows about any specific remote backend. `D1Client` and `ResolvedTarget::D1` are gone from `smugglr-core`; every remote is a plugin. The same release ships the sync engine to the browser via WebAssembly and npm.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smugglr"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "clap",
  "indicatif",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-http-sql"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "hex",
  "reqwest",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-plugin-sdk"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-wasm"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "hex",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -241,7 +241,16 @@ s.dispose();
 
 The package exports `Smugglr.init(config)` and the same verbs as the CLI: `.push()`, `.pull()`, `.sync()`, `.diff()`. All return typed results. The `./wasm` subpath export is available for consumers who need to control WASM binary loading directly (CDN URL, pre-fetched buffer, bundler import).
 
-This is the current browser story: sync between two remote HTTP SQL endpoints from the browser. Local SQLite storage in the browser is a separate track, not yet shipped.
+The 0.4.0 release adds the runtime affordances a real browser app needs:
+
+- **Local SQLite (OPFS)** via `wa-sqlite`: pass `source: { type: "local", executor }` to sync a real SQLite database in the browser against any HTTP-SQL backend. Generic `SqlExecutor` contract -- swap wa-sqlite for the official sqlite-wasm, sql.js, better-sqlite3 in Node, or your own.
+- **`autoSync`**: opt-in hands-off triggers. Hydrate from dest when the local DB is empty on init, re-sync on `online` events, multi-tab safe via `navigator.locks`, exponential backoff on failure.
+- **Anonymous-first**: omit `dest` entirely to run with no network at all. Attach a dest later via `updateDest()` for the anonymous-to-account upgrade path.
+- **`updateAuth(token)` / `updateDest(dest)`**: token rotation and endpoint replacement without re-initializing the WASM module.
+- **`table-changed` events**: subscribe to per-table writes after pull/sync. The primitive `@smugglr/zustand` and `@smugglr/nanostores` build on for reactive state.
+- **`eraseLocal()`**: GDPR-shaped right-to-erasure helper. Empties every configured sync table locally; dest is the app's concern.
+
+See the [npm README](packages/smugglr/README.md) for the full API, OPFS setup, and bundle-size breakdown.
 
 ## LAN Broadcast Sync
 

--- a/crates/smugglr/Cargo.toml
+++ b/crates/smugglr/Cargo.toml
@@ -22,7 +22,7 @@ name = "smugglr"
 path = "src/main.rs"
 
 [dependencies]
-smugglr-core = { path = "../smugglr-core", version = "0.3.0" }
+smugglr-core = { path = "../smugglr-core", version = "0.4.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/packages/nanostores-plugin/package.json
+++ b/packages/nanostores-plugin/package.json
@@ -31,7 +31,7 @@
   "author": "Sean Silvius",
   "peerDependencies": {
     "nanostores": "^1.0.0",
-    "smugglr": "^0.3.3"
+    "smugglr": "^0.4.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/packages/smugglr/README.md
+++ b/packages/smugglr/README.md
@@ -116,6 +116,30 @@ const result = await s.eraseLocal();
 // { erasedTables: ["users", "posts"] }
 ```
 
+## Auto-sync
+
+Opt in to hands-off triggers: pull from dest when the local database is empty on init, and re-sync whenever the browser fires `online`.
+
+```ts
+const s = await Smugglr.init({
+  source: { type: "local", executor },
+  dest:   { url, authToken, profile: "turso" },
+  sync:   { tables: ["users", "posts"] },
+  autoSync: {
+    onInit: "hydrate-if-empty", // default; or "always" | "never"
+    onReconnect: true,          // default; runs sync() on `online` events
+    backoff: { initialMs: 1000, maxMs: 300_000, jitter: true },
+  },
+});
+
+await s.ready; // optional: wait for the init-phase trigger to finish
+s.stopAutoSync(); // cancel the loop
+```
+
+Multi-tab safe: a Web Lock (`smugglr:auto:<dest>` by default, overridable via `lockName`) ensures only the lead tab runs the sync. Other tabs wait. Failures back off exponentially with jitter, capped at 5 min. No retry ceiling -- the loop survives indefinite outages.
+
+No-op in Node (relies on `navigator.locks` and the `online` event); pass the config unconditionally and it falls through silently.
+
 ## Anonymous-first
 
 Omit `dest` to run smugglr with no network at all -- nothing leaves the device. Useful for the "let users try the app before signing up" flow.

--- a/packages/smugglr/package.json
+++ b/packages/smugglr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smugglr",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Content-hashed delta sync for SQLite, in the browser",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/zustand-plugin/package.json
+++ b/packages/zustand-plugin/package.json
@@ -30,7 +30,7 @@
   },
   "author": "Sean Silvius",
   "peerDependencies": {
-    "smugglr": "^0.3.3",
+    "smugglr": "^0.4.0",
     "zustand": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {

--- a/plugins/smugglr-http-sql/Cargo.toml
+++ b/plugins/smugglr-http-sql/Cargo.toml
@@ -18,8 +18,8 @@ name = "smugglr-http-sql"
 path = "src/main.rs"
 
 [dependencies]
-smugglr-core = { path = "../../crates/smugglr-core", version = "0.3.0", default-features = false }
-smugglr-plugin-sdk = { path = "../../crates/smugglr-plugin-sdk", version = "0.3.0" }
+smugglr-core = { path = "../../crates/smugglr-core", version = "0.4.0", default-features = false }
+smugglr-plugin-sdk = { path = "../../crates/smugglr-plugin-sdk", version = "0.4.0" }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Release prep for **0.4.0** (from 0.3.3; latest tag v0.3.3).

**Versions:** workspace crates (smugglr / smugglr-core / smugglr-wasm / smugglr-http-sql) + internal dep pins -> 0.4.0; `@smugglr/smugglr` npm -> 0.4.0. New plugins `@smugglr/zustand` / `@smugglr/nanostores` ship at initial **0.1.0**.

**CHANGELOG** completed for all merge since v0.3.3 -- prior draft only covered browser/npm/multicast features; added http-sql profile (#131), `${VAR}` config expansion (#136), write-path retry (#137); a **Fixed** section (#140-#144); and the structural-cleanup note (#145-#152, where #145's TCP removal corrects the earlier 'TCP path retained' line in #133). Date 2026-05-30.

`cargo build --workspace` clean at 0.4.0. Merge -> tag `v0.4.0` cuts the release.