### PR TITLE
fix(#207): ts audit fixes

### DIFF
--- a/packages/smugglr/e2e/main.ts
+++ b/packages/smugglr/e2e/main.ts
@@ -10,6 +10,10 @@ declare global {
       syncWithAuthSwap(opts: unknown): Promise<unknown>;
       anonymousMode(): Promise<unknown>;
       autoSync(opts: unknown): Promise<unknown>;
+      autoSyncRetryIsolation(): Promise<unknown>;
+      unsubAfterDispose(opts: unknown): Promise<unknown>;
+      setWasmInitsModule(opts: unknown): Promise<unknown>;
+      loadWasmTransientRetry(): Promise<unknown>;
       reset(): Promise<unknown>;
     };
   }
@@ -46,6 +50,10 @@ window.e2e = {
   syncWithAuthSwap: (opts) => call("syncWithAuthSwap", [opts]),
   anonymousMode: () => call("anonymousMode", []),
   autoSync: (opts) => call("autoSync", [opts]),
+  autoSyncRetryIsolation: () => call("autoSyncRetryIsolation", []),
+  unsubAfterDispose: (opts) => call("unsubAfterDispose", [opts]),
+  setWasmInitsModule: (opts) => call("setWasmInitsModule", [opts]),
+  loadWasmTransientRetry: () => call("loadWasmTransientRetry", []),
   reset: () => call("reset", []),
 };
 

--- a/packages/smugglr/e2e/tests/lifecycle.spec.ts
+++ b/packages/smugglr/e2e/tests/lifecycle.spec.ts
@@ -1,0 +1,158 @@
+// e2e: WASM lifecycle + autoSync retry-isolation regressions.
+//
+// Covers audit fixes:
+//   #207 setWasm() must instantiate the WASM module (mod.default()).
+//   #208 loadWasm must not cache a rejected promise forever (transient retry).
+//   #209 init-pull and online-sync retry loops must back off / cancel independently.
+//   #210 unsubscribe handle returned by on() must be inert after dispose()/free().
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+interface RemoteRow { id: string; name: string; updated_at: number }
+
+interface MockState {
+  rows: Map<string, RemoteRow>;
+}
+
+function reply(route: Route, columns: string[], rows: unknown[][]) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ columns, rows }),
+  });
+}
+
+function installMockTarget(page: Page, state: MockState, host = "https://mock.smugglr.test") {
+  return page.route(`${host}/**`, async (route) => {
+    const body = JSON.parse(route.request().postData() ?? "{}") as {
+      sql: string; params?: unknown[];
+    };
+    const lower = body.sql.trim().toLowerCase();
+    if (lower.startsWith("select name from sqlite_master")) {
+      return reply(route, ["name"], [["users"]]);
+    }
+    if (lower.startsWith("pragma table_info")) {
+      return reply(
+        route,
+        ["cid", "name", "type", "notnull", "dflt_value", "pk"],
+        [
+          [0, "id", "TEXT", 1, null, 1],
+          [1, "name", "TEXT", 0, null, 0],
+          [2, "updated_at", "INTEGER", 0, null, 0],
+        ],
+      );
+    }
+    if (lower.startsWith("select") && lower.includes('from "users"')) {
+      const out: unknown[][] = [];
+      for (const r of state.rows.values()) out.push([r.id, r.name, r.updated_at, r.id]);
+      const cols = lower.includes("__pk")
+        ? ["id", "name", "updated_at", "__pk"]
+        : ["id", "name", "updated_at"];
+      return reply(route, cols, lower.includes("__pk") ? out : out.map((r) => r.slice(0, 3)));
+    }
+    return reply(route, [], []);
+  });
+}
+
+async function bootstrap(page: Page) {
+  await page.goto("/");
+  await expect(page.locator("#status")).toHaveText("ready");
+  await page.evaluate(() => window.e2e.reset());
+  await page.evaluate(() => window.e2e.init("lifecycle.db"));
+  await page.evaluate(() =>
+    window.e2e.runSql(
+      "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)",
+    ),
+  );
+}
+
+test.describe("lifecycle", () => {
+  test.beforeEach(async ({ page }) => { await bootstrap(page); });
+
+  // #207: the worker's init() now relies solely on `await setWasm(wasm)` to
+  // instantiate the module (no hand-call to wasm.default()). If setWasm did not
+  // run mod.default(), Smugglr.init() would fault against an uninitialized
+  // module. A successful diff round-trip proves setWasm initialized the WASM.
+  test("#207 setWasm() initializes the WASM module so init/diff works", async ({ page }) => {
+    const state: MockState = { rows: new Map() };
+    await installMockTarget(page, state);
+
+    const out = (await page.evaluate(() =>
+      window.e2e.setWasmInitsModule({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+      }),
+    )) as { command: string; status: string };
+
+    expect(out).toMatchObject({ command: "diff", status: "ok" });
+  });
+
+  // #210: a stale unsubscribe handle invoked after dispose() must be a no-op,
+  // not a use-after-free deref of the freed Rust Smugglr. on() after dispose
+  // must throw loudly rather than reach freed memory.
+  test("#210 unsubscribe after dispose() is an inert no-op (no use-after-free)", async ({ page }) => {
+    const state: MockState = { rows: new Map() };
+    await installMockTarget(page, state);
+
+    const out = (await page.evaluate(() =>
+      window.e2e.unsubAfterDispose({
+        destUrl: "https://mock.smugglr.test",
+        tables: ["users"],
+      }),
+    )) as { unsubThrew: boolean; onAfterDisposeError: string };
+
+    // Calling the stale unsubscribe handle (twice) must NOT throw/fault.
+    expect(out.unsubThrew).toBe(false);
+    // Subscribing after dispose must surface the wrapper's clean guard error,
+    // emitted by the JS wrapper BEFORE it ever calls into the freed Rust
+    // instance. Before the fix on() reached `this.inner.on()` on freed memory
+    // (undefined behavior), never producing this deterministic message.
+    expect(out.onAfterDisposeError).toContain("Smugglr.on() called after dispose()");
+  });
+
+  // #209: the init-pull retry loop and the online-sync retry loop must use
+  // independent attempt counters. Before the fix they shared one counter, so a
+  // continuously-failing init pull inflated the online-sync's first retry delay
+  // from ~initialMs (50ms) toward maxMs. We measure the gap between the first
+  // two sync attempts: under the fix it is ~initialMs; under the bug it balloons.
+  test("#209 init-pull and online-sync retry loops back off independently", async ({ page }) => {
+    const out = (await page.evaluate(() =>
+      window.e2e.autoSyncRetryIsolation(),
+    )) as { sawPull: boolean; sawSync: boolean; syncAttempts: number; firstSyncGap: number };
+
+    // Both loops actually ran (and failed, entering retry).
+    expect(out.sawPull).toBe(true);
+    expect(out.sawSync).toBe(true);
+    // The sync loop retried (so we have a measurable first-to-second gap).
+    expect(out.syncAttempts).toBeGreaterThanOrEqual(2);
+    // With independent counters sync's first retry uses initialMs (50ms), not
+    // the pull-inflated delay. Allow generous slack for scheduler jitter but
+    // far below the buggy >=800ms a shared counter would produce.
+    expect(out.firstSyncGap).toBeGreaterThan(0);
+    expect(out.firstSyncGap).toBeLessThan(400);
+  });
+});
+
+// Separate describe with NO init() in setup: loadWasmTransientRetry must run in
+// a fresh worker where `wasmReady` is still null, so it exercises loadWasm's
+// real caching path (not the setWasm short-circuit the other tests rely on).
+test.describe("lifecycle (fresh module state)", () => {
+  // #208: a transient WASM load failure must not permanently brick init().
+  test("#208 a transient WASM load failure does not brick later init() calls", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#status")).toHaveText("ready");
+    await page.evaluate(() => window.e2e.reset());
+
+    const out = (await page.evaluate(() =>
+      window.e2e.loadWasmTransientRetry(),
+    )) as { firstFailed: boolean; secondSucceeded: boolean; defaultCalls: number };
+
+    // First init() saw the transient default() rejection.
+    expect(out.firstFailed).toBe(true);
+    // Retry: the cached rejected promise was cleared, so the second init()
+    // re-ran default() and succeeded. Before the fix this stayed false (the
+    // stale rejection was re-thrown) and defaultCalls would be 1, not 2.
+    expect(out.secondSucceeded).toBe(true);
+    expect(out.defaultCalls).toBe(2);
+  });
+});

--- a/packages/smugglr/e2e/worker.ts
+++ b/packages/smugglr/e2e/worker.ts
@@ -8,14 +8,14 @@ import * as SQLite from "wa-sqlite";
 import { OriginPrivateFileSystemVFS } from "wa-sqlite/src/examples/OriginPrivateFileSystemVFS.js";
 
 import { Smugglr, createWaSqliteExecutor, setWasm } from "../dist/index.js";
+import { startAutoSync, type AutoSyncTarget } from "../dist/autoSync.js";
 import * as wasm from "../dist/wasm/smugglr_wasm.js";
 
 let sqlite3: any = null;
 let db: number | null = null;
 
 async function init(dbPath: string) {
-  await (wasm as unknown as { default: () => Promise<unknown> }).default();
-  setWasm(wasm as never);
+  await setWasm(wasm as never);
   const module = await SQLiteAsyncESMFactory();
   sqlite3 = SQLite.Factory(module);
   const vfs = new OriginPrivateFileSystemVFS();
@@ -165,6 +165,188 @@ async function autoSync(opts: {
   return { local };
 }
 
+// Regression for #210: an unsubscribe handle returned by on() must be safe to
+// invoke AFTER dispose()/free(). Before the fix the closure dereferenced freed
+// WASM memory; the guarded wrapper makes it an inert no-op. We also assert
+// on() itself rejects after dispose. Returns flags the test asserts on.
+async function unsubAfterDispose(opts: { destUrl: string; tables: string[] }) {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const s = await Smugglr.init({
+    source: { type: "local", executor: createWaSqliteExecutor(sqlite3, db) },
+    dest: { url: opts.destUrl, profile: "generic" },
+    sync: { tables: opts.tables },
+  });
+
+  const unsub = s.on("table-changed", () => {});
+  s.dispose();
+
+  // Invoking the stale handle after free() must not fault. Before the fix this
+  // dereferenced a dangling *const Smugglr in wasm.
+  let unsubThrew = false;
+  try {
+    unsub();
+    unsub(); // double-invoke is also a no-op
+  } catch {
+    unsubThrew = true;
+  }
+
+  // on() after dispose must surface a CLEAN guard error BEFORE touching freed
+  // wasm memory. Use-after-free is non-deterministic (wasm may silently read
+  // stale bytes), so the deterministic signal of the fix is this specific
+  // guard message -- which only the JS wrapper, not the freed Rust side, emits.
+  let onAfterDisposeError = "";
+  try {
+    s.on("table-changed", () => {});
+  } catch (e) {
+    onAfterDisposeError = e instanceof Error ? e.message : String(e);
+  }
+
+  return { unsubThrew, onAfterDisposeError };
+}
+
+// Regression for #207: after only calling setWasm() (no manual mod.default()),
+// the module must be fully instantiated so Smugglr.init() works. The worker's
+// init() above already relies on this; this op makes it an explicit assertion
+// by exercising a real sync round-trip with a module that was set, not
+// hand-initialized. Returns the sync status.
+async function setWasmInitsModule(opts: { destUrl: string; tables: string[] }) {
+  if (!sqlite3 || db === null) throw new Error("init() first");
+  const s = await Smugglr.init({
+    source: { type: "local", executor: createWaSqliteExecutor(sqlite3, db) },
+    dest: { url: opts.destUrl, profile: "generic" },
+    sync: { tables: opts.tables },
+  });
+  const result = (await s.diff()) as { command: string; status: string };
+  s.dispose();
+  return result;
+}
+
+// Regression for #208: a transient WASM load failure must NOT permanently brick
+// init(). loadWasm caches the in-flight promise in `wasmReady`; before the fix a
+// rejected load stuck around forever, so every later init() re-threw the stale
+// rejection. The fix clears wasmReady/wasmModule on failure so a retry works.
+//
+// We drive Smugglr.init(config, { wasmModule }) where the injected module's
+// default() rejects on the first call and resolves on the second. With the fix
+// the second init() succeeds; without it the second init() re-throws the cached
+// failure. This op MUST run in a fresh worker before any other init() has set
+// wasmReady, so its test does not call window.e2e.init().
+async function loadWasmTransientRetry() {
+  let calls = 0;
+  // A minimal wasm-bindgen-shaped module. default() fails first, succeeds after.
+  const fakeModule = {
+    default: () => {
+      calls += 1;
+      return calls === 1
+        ? Promise.reject(new Error("transient .wasm fetch 503"))
+        : Promise.resolve(undefined);
+    },
+    // Smugglr.init returns a stub inner we never call methods on; the test only
+    // asserts the second init() resolves rather than re-throwing the cached err.
+    Smugglr: {
+      init: () => ({
+        free() {},
+        push: () => Promise.resolve({}),
+        pull: () => Promise.resolve({}),
+        sync: () => Promise.resolve({}),
+        diff: () => Promise.resolve({}),
+        on: () => () => {},
+        eraseLocal: () => Promise.resolve({}),
+        updateAuth() {},
+        updateDest() {},
+      }),
+    },
+  };
+
+  const config = {
+    source: { url: "https://src.smugglr.test", profile: "generic" },
+    dest: { url: "https://dest.smugglr.test", profile: "generic" },
+    sync: { tables: ["users"] },
+  };
+
+  let firstFailed = false;
+  try {
+    await Smugglr.init(config as never, { wasmModule: fakeModule as never });
+  } catch {
+    firstFailed = true;
+  }
+
+  // The retry: if the cache was not cleared, this re-throws the same error.
+  let secondSucceeded = false;
+  try {
+    const s = await Smugglr.init(config as never, { wasmModule: fakeModule as never });
+    s.dispose();
+    secondSucceeded = true;
+  } catch {
+    secondSucceeded = false;
+  }
+
+  return { firstFailed, secondSucceeded, defaultCalls: calls };
+}
+
+// Regression for #209: the init-pull retry loop and the online-sync retry loop
+// must use INDEPENDENT attempt counters. Before the fix they shared one
+// module-scoped `attempt`, so a continuously-failing init pull inflated the
+// online-sync's exponential backoff: sync's FIRST retry used a delay of
+// initialMs * 2^(pull's accumulated attempts) instead of initialMs * 2^0.
+//
+// Setup: pull always rejects (its loop keeps incrementing the shared counter
+// every ~initialMs). sync always rejects too, and we timestamp each sync
+// attempt. We measure the gap between sync attempt #1 and #2:
+//   - fixed (independent counters): sync's own attempt starts at 0 -> gap ~=
+//     initialMs (50ms).
+//   - buggy (shared counter): by the time online fires the pull loop has
+//     advanced the counter several times, so the gap balloons toward maxMs.
+//
+// jitter:false makes the delay deterministic. We assert the gap is small.
+async function autoSyncRetryIsolation() {
+  const syncTimes: number[] = [];
+  let sawPull = false;
+  const target: AutoSyncTarget = {
+    pull: () => { sawPull = true; return Promise.reject(new Error("boom")); },
+    sync: () => { syncTimes.push(performance.now()); return Promise.reject(new Error("boom")); },
+  };
+
+  const runtime = startAutoSync({
+    target,
+    config: {
+      onInit: "always",
+      onReconnect: true,
+      // initialMs small; maxMs large so a corrupted (shared) counter produces a
+      // visibly large first-retry gap. jitter off for determinism.
+      backoff: { initialMs: 50, maxMs: 4000, jitter: false },
+    },
+    // Non-local dest so the locks/online wiring engages; the URLs are never
+    // fetched because the fake target rejects before any network call.
+    source: { url: "https://src.smugglr.test", profile: "generic" },
+    dest: { url: "https://dest.smugglr.test", profile: "generic" },
+    sync: { tables: ["users"] },
+  });
+
+  // Give the init "always" pull loop time to fail and re-fire several times,
+  // advancing the (shared, under the bug) attempt counter well past 0.
+  await new Promise((r) => setTimeout(r, 300));
+  // Now fire online -> 250ms debounce -> first sync attempt -> schedule retry.
+  self.dispatchEvent(new Event("online"));
+  // Wait long enough to observe a fixed-backoff (~50ms) second sync attempt,
+  // but NOT long enough to observe a buggy (inflated, >=800ms) one within a
+  // tight bound. 250 debounce + 600 margin.
+  await new Promise((r) => setTimeout(r, 850));
+
+  runtime.stop();
+  await new Promise((r) => setTimeout(r, 50));
+
+  // Gap between the first two sync attempts. Under the fix this is ~initialMs.
+  const firstSyncGap = syncTimes.length >= 2 ? syncTimes[1] - syncTimes[0] : -1;
+
+  return {
+    sawPull,
+    sawSync: syncTimes.length > 0,
+    syncAttempts: syncTimes.length,
+    firstSyncGap,
+  };
+}
+
 async function reset() {
   if (sqlite3 && db !== null) {
     sqlite3.close(db);
@@ -178,7 +360,19 @@ async function reset() {
 
 interface RpcCall {
   id: number;
-  op: "init" | "runSql" | "sync" | "eraseLocal" | "syncWithAuthSwap" | "anonymousMode" | "autoSync" | "reset";
+  op:
+    | "init"
+    | "runSql"
+    | "sync"
+    | "eraseLocal"
+    | "syncWithAuthSwap"
+    | "anonymousMode"
+    | "autoSync"
+    | "autoSyncRetryIsolation"
+    | "unsubAfterDispose"
+    | "setWasmInitsModule"
+    | "loadWasmTransientRetry"
+    | "reset";
   args: unknown[];
 }
 
@@ -194,6 +388,10 @@ self.addEventListener("message", async (ev: MessageEvent<RpcCall>) => {
       case "syncWithAuthSwap": result = await syncWithAuthSwap(args[0] as Parameters<typeof syncWithAuthSwap>[0]); break;
       case "anonymousMode": result = await anonymousMode(); break;
       case "autoSync": result = await autoSync(args[0] as Parameters<typeof autoSync>[0]); break;
+      case "autoSyncRetryIsolation": result = await autoSyncRetryIsolation(); break;
+      case "unsubAfterDispose": result = await unsubAfterDispose(args[0] as Parameters<typeof unsubAfterDispose>[0]); break;
+      case "setWasmInitsModule": result = await setWasmInitsModule(args[0] as Parameters<typeof setWasmInitsModule>[0]); break;
+      case "loadWasmTransientRetry": result = await loadWasmTransientRetry(); break;
       case "reset": result = await reset(); break;
     }
     (self as unknown as Worker).postMessage({ id, ok: true, result });

--- a/packages/smugglr/src/autoSync.ts
+++ b/packages/smugglr/src/autoSync.ts
@@ -58,8 +58,13 @@ export function startAutoSync(opts: {
   const locks = g.navigator.locks;
 
   let stopped = false;
-  let attempt = 0;
-  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  // Each retry loop ("pull" from init, "sync" from online) backs off
+  // independently: a failing pull must not inflate the sync's next delay, and
+  // a new sync must not orphan the pull's pending retry timer.
+  const attempts: Record<"pull" | "sync", number> = { pull: 0, sync: 0 };
+  // Every live retry timer, so stop() can clear them all -- not just the
+  // most-recently-assigned one.
+  const retryTimers = new Set<ReturnType<typeof setTimeout>>();
   let onlineDebounce: ReturnType<typeof setTimeout> | null = null;
   const onlineHandler = () => {
     if (onlineDebounce !== null) clearTimeout(onlineDebounce);
@@ -74,7 +79,7 @@ export function startAutoSync(opts: {
       if (stopped) return;
       if (kind === "pull") await opts.target.pull();
       else await opts.target.sync();
-      attempt = 0;
+      attempts[kind] = 0;
     });
   }
 
@@ -84,8 +89,12 @@ export function startAutoSync(opts: {
       await runOnce(kind);
     } catch {
       if (stopped) return;
-      const delay = nextDelay(backoff, attempt++);
-      retryTimer = setTimeout(() => { void runWithRetry(kind); }, delay);
+      const delay = nextDelay(backoff, attempts[kind]++);
+      const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+        retryTimers.delete(timer);
+        void runWithRetry(kind);
+      }, delay);
+      retryTimers.add(timer);
     }
   }
 
@@ -105,7 +114,8 @@ export function startAutoSync(opts: {
     ready,
     stop() {
       stopped = true;
-      if (retryTimer !== null) clearTimeout(retryTimer);
+      for (const timer of retryTimers) clearTimeout(timer);
+      retryTimers.clear();
       if (onlineDebounce !== null) clearTimeout(onlineDebounce);
       if (onReconnect) g.removeEventListener?.("online", onlineHandler);
     },

--- a/packages/smugglr/src/index.ts
+++ b/packages/smugglr/src/index.ts
@@ -88,13 +88,25 @@ interface WasmSmugglr {
  * // Point to a CDN-hosted binary
  * import { setWasm } from "smugglr";
  * const mod = await import("smugglr/wasm");
- * await mod.default("https://cdn.example.com/smugglr_wasm_bg.wasm");
- * setWasm(mod);
+ * await setWasm(mod, "https://cdn.example.com/smugglr_wasm_bg.wasm");
  * ```
+ *
+ * @param input Optional argument forwarded to the wasm-bindgen `default()`
+ *   initializer (a URL/path to the `.wasm` binary, a fetched `Response`, a
+ *   `BufferSource`, or a compiled `WebAssembly.Module`). Omit it to use the
+ *   module's default-resolved binary.
  */
-export function setWasm(mod: WasmModule): void {
+export async function setWasm(
+  mod: WasmModule,
+  input?: RequestInfo | URL | BufferSource | WebAssembly.Module,
+): Promise<WasmModule> {
+  // Actually instantiate the WebAssembly instance. Without this the
+  // wasm-bindgen glue is loaded but no memory/exports exist, so the first
+  // Smugglr.init() faults against an uninitialized module.
+  await mod.default(input);
   wasmModule = mod;
   wasmReady = Promise.resolve(mod);
+  return mod;
 }
 
 async function loadWasm(options?: InitOptions): Promise<WasmModule> {
@@ -115,7 +127,13 @@ async function loadWasm(options?: InitOptions): Promise<WasmModule> {
     await mod.default(options?.wasmUrl);
     wasmModule = mod;
     return mod;
-  })();
+  })().catch((e) => {
+    // A transient load failure (network blip, CDN 503) must not brick init
+    // forever. Clear the cached rejected promise so a later init() can retry.
+    wasmReady = null;
+    wasmModule = null;
+    throw e;
+  });
 
   return wasmReady;
 }
@@ -124,6 +142,10 @@ async function loadWasm(options?: InitOptions): Promise<WasmModule> {
 export class Smugglr {
   private inner: WasmSmugglr;
   private auto: AutoSyncRuntime | null = null;
+  private disposed = false;
+  // Unsubscribe wrappers handed out by on(). dispose() neutralizes them so a
+  // stale handle invoked after free() cannot deref freed WASM memory.
+  private unsubs = new Set<() => void>();
 
   private constructor(inner: WasmSmugglr) {
     this.inner = inner;
@@ -239,8 +261,22 @@ export class Smugglr {
     event: K,
     handler: (e: SmugglrEventMap[K]) => void,
   ): Unsubscribe {
+    if (this.disposed) {
+      throw new SmugglrError("Smugglr.on() called after dispose()", 1);
+    }
     const wrapped = (raw: unknown) => handler(raw as SmugglrEventMap[K]);
-    return this.inner.on(event, wrapped);
+    const innerUnsub = this.inner.on(event, wrapped);
+    // The inner unsubscribe dereferences a raw pointer back into the Rust
+    // Smugglr (crates/smugglr-wasm/src/lib.rs on()). Once dispose() has called
+    // free(), that pointer is dangling. Guard so a post-dispose unsubscribe is
+    // a safe no-op instead of a use-after-free.
+    const guarded: Unsubscribe = () => {
+      if (this.disposed) return;
+      this.unsubs.delete(guarded);
+      innerUnsub();
+    };
+    this.unsubs.add(guarded);
+    return guarded;
   }
 
   /**
@@ -310,7 +346,14 @@ export class Smugglr {
 
   /** Release WASM resources. Called automatically if using `using` syntax. */
   dispose(): void {
+    if (this.disposed) return;
     this.stopAutoSync();
+    // Drain listeners on the JS side and neutralize outstanding unsubscribe
+    // handles BEFORE free(), so any handle a consumer still holds becomes an
+    // inert no-op rather than a deref of freed WASM memory.
+    for (const unsub of this.unsubs) unsub();
+    this.unsubs.clear();
+    this.disposed = true;
     this.inner.free();
   }
 


### PR DESCRIPTION
## Summary

Fixes four TS-cluster audit defects in `packages/smugglr`: `setWasm()` now actually instantiates the WASM module (#207), a transient WASM load failure no longer bricks later `init()` calls (#208), the init-pull and online-sync retry loops back off with independent counters (#209), and an unsubscribe handle invoked after `dispose()` is an inert no-op instead of a use-after-free (#210). Each defect gains a Playwright e2e regression that fails before the fix and passes after.

## Acceptance criteria mapping

### All tests pass (including a regression test that fails before the fix)

Four new Playwright e2e regressions were added, one per defect, each wired through the worker RPC harness. Evidence: `packages/smugglr/e2e/tests/lifecycle.spec.ts:76` ("#207 setWasm() initializes the WASM module so init/diff works") asserts a `diff` round-trip returns `{ command: "diff", status: "ok" }`, which is only reachable if `setWasm` ran `mod.default()` (the fix at `packages/smugglr/src/index.ts:106`). The `#208`, `#209`, and `#210` tests at lifecycle.spec.ts:141, :118, and :93 cover the remaining fixes. clippy `--all-targets -D warnings`, `fmt --check`, and the wasm32 build are GREEN on this branch; the only failing tests are pre-existing environmental multicast UDP port-bind flakes in `multicast.rs` that fail identically on origin/main (0.4.0) and are untouched by this diff. The touched `packages/smugglr` pnpm build and typecheck are green.

### Simplify pass completed

The legion-simplify gate ran HEAD-keyed over all five changed files and was accepted clean with 0 findings. Evidence: gate id `019f1c7b-2186-72c1-8db1-0f206732a5a8` recorded via `legion quality-gate check --skill legion-simplify --result clean`, with a per-file articulation citing within-file locators (e.g. the `attempts` keyed record at `packages/smugglr/src/autoSync.ts:64` as the #209 fix, not a smell to remove).

### Review pass completed and issues fixed

The review dimension runs against the open PR after creation; this body is the pr-write forcing function that precedes it. Evidence: the diff is scoped to exactly the five files `git diff --name-only main...HEAD` reports (`packages/smugglr/{src/index.ts,src/autoSync.ts,e2e/main.ts,e2e/worker.ts,e2e/tests/lifecycle.spec.ts}`), each fix carries an explanatory WHY comment tying it to its issue (e.g. `index.ts:270-272` documents the freed-pointer guard for #210), so a reviewer can map every hunk to a criterion.

### PR created and linked to this issue

This PR is opened against `main` from `fix/ts-audit` and links #207 as the primary plus #208-#210. Evidence: the `## Closes` section below emits `Closes #207 #208 #209 #210`, and the PR title is `fix(#207): ts audit fixes`.

## Not done

- The pre-existing `multicast.rs` UDP port-bind test flakes are NOT addressed here; they fail identically on origin/main and are outside the TS cluster scope of these issues.
- No broader structural extraction of the shared `Smugglr.init({...})` preamble across worker e2e ops was performed, per #207's explicit "Out of Scope" note (that is tracked as a separate refactor).
- The first `setWasm` JSDoc example was made correct by fixing the implementation to match it (async + `mod.default()`), rather than by rewriting the contract to require a pre-initialized module; the alternative documentation-only path was deliberately not taken.

## Closes

Closes #207 #208 #209 #210