### PR TITLE
fix(#181): core-config audit fixes

### DIFF
--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -47,7 +47,7 @@ pub enum TargetConfig {
     Sqlite { database: String },
     /// External plugin adapter
     Plugin {
-        /// Plugin name (resolved from ~/.smugglr/plugins/smuggler-{name} or $PATH)
+        /// Plugin name (resolved from ~/.smugglr/plugins/smugglr-{name} or $PATH)
         name: Option<String>,
         /// Explicit path to plugin binary
         path: Option<String>,
@@ -400,7 +400,9 @@ fn expand_env_vars(input: &str) -> Result<String> {
                     ));
                 }
                 let (name, default) = match spec.split_once(":-") {
-                    Some((n, d)) => (n.trim(), Some(d)),
+                    // Trim the default symmetrically with the name so a default
+                    // cannot inject leading/trailing whitespace into a credential.
+                    Some((n, d)) => (n.trim(), Some(d.trim())),
                     None => (spec.trim(), None),
                 };
                 if name.is_empty() {
@@ -441,7 +443,9 @@ impl Config {
             return Err(SyncError::ConfigNotFound(path.display().to_string()));
         }
 
-        let content = std::fs::read_to_string(path)?;
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            SyncError::Config(format!("failed to read config {}: {}", path.display(), e))
+        })?;
         let mut config: Config = parse_with_env(&content)?;
 
         // Auto-detect local_db if not specified
@@ -1200,5 +1204,28 @@ path = "/usr/local/bin/smuggler-custom"
         // No `injected` key leaked into the config as structure.
         assert!(cfg.database_id.is_none());
         std::env::remove_var("SMUGGLR_TEST_ENV_NASTY");
+    }
+
+    #[test]
+    fn env_expand_default_is_trimmed_symmetrically() {
+        // Regression for #184: surrounding whitespace around the default must be
+        // stripped (matching the name's trim) so a default cannot inject blanks
+        // into a credential.
+        let out = expand_env_vars("${ SMUGGLR_TEST_ENV_UNSET_Z :- s3cr3t }").unwrap();
+        assert_eq!(out, "s3cr3t");
+    }
+
+    #[test]
+    fn load_read_error_maps_to_exit_2() {
+        // Regression for #182: a config-phase I/O failure (here, the path is a
+        // directory, which read_to_string rejects) must classify as a config
+        // error (exit 2), not the general/unknown bucket (exit 1).
+        let dir = std::env::temp_dir();
+        let err = Config::load(&dir).unwrap_err();
+        assert!(
+            matches!(err, SyncError::Config(_)),
+            "expected SyncError::Config, got {err:?}"
+        );
+        assert_eq!(err.exit_code(), 2);
     }
 }

--- a/crates/smugglr-core/src/error.rs
+++ b/crates/smugglr-core/src/error.rs
@@ -165,7 +165,10 @@ impl SyncError {
 
             SyncError::D1Api { .. } | SyncError::BadRequest { .. } => 5,
 
-            SyncError::Plugin(_) => 6,
+            // Plugin/adapter failures are non-retryable and have no dedicated
+            // class in the documented 0-5 contract, so they fold into the
+            // general/unknown bucket rather than emitting an out-of-range code.
+            SyncError::Plugin(_) => 1,
 
             _ => 1,
         }
@@ -343,7 +346,14 @@ mod tests {
 
     #[test]
     fn test_exit_code_plugin() {
-        assert_eq!(SyncError::Plugin("err".into()).exit_code(), 6);
+        // Plugin failures map into the documented 0-5 contract (general/1),
+        // never an out-of-range code. Regression guard for #181.
+        let code = SyncError::Plugin("err".into()).exit_code();
+        assert_eq!(code, 1);
+        assert!(
+            (0..=5).contains(&code),
+            "exit_code must stay within the documented 0-5 contract, got {code}"
+        );
         assert!(!SyncError::Plugin("err".into()).is_retryable());
     }
 


### PR DESCRIPTION
## Summary

Core-config audit fixes for `smugglr-core`. `SyncError::Plugin` now maps to the documented general/unknown exit code `1` instead of the out-of-range `6`, keeping every plugin/adapter failure inside the agent-facing 0-5 contract. Alongside it, config loading now enriches read failures into `SyncError::Config` (exit 2) and env-var defaults are trimmed symmetrically with the name so a `:-` default cannot inject leading/trailing whitespace into a credential.

## Acceptance criteria mapping

### All tests pass (including a regression test that fails before the fix)

The exit-code fix is guarded by `test_exit_code_plugin`, which asserts `SyncError::Plugin(_).exit_code() == 1` and the invariant that the code stays inside `(0..=5)` — this test fails against the old `=> 6` mapping and passes after the fold into `1`. The config-side fixes add `load_read_error_maps_to_exit_2` (directory path forces a `read_to_string` failure, expects `SyncError::Config` / exit 2) and `env_expand_default_is_trimmed_symmetrically` (expects `${ VAR :- s3cr3t }` to expand to `s3cr3t`). Evidence: tests `test_exit_code_plugin` (error.rs:347), `load_read_error_maps_to_exit_2` (config.rs) and `env_expand_default_is_trimmed_symmetrically` (config.rs); clippy `--all-targets -D warnings`, `fmt --check`, and the wasm32 build are GREEN on this branch, with the only failures being pre-existing environmental multicast UDP port-bind flakes in multicast.rs that fail identically on origin/main (0.4.0) and are untouched by this diff.

### Simplify pass completed

A HEAD-keyed legion-simplify gate was run over both changed files (config.rs, error.rs), articulating the duplicate-logic, error-swallowing, and change-narrating-comment checks per file and recording a clean verdict. Evidence: `legion quality-gate check --skill legion-simplify --result clean` accepted the articulation (gate id 019f1c7a-edff-7872-9e71-33d50680d444, 2 file entries, 0 findings).

### Review pass completed and issues fixed

This PR is being opened as the entry point for the review stage; the simplify and pr-write gates precede it in the pipeline (simplify -> pr-write -> review). No review findings are outstanding at open time because none have been filed yet against this HEAD. Evidence: the diff is confined to two files (error.rs Plugin arm at error.rs:171 plus its test, config.rs `expand_env_vars`/`Config::load` at config.rs:405 and config.rs:446 plus two tests), keeping the review surface small and self-contained.

### PR created and linked to this issue

This PR is opened via `legion pr create` with a body that closes #181 (and the sibling cluster issues), linking the change back to the issue. Evidence: the `## Closes` line below references `Closes #181`, and the PR title is `fix(#181): core-config audit fixes`.

## Not done

- The website "exit code strip" mentioned in the issue could not be updated because there is no `website/` source in this checkout; the authoritative in-tree contract (the `exit_code()` doc comment at error.rs:139-145, which already enumerates 0-5) needed no edit since Plugin now folds into the existing `1`.
- No broader structural extraction of the plugin-error mapping was attempted; per the issue's Out of Scope note, this PR fixes only the defects described and leaves any refactor to a separate issue.
- The pre-existing multicast.rs UDP port-bind test flakes are left untouched — they are environmental and unrelated to config/error.

## Closes

Closes #181 #182 #183 #184