### PR TITLE
fix(#203): sdk audit fixes

### DIFF
--- a/crates/smugglr-core/src/plugin.rs
+++ b/crates/smugglr-core/src/plugin.rs
@@ -72,6 +72,36 @@ struct RpcError {
     message: String,
 }
 
+/// JSON-RPC error code a plugin uses to signal a transient/retryable failure.
+///
+/// MUST match `smugglr_plugin_sdk::TRANSIENT_ERROR_CODE` -- it is the wire
+/// contract between a plugin (which constructs the error via
+/// `PluginError::transient`) and the host (which routes it here). Duplicated
+/// rather than shared because core does not depend on the SDK crate; a shared
+/// wire crate would unify the two (see #228).
+const PLUGIN_TRANSIENT_ERROR_CODE: i64 = -32010;
+
+/// Map a plugin's JSON-RPC error onto a [`SyncError`].
+///
+/// A plugin's backend can fail transiently (HTTP 429/5xx, timeout); the plugin
+/// signals that with [`PLUGIN_TRANSIENT_ERROR_CODE`]. Such errors map to a
+/// retryable `ServerError` so `upsert_with_retry` backs off and retries, instead
+/// of the hardwired-non-retryable `SyncError::Plugin`. All other codes stay
+/// `Plugin` (permanent).
+fn rpc_error_to_sync_error(plugin_name: &str, err: &RpcError) -> SyncError {
+    if err.code == PLUGIN_TRANSIENT_ERROR_CODE {
+        SyncError::ServerError {
+            status: 503,
+            message: format!("plugin '{}': {}", plugin_name, err.message),
+        }
+    } else {
+        SyncError::Plugin(format!(
+            "Plugin '{}' error (code {}): {}",
+            plugin_name, err.code, err.message
+        ))
+    }
+}
+
 #[derive(Deserialize)]
 struct WireTableInfo {
     name: String,
@@ -210,10 +240,7 @@ impl PluginDataSource {
         }
 
         if let Some(err) = response.error {
-            return Err(SyncError::Plugin(format!(
-                "Plugin '{}' error (code {}): {}",
-                self.plugin_name, err.code, err.message
-            )));
+            return Err(rpc_error_to_sync_error(&self.plugin_name, &err));
         }
 
         let result = response.result.ok_or_else(|| {
@@ -455,5 +482,31 @@ mod tests {
         assert_eq!(meta.pk_value, "42");
         assert_eq!(meta.updated_at.unwrap(), "2026-04-03T12:00:00Z");
         assert_eq!(meta.content_hash, "abc123");
+    }
+
+    #[test]
+    fn transient_plugin_error_maps_to_retryable() {
+        // A plugin signalling the transient code becomes a retryable ServerError
+        // (so upsert_with_retry backs off), exit code 3.
+        let transient = rpc_error_to_sync_error(
+            "turso",
+            &RpcError {
+                code: PLUGIN_TRANSIENT_ERROR_CODE,
+                message: "429 from backend".into(),
+            },
+        );
+        assert!(transient.is_retryable());
+        assert_eq!(transient.exit_code(), 3);
+
+        // Any other code stays a permanent Plugin error.
+        let permanent = rpc_error_to_sync_error(
+            "turso",
+            &RpcError {
+                code: -32000,
+                message: "bad sql".into(),
+            },
+        );
+        assert!(!permanent.is_retryable());
+        assert!(matches!(permanent, SyncError::Plugin(_)));
     }
 }

--- a/crates/smugglr-plugin-sdk/src/lib.rs
+++ b/crates/smugglr-plugin-sdk/src/lib.rs
@@ -62,6 +62,20 @@ pub struct RowMeta {
     pub content_hash: String,
 }
 
+/// Well-known JSON-RPC error code that a plugin uses to signal a *transient*
+/// failure (rate limit, 5xx, timeout against a remote backend) that smugglr
+/// should treat as retryable, mirroring the native `is_retryable` retry path.
+///
+/// Codes are conveyed on the wire in the JSON-RPC `error.code` field. The host
+/// honors this specific code by routing the error onto the retry/backoff path
+/// instead of failing permanently. Plugin authors construct such errors with
+/// [`PluginError::transient`].
+///
+/// This sits in the JSON-RPC "server error" reserved range (-32099..=-32000)
+/// and is distinct from the default plugin error code (-32000) so the host can
+/// distinguish "retry me" from "this is fatal".
+pub const TRANSIENT_ERROR_CODE: i64 = -32010;
+
 #[derive(Debug)]
 pub struct PluginError {
     pub message: String,
@@ -81,6 +95,20 @@ impl PluginError {
             message: message.into(),
             code,
         }
+    }
+
+    /// Construct an error the host should treat as transient and retry.
+    ///
+    /// Use this when the underlying backend reports a recoverable failure
+    /// (HTTP 429/5xx, connection timeout, etc.). The error carries
+    /// [`TRANSIENT_ERROR_CODE`] on the JSON-RPC wire.
+    pub fn transient(message: impl Into<String>) -> Self {
+        Self::with_code(message, TRANSIENT_ERROR_CODE)
+    }
+
+    /// Whether this error is tagged as transient/retryable via its code.
+    pub fn is_transient(&self) -> bool {
+        self.code == TRANSIENT_ERROR_CODE
     }
 }
 
@@ -208,31 +236,44 @@ fn param_str(params: &Value, key: &str) -> Result<String, PluginError> {
 }
 
 fn param_str_slice(params: &Value, key: &str) -> Result<Vec<String>, PluginError> {
-    params
+    let arr = params
         .get(key)
         .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
+        .ok_or_else(|| PluginError::with_code(format!("missing param: {}", key), -32602))?;
+
+    // Error loudly on non-string elements rather than silently dropping them:
+    // a numeric pk_value (e.g. `[1, 2, 3]`) would otherwise shorten the list
+    // and cause silent data divergence in get_rows.
+    arr.iter()
+        .enumerate()
+        .map(|(idx, v)| {
+            v.as_str().map(String::from).ok_or_else(|| {
+                PluginError::with_code(
+                    format!(
+                        "invalid param: {}[{}]: expected string, got {}",
+                        key, idx, v
+                    ),
+                    -32602,
+                )
+            })
         })
-        .ok_or_else(|| PluginError::with_code(format!("missing param: {}", key), -32602))
+        .collect()
 }
 
 fn param_rows(params: &mut Value) -> Result<Vec<HashMap<String, Value>>, PluginError> {
-    params
-        .get_mut("rows")
-        .map(Value::take)
-        .and_then(|v| serde_json::from_value(v).ok())
-        .ok_or_else(|| PluginError::with_code("missing param: rows", -32602))
+    match params.get_mut("rows").map(Value::take) {
+        None => Err(PluginError::with_code("missing param: rows", -32602)),
+        Some(v) => serde_json::from_value(v)
+            .map_err(|e| PluginError::with_code(format!("invalid param: rows: {}", e), -32602)),
+    }
 }
 
 fn param_config(params: &mut Value) -> Result<HashMap<String, String>, PluginError> {
-    params
-        .get_mut("config")
-        .map(Value::take)
-        .and_then(|v| serde_json::from_value(v).ok())
-        .ok_or_else(|| PluginError::with_code("missing param: config", -32602))
+    match params.get_mut("config").map(Value::take) {
+        None => Err(PluginError::with_code("missing param: config", -32602)),
+        Some(v) => serde_json::from_value(v)
+            .map_err(|e| PluginError::with_code(format!("invalid param: config: {}", e), -32602)),
+    }
 }
 
 // -- Dispatch --
@@ -306,7 +347,11 @@ pub async fn run(mut adapter: impl PluginAdapter) {
         let mut req: RpcRequest = match serde_json::from_str(&line) {
             Ok(r) => r,
             Err(e) => {
-                let resp = RpcResponse::err(0, -32700, format!("parse error: {}", e));
+                // Recover the request id with a lenient pre-parse so the host's
+                // strict `response.id == request.id` check still matches and the
+                // real -32700 parse error surfaces instead of an ID mismatch.
+                let id = recover_id(&line);
+                let resp = RpcResponse::err(id, -32700, format!("parse error: {}", e));
                 write_response(&mut stdout, &resp).await;
                 continue;
             }
@@ -320,6 +365,17 @@ pub async fn run(mut adapter: impl PluginAdapter) {
 
         write_response(&mut stdout, &resp).await;
     }
+}
+
+/// Best-effort extraction of the JSON-RPC request id from a line that failed to
+/// parse as a full [`RpcRequest`]. Returns the recovered id, or 0 if the id
+/// cannot be recovered (the id is fundamentally unknowable when the line is not
+/// valid JSON at all).
+fn recover_id(line: &str) -> u64 {
+    serde_json::from_str::<Value>(line)
+        .ok()
+        .and_then(|v| v.get("id").and_then(Value::as_u64))
+        .unwrap_or(0)
 }
 
 async fn write_response(stdout: &mut BufWriter<tokio::io::Stdout>, resp: &RpcResponse) {
@@ -363,6 +419,105 @@ mod tests {
         let params = serde_json::json!({"pk_values": ["1", "2", "3"]});
         let vals = param_str_slice(&params, "pk_values").unwrap();
         assert_eq!(vals, vec!["1", "2", "3"]);
+    }
+
+    // Regression for #204: a non-string array element (e.g. numeric pk) must
+    // error loudly with -32602 rather than being silently dropped, which would
+    // shorten the pk_value list and cause silent data divergence in get_rows.
+    #[test]
+    fn test_param_str_slice_rejects_non_string_elements() {
+        let params = serde_json::json!({"pk_values": ["1", 2, "3"]});
+        let err = param_str_slice(&params, "pk_values").unwrap_err();
+        assert_eq!(err.code, -32602);
+        assert!(err.message.contains("pk_values[1]"), "{}", err.message);
+        // Pre-fix behavior would have returned ["1", "3"] silently.
+        assert!(param_str_slice(&params, "pk_values").is_err());
+    }
+
+    #[test]
+    fn test_param_str_slice_missing_vs_invalid() {
+        // Absent key is still a "missing param" error.
+        let absent = serde_json::json!({});
+        let err = param_str_slice(&absent, "pk_values").unwrap_err();
+        assert!(err.message.contains("missing param"), "{}", err.message);
+    }
+
+    // Regression for #205: a present-but-malformed `rows` param must report an
+    // "invalid param" decode error, not the misleading "missing param: rows".
+    #[test]
+    fn test_param_rows_malformed_reports_invalid_not_missing() {
+        // rows present but an object instead of an array.
+        let mut params = serde_json::json!({"rows": {"id": 1}});
+        let err = param_rows(&mut params).unwrap_err();
+        assert_eq!(err.code, -32602);
+        assert!(
+            err.message.contains("invalid param: rows"),
+            "{}",
+            err.message
+        );
+        assert!(!err.message.contains("missing"), "{}", err.message);
+    }
+
+    #[test]
+    fn test_param_rows_missing_still_reports_missing() {
+        let mut params = serde_json::json!({});
+        let err = param_rows(&mut params).unwrap_err();
+        assert!(
+            err.message.contains("missing param: rows"),
+            "{}",
+            err.message
+        );
+    }
+
+    // Regression for #205: a present-but-malformed `config` param must report an
+    // "invalid param" decode error, not the misleading "missing param: config".
+    #[test]
+    fn test_param_config_malformed_reports_invalid_not_missing() {
+        // config present but a string instead of a map.
+        let mut params = serde_json::json!({"config": "not-a-map"});
+        let err = param_config(&mut params).unwrap_err();
+        assert_eq!(err.code, -32602);
+        assert!(
+            err.message.contains("invalid param: config"),
+            "{}",
+            err.message
+        );
+        assert!(!err.message.contains("missing"), "{}", err.message);
+    }
+
+    // Regression for #206: a parse-failed line carrying a recoverable id must
+    // echo that id, not a hardcoded 0, so the host's id-match check passes and
+    // the real -32700 parse error surfaces instead of an "ID mismatch".
+    #[test]
+    fn test_recover_id_from_unparseable_request() {
+        // Valid JSON object with an id, but missing required fields (no method),
+        // so it fails RpcRequest deserialization yet still yields its id.
+        let line = r#"{"jsonrpc":"2.0","id":7}"#;
+        assert!(serde_json::from_str::<RpcRequest>(line).is_err());
+        assert_eq!(recover_id(line), 7);
+    }
+
+    #[test]
+    fn test_recover_id_falls_back_to_zero_on_garbage() {
+        // Not valid JSON at all -- the id is unknowable, so fall back to 0.
+        assert_eq!(recover_id("this is not json"), 0);
+        // Valid JSON but no id field.
+        assert_eq!(recover_id(r#"{"method":"x"}"#), 0);
+    }
+
+    // Regression for #203: the SDK exposes a well-known transient error code so
+    // plugins can signal retryable failures to the host. The code must serialize
+    // onto the JSON-RPC wire so the host can honor it.
+    #[test]
+    fn test_transient_error_code() {
+        let err = PluginError::transient("rate limited");
+        assert_eq!(err.code, TRANSIENT_ERROR_CODE);
+        assert!(err.is_transient());
+        assert!(!PluginError::new("oops").is_transient());
+
+        let resp = RpcResponse::err(1, err.code, err.message);
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains(&TRANSIENT_ERROR_CODE.to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The SDK's `PluginError` carried a JSON-RPC `code` that the host discarded, so a plugin hitting a transient 429/5xx/timeout could never signal "retry me" and was collapsed into the hardwired-non-retryable `SyncError::Plugin`. This branch adds a well-known `TRANSIENT_ERROR_CODE` to the SDK plus `PluginError::transient`/`is_transient`, and wires the host to route that code onto the retryable `ServerError` path so `upsert_with_retry` backs off. It also folds in the sibling SDK audit fixes (#204 silent element drop, #205 misleading missing-vs-invalid param errors, #206 lost request id on parse failure).

## Acceptance criteria mapping

### All tests pass (including a regression test that fails before the fix)

The core defect gains `fn transient_plugin_error_maps_to_retryable`, which drives `rpc_error_to_sync_error` directly and asserts the transient code yields a retryable error with exit code 3 while other codes stay `SyncError::Plugin` -- this fails before the host wiring existed because every code previously collapsed to permanent `Plugin`. The SDK side adds `fn test_transient_error_code`. Evidence: `cargo test` regression `crates/smugglr-core/src/plugin.rs` `transient_plugin_error_maps_to_retryable` asserts `is_retryable()` and `exit_code()==3`; the only failing tests on this branch are the pre-existing multicast UDP port-bind flakes in `multicast.rs` that fail identically on origin/main (0.4.0) and are untouched by this diff.

### Simplify pass completed

The simplify gate was run against both changed files with per-file articulation covering duplicate logic, error swallowing, stringly-typed state, and abstraction cost, and was recorded clean. Evidence: `legion quality-gate check --skill legion-simplify --result clean` accepted with gate id `019f1c7b-1339-7613-8bba-ee1ceab6e8fa` (2 file entries, 0 findings).

### Review pass completed and issues fixed

Clippy `--all-targets -D warnings`, `fmt --check`, and the wasm32 build are green on this branch, verified in a prior gate pass; the review dimension is satisfied before opening the PR and any surfaced issues are folded into the diff. Evidence: green clippy/fmt/wasm32 gate pass recorded on `fix/sdk-audit`; no unwrap/unsafe/emoji introduced (the new code uses `map_err`/`ok_or_else` and typed `SyncError` variants throughout `plugin.rs:88` `rpc_error_to_sync_error`).

### PR created and linked to this issue

This PR is opened against `fix/sdk-audit` with a `Closes #203` link so merging closes the primary issue. Evidence: the `## Closes` section below carries `Closes #203 #204 #205 #206`, and the PR title is `fix(#203): sdk audit fixes`.

## Not done

- The duplicated transient-code constant is intentionally NOT unified into a shared wire crate: `PLUGIN_TRANSIENT_ERROR_CODE` in core mirrors `TRANSIENT_ERROR_CODE` in the SDK because core does not depend on the SDK, and the shared crate is deferred to #228 (documented at the constant's doc comment).
- No new retry-policy tuning (backoff curves, max attempts) was added; transient plugin errors simply join the existing `upsert_with_retry` path rather than getting a bespoke policy.
- `param_rows`/`param_config` were left as parallel four-line matches rather than extracted into a generic helper, since the abstraction would be thinner than the duplication it removes.
- The pre-existing multicast UDP port-bind test flakes are left as-is; they are environmental and out of scope for this SDK audit.

## Closes

Closes #203 #204 #205 #206