### PR TITLE
fix(#173): core-wire audit fixes

### DIFF
--- a/crates/smugglr-core/src/broadcast.rs
+++ b/crates/smugglr-core/src/broadcast.rs
@@ -134,6 +134,12 @@ impl BroadcastConfig {
 }
 
 /// A discovered peer on the LAN.
+///
+/// No `protocol_version` is stored: [`PeerDiscovery::receive_one`] already drops
+/// announcements whose version differs from [`PROTOCOL_VERSION`] before
+/// `register_peer` is ever called, so every registered peer is on the current
+/// protocol. The field was vestigial TCP-era state advertising a version
+/// guarantee the table did not enforce (#175).
 #[derive(Debug, Clone)]
 pub struct Peer {
     /// Unique instance identifier
@@ -144,9 +150,6 @@ pub struct Peer {
     pub db_path_hash: String,
     /// When we last heard from this peer
     pub last_seen: Instant,
-    /// Protocol version the peer is running
-    #[allow(dead_code)]
-    pub protocol_version: u8,
 }
 
 impl Peer {
@@ -398,7 +401,6 @@ impl PeerDiscovery {
             addr,
             db_path_hash: announcement.db_path_hash.clone(),
             last_seen: Instant::now(),
-            protocol_version: announcement.version,
         };
 
         let mut peers = self.peers.write().await;
@@ -656,21 +658,43 @@ pub fn split_delta(
     Ok(packets)
 }
 
+/// Hard cap on distinct peers tracked at once. When full, the
+/// least-recently-seen peer is evicted to admit a new one (rather than rejecting
+/// the newcomer), so a masterless LAN with churning instance_ids never locks out
+/// live peers. See #174.
+const REPLAY_PEER_CAP: usize = 256;
+
+/// Per-peer replay window plus a last-seen ordinal for LRU eviction.
+#[derive(Debug, Clone, Copy)]
+struct Window {
+    /// Highest sequence number seen from this peer.
+    highest: u64,
+    /// Bitfield of recently seen sequences below `highest`.
+    bitfield: u64,
+    /// Monotonic ordinal of the most recent `check` that touched this peer,
+    /// used only to pick the least-recently-seen peer to evict at the cap.
+    last_seen: u64,
+}
+
 /// Tracks seen sequence numbers per peer to detect replay attacks.
 ///
 /// Uses a sliding window of 64 sequence numbers per peer. Packets with
-/// previously seen or too-old sequence numbers are rejected.
+/// previously seen or too-old sequence numbers are rejected. The peer table is
+/// capped at [`REPLAY_PEER_CAP`]; at the cap the least-recently-seen peer is
+/// evicted so a fresh peer is always admitted (no permanent lockout, #174).
 #[derive(Debug)]
 pub struct ReplayGuard {
-    /// Per-peer sliding window of seen sequences.
-    /// Key: source_id, Value: (highest_seen_seq, bitfield of recent seqs)
-    windows: HashMap<String, (u64, u64)>,
+    /// Per-peer sliding window of seen sequences keyed by source_id.
+    windows: HashMap<String, Window>,
+    /// Monotonic clock stamped onto each touched peer's `last_seen`.
+    clock: u64,
 }
 
 impl ReplayGuard {
     pub fn new() -> Self {
         Self {
             windows: HashMap::new(),
+            clock: 0,
         }
     }
 
@@ -680,10 +704,22 @@ impl ReplayGuard {
             .retain(|id, _| active_peers.contains(&id.as_str()));
     }
 
+    /// Evict the least-recently-seen peer to make room for a newcomer. Returns
+    /// the evicted source_id, if any.
+    fn evict_lru(&mut self) -> Option<String> {
+        let victim = self
+            .windows
+            .iter()
+            .min_by_key(|(_, w)| w.last_seen)
+            .map(|(id, _)| id.clone())?;
+        self.windows.remove(&victim);
+        Some(victim)
+    }
+
     /// Check whether a packet with the given source_id and seq should be accepted.
     /// Returns `true` if accepted (not a replay), `false` if rejected.
     pub fn check(&mut self, source_id: &str, seq: u64) -> bool {
-        // Cap source_id length and total peers to prevent DoS via crafted packets
+        // Cap source_id length to prevent DoS via crafted packets.
         if source_id.len() > 128 {
             warn!(
                 "Replay guard: rejecting oversized source_id ({}B)",
@@ -691,21 +727,39 @@ impl ReplayGuard {
             );
             return false;
         }
-        if !self.windows.contains_key(source_id) && self.windows.len() >= 256 {
-            warn!(
-                "Replay guard: peer limit reached, rejecting new peer '{}'",
-                source_id
-            );
-            return false;
+        // At the peer cap, evict the least-recently-seen peer rather than reject
+        // the newcomer, so churning instance_ids cannot lock out live peers.
+        if !self.windows.contains_key(source_id) && self.windows.len() >= REPLAY_PEER_CAP {
+            if let Some(victim) = self.evict_lru() {
+                debug!(
+                    "Replay guard: peer cap reached, evicting least-recently-seen '{}' for '{}'",
+                    victim, source_id
+                );
+            }
         }
+
+        self.clock += 1;
+        let now = self.clock;
 
         let entry = self.windows.get_mut(source_id);
         match entry {
             None => {
-                self.windows.insert(source_id.to_string(), (seq, 0));
+                self.windows.insert(
+                    source_id.to_string(),
+                    Window {
+                        highest: seq,
+                        bitfield: 0,
+                        last_seen: now,
+                    },
+                );
                 true
             }
-            Some((highest, bitfield)) => {
+            Some(Window {
+                highest,
+                bitfield,
+                last_seen,
+            }) => {
+                *last_seen = now;
                 if seq > *highest {
                     let shift = seq - *highest;
                     if shift < 64 {
@@ -809,7 +863,6 @@ mod tests {
             addr: "127.0.0.1:31337".parse().unwrap(),
             db_path_hash: "abc".to_string(),
             last_seen: Instant::now() - Duration::from_secs(100),
-            protocol_version: 1,
         };
         assert!(peer.is_expired(Duration::from_secs(90)));
         assert!(!peer.is_expired(Duration::from_secs(110)));
@@ -1232,5 +1285,36 @@ mod tests {
     fn test_replay_guard_default() {
         let guard = ReplayGuard::default();
         assert!(guard.windows.is_empty());
+    }
+
+    /// Regression for #174: at the peer cap, a brand-new peer must be admitted
+    /// by evicting the least-recently-seen peer, not rejected. Before the fix,
+    /// `check` returned false for every new source_id once the table hit 256,
+    /// permanently locking out fresh peers on a churning LAN.
+    #[test]
+    fn test_replay_guard_evicts_lru_instead_of_rejecting_new_peer() {
+        let mut guard = ReplayGuard::new();
+
+        // Fill to the cap. peer-0 is touched first, so it is the LRU.
+        for i in 0..REPLAY_PEER_CAP {
+            assert!(guard.check(&format!("peer-{i}"), 1));
+        }
+        assert_eq!(guard.windows.len(), REPLAY_PEER_CAP);
+
+        // Re-touch every peer except peer-0 so peer-0 stays the LRU.
+        for i in 1..REPLAY_PEER_CAP {
+            assert!(guard.check(&format!("peer-{i}"), 2));
+        }
+
+        // A fresh peer at the cap must be ACCEPTED (the bug returned false here).
+        assert!(
+            guard.check("fresh-peer", 1),
+            "new peer must be admitted at the cap, not locked out"
+        );
+
+        // The table stays bounded and the LRU peer-0 was the one evicted.
+        assert_eq!(guard.windows.len(), REPLAY_PEER_CAP);
+        assert!(!guard.windows.contains_key("peer-0"));
+        assert!(guard.windows.contains_key("fresh-peer"));
     }
 }

--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -64,6 +64,14 @@ const RECV_BUF: usize = 65_536;
 /// datagram never exceeds [`SAFE_PACKET_SIZE`].
 const DELTA_WIRE_RESERVE: usize = 128;
 
+/// Wire headroom reserved when chunking digests for multicast: the
+/// XChaCha20-Poly1305 nonce+tag (24 + 16 = 40 bytes) that [`Gossip::seal`] adds
+/// on top of the serialized `Msg`. `split_digest` already probes against the
+/// full `Msg` envelope, so unlike [`DELTA_WIRE_RESERVE`] only the AEAD seal
+/// overhead must be reserved here. Conservative, so a sealed `Digest` datagram
+/// never exceeds [`SAFE_PACKET_SIZE`].
+const DIGEST_WIRE_RESERVE: usize = 64;
+
 /// A `primary_key -> content_hash` advertisement for one table (one datagram).
 ///
 /// Large tables are chunked across several parts; each part is processed and
@@ -184,6 +192,11 @@ pub fn split_digest(
         return Ok(vec![mk()]);
     }
 
+    // Reserve AEAD seal headroom so a *sealed* part stays under the safe MTU,
+    // mirroring split_delta's `reserve` discipline (the probe already includes
+    // the Msg envelope, so only the 40-byte nonce+tag must be reserved here).
+    let limit = SAFE_PACKET_SIZE.saturating_sub(DIGEST_WIRE_RESERVE);
+
     let mut parts: Vec<DigestPacket> = Vec::new();
     let mut current = mk();
 
@@ -191,7 +204,7 @@ pub fn split_digest(
         current.hashes.insert(pk.clone(), hash.clone());
         // Measure with the envelope so we stay under the wire limit end-to-end.
         let probe = Msg::new(Body::Digest(current.clone())).to_bytes()?;
-        if probe.len() > SAFE_PACKET_SIZE && current.hashes.len() > 1 {
+        if probe.len() > limit && current.hashes.len() > 1 {
             current.hashes.remove(&pk);
             parts.push(std::mem::replace(&mut current, mk()));
             current.hashes.insert(pk, hash);
@@ -684,6 +697,38 @@ mod tests {
             reunion.extend(p.hashes.clone());
         }
         assert_eq!(reunion, big, "chunking must be lossless");
+    }
+
+    /// Regression for #168/#173: a sealed digest part must stay under the safe
+    /// MTU. Before the fix, split_digest sized parts against the bare `Msg`
+    /// envelope up to SAFE_PACKET_SIZE, so adding the 40-byte AEAD seal pushed
+    /// the on-the-wire datagram over the limit. Mirrors
+    /// `keyed_delta_parts_stay_under_mtu_when_sealed` by sealing each part.
+    #[tokio::test]
+    async fn keyed_digest_parts_stay_under_mtu_when_sealed() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+        let key = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+        seed(&a_path, &[]);
+        seed(&b_path, &[]);
+        let (a, _ac, _al, _b, _bc, _bl) =
+            two_nodes_keyed(&a_path, &b_path, Some(key), Some(key)).await;
+
+        let big: HashMap<String, String> = (0..2000)
+            .map(|i| (format!("pk-{i:020}"), format!("hash-{i:032}")))
+            .collect();
+        let parts = split_digest("node-a", "users", big).unwrap();
+        assert!(parts.len() > 1, "2000 entries must span multiple datagrams");
+        for part in parts {
+            let sealed = a.seal(Body::Digest(part)).unwrap();
+            assert!(
+                sealed.len() <= SAFE_PACKET_SIZE,
+                "sealed digest part is {} bytes, exceeds SAFE_PACKET_SIZE {}",
+                sealed.len(),
+                SAFE_PACKET_SIZE
+            );
+        }
     }
 
     /// Bind two gossip nodes with distinct instance ids on a test group. They


### PR DESCRIPTION
## Summary

Audit fixes for the `core:wire` cluster. `split_digest` now reserves AEAD seal
headroom so sealed digest datagrams stay under the safe MTU (#173/#168), the
`ReplayGuard` peer table evicts the least-recently-seen peer at its cap instead
of permanently locking out new peers (#174), and the vestigial
`Peer::protocol_version` field with no live consumer is removed (#175). Only two
files change: `crates/smugglr-core/src/{multicast.rs, broadcast.rs}`.

## Acceptance criteria mapping

### All tests pass (including a regression test that fails before the fix)

The digest MTU fix ships with a dedicated regression test that seals each split
part and asserts it stays within the wire limit, mirroring the existing delta
test. Evidence: `keyed_digest_parts_stay_under_mtu_when_sealed` in
`crates/smugglr-core/src/multicast.rs` (around line 705) seals every part via
`a.seal(Body::Digest(part))` and asserts `sealed.len() <= SAFE_PACKET_SIZE`;
this fails before the fix because `split_digest` sized against the bare `Msg`
envelope up to `SAFE_PACKET_SIZE`, and passes after because `split_digest` now
probes against `SAFE_PACKET_SIZE - DIGEST_WIRE_RESERVE`
(`crates/smugglr-core/src/multicast.rs:198`). The companion #174 regression
`test_replay_guard_evicts_lru_instead_of_rejecting_new_peer`
(`crates/smugglr-core/src/broadcast.rs`, around line 1291) fills the guard to the
cap and asserts a fresh peer is admitted while the LRU peer is evicted. The only
failing tests on this branch are the pre-existing multicast UDP port-bind flakes
in `multicast.rs` that fail identically on `origin/main` (0.4.0) and are
untouched by this diff.

### Simplify pass completed

The `legion-simplify` quality gate was run and accepted clean on HEAD with zero
findings across both changed files. Evidence: `legion quality-gate check --skill
legion-simplify --result clean` returned "simplify-check articulation accepted
... (2 file entries, 0 skill findings). Gate id:
019f1c7b-23a9-7a50-8285-bdda2898d5a1", keyed to this branch HEAD.

### Review pass completed and issues fixed

`clippy --all-targets -D warnings`, `fmt --check`, and the wasm32 build are all
GREEN on this branch (verified in a prior gate pass), and the self-review during
the simplify stage surfaced no structural findings to fix. Evidence: the clean
simplify gate (id `019f1c7b-23a9-7a50-8285-bdda2898d5a1`) plus green
clippy/fmt/wasm; the formal `legion-review` fan-out is the next pipeline stage
and runs against this PR once opened (see Not done).

### PR created and linked to this issue

This PR is opened from `fix/core-wire-audit` and closes #173 (plus the sibling
audit issues) via the Closes footer. Evidence: the `## Closes` section below
carries `Closes #173 #174 #175`, linking the primary and sibling issues on merge.

## Not done

- The formal `legion-review` fan-out (spec-vs-diff, correctness, security
  dimensions) is intentionally deferred to the post-open review stage of the
  pipeline; this PR opens the review, it does not pre-empt it. The
  "Review pass completed" criterion is satisfied here only by the clean simplify
  self-review plus green clippy/fmt/wasm gates.
- The pre-existing multicast UDP port-bind test flakes are left untouched; they
  are environmental and fail identically on `origin/main`, outside this audit's
  scope.
- #175's alternative remedy (wiring `protocol_version` into a live skew
  decision) was not taken; the field is deleted instead, since the multicast
  envelope check (`multicast.rs` version gate) is already the real enforcement
  point and nothing in-tree reads the field.

## Closes

Closes #173 #174 #175