### PR TITLE
fix(#190): cli audit fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smugglr-core",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/smugglr-core/src/broadcast.rs
+++ b/crates/smugglr-core/src/broadcast.rs
@@ -108,7 +108,7 @@ impl BroadcastConfig {
 
     /// Peer TTL based on broadcast interval.
     pub fn peer_ttl(&self) -> Duration {
-        Duration::from_secs(self.interval_secs * PEER_TTL_MULTIPLIER)
+        Duration::from_secs(self.interval_secs.saturating_mul(PEER_TTL_MULTIPLIER))
     }
 
     /// Parse the hex-encoded secret into a 256-bit key for multicast encryption.
@@ -832,6 +832,25 @@ mod tests {
         let bytes = original.to_bytes().expect("serialize");
         let decoded = Announcement::from_bytes(&bytes).expect("deserialize");
         assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn peer_ttl_saturates_instead_of_overflowing() {
+        // Regression for #194: interval_secs is operator-controlled with no upper
+        // bound, so interval_secs * PEER_TTL_MULTIPLIER can overflow u64 --
+        // panicking in debug, wrapping to a tiny TTL in release. saturating_mul
+        // pins it to the max instead.
+        let bc = BroadcastConfig {
+            interval_secs: u64::MAX,
+            ..BroadcastConfig::default()
+        };
+        assert_eq!(bc.peer_ttl(), Duration::from_secs(u64::MAX));
+
+        let bc = BroadcastConfig {
+            interval_secs: 30,
+            ..BroadcastConfig::default()
+        };
+        assert_eq!(bc.peer_ttl(), Duration::from_secs(30 * PEER_TTL_MULTIPLIER));
     }
 
     #[test]

--- a/crates/smugglr/Cargo.toml
+++ b/crates/smugglr/Cargo.toml
@@ -40,3 +40,7 @@ serde_json = "1"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+# Isolated temp dirs for subprocess integration tests
+tempfile = "3"

--- a/crates/smugglr/src/broadcast.rs
+++ b/crates/smugglr/src/broadcast.rs
@@ -44,7 +44,10 @@ pub async fn run_broadcast(
     let _pid_lock = PidLock::acquire(&pid_path)?;
 
     let instance_id = broadcast_config.resolve_instance_id();
-    let interval_secs = broadcast_config.interval_secs;
+    // `tokio::time::interval` panics on a zero period; clamp defensively so a
+    // `--interval 0` (or a config carrying interval_secs == 0) cannot crash the
+    // daemon.
+    let interval_secs = broadcast_config.interval_secs.max(1);
 
     info!(
         "Starting masterless multicast sync (group {}, port {}, interval {}s, instance {}, dry_run {})",

--- a/crates/smugglr/src/main.rs
+++ b/crates/smugglr/src/main.rs
@@ -306,7 +306,7 @@ enum Commands {
     /// Watch for changes and sync periodically (daemon mode)
     Watch {
         /// Sync interval in seconds
-        #[arg(short, long, default_value = "30")]
+        #[arg(short, long, default_value = "30", value_parser = clap::value_parser!(u64).range(1..=86400))]
         interval: u64,
 
         /// Show what would be synced without actually syncing
@@ -341,7 +341,7 @@ enum Commands {
         port: Option<u16>,
 
         /// Sync interval in seconds
-        #[arg(short, long)]
+        #[arg(short, long, value_parser = clap::value_parser!(u64).range(1..=86400))]
         interval: Option<u64>,
 
         /// Run a single sync cycle and exit
@@ -795,28 +795,49 @@ fn print_diff_category(label: &str, keys: &[String]) {
     }
 }
 
-/// Connect to a data source and collect per-table row counts for `status`.
+/// Collect per-table row counts for `status` from an already-open data source.
 ///
-/// Returns a connected `StatusDb` with row counts for every synced table.
-/// Connection failures are handled by the caller (which builds the
-/// disconnected `StatusDb` variant).
-async fn gather_status<D: DataSource>(db: &D, config: &Config) -> error::Result<StatusDb> {
-    let tables = db.list_tables().await?;
+/// The connection has already succeeded by the time this is called, so a
+/// post-connection failure (locked table, transient plugin RPC error, etc.)
+/// must NOT abort the whole status report -- `status` is designed to degrade
+/// gracefully and always report both sides. A list_tables/row_count failure
+/// here is captured as `connected: true` with an `error` string and whatever
+/// table counts were gathered before the failure, mirroring the disconnected
+/// `StatusDb` the caller builds when `open` itself fails (#192).
+async fn gather_status<D: DataSource>(db: &D, config: &Config) -> StatusDb {
+    let tables = match db.list_tables().await {
+        Ok(tables) => tables,
+        Err(e) => {
+            return StatusDb {
+                connected: true,
+                error: Some(e.to_string()),
+                tables: vec![],
+            }
+        }
+    };
     let mut table_rows = Vec::new();
     for table in &tables {
         if config.should_sync_table(table) {
-            let count = db.row_count(table).await?;
-            table_rows.push(StatusTable {
-                name: table.clone(),
-                rows: count,
-            });
+            match db.row_count(table).await {
+                Ok(count) => table_rows.push(StatusTable {
+                    name: table.clone(),
+                    rows: count,
+                }),
+                Err(e) => {
+                    return StatusDb {
+                        connected: true,
+                        error: Some(e.to_string()),
+                        tables: table_rows,
+                    }
+                }
+            }
         }
     }
-    Ok(StatusDb {
+    StatusDb {
         connected: true,
         error: None,
         tables: table_rows,
-    })
+    }
 }
 
 async fn run_status(
@@ -831,7 +852,7 @@ async fn run_status(
 
     // Gather local DB info
     let local_status = match LocalDb::open_readonly(config.local_db_path()) {
-        Ok(local) => gather_status(&local, config).await?,
+        Ok(local) => gather_status(&local, config).await,
         Err(e) => StatusDb {
             connected: false,
             error: Some(e.to_string()),
@@ -841,7 +862,7 @@ async fn run_status(
 
     // Gather target info
     let target_status = match TargetSource::open(&target, false).await {
-        Ok(remote) => gather_status(&remote, config).await?,
+        Ok(remote) => gather_status(&remote, config).await,
         Err(e) => StatusDb {
             connected: false,
             error: Some(e.to_string()),
@@ -1146,4 +1167,153 @@ async fn run_restore(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Regression for #190/#194: `watch --interval 0` must be rejected at parse
+    /// time rather than reaching `tokio::time::interval`, which panics on a zero
+    /// period. The clap range also caps the upper bound that drives peer_ttl.
+    #[test]
+    fn watch_interval_zero_is_rejected_at_parse() {
+        let result = Cli::try_parse_from(["smugglr", "watch", "--interval", "0"]);
+        let err = match result {
+            Ok(_) => panic!("interval 0 must be rejected"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+
+        // A sane interval still parses.
+        let cli = Cli::try_parse_from(["smugglr", "watch", "--interval", "30"])
+            .unwrap_or_else(|e| panic!("interval 30 parses: {e}"));
+        match cli.command {
+            Commands::Watch { interval, .. } => assert_eq!(interval, 30),
+            _ => panic!("expected watch command"),
+        }
+    }
+
+    /// Regression for #190/#194: `broadcast --interval 0` is likewise rejected at
+    /// parse time; the same construction lives in run_broadcast's loop.
+    #[test]
+    fn broadcast_interval_zero_is_rejected_at_parse() {
+        let result = Cli::try_parse_from(["smugglr", "broadcast", "--interval", "0"]);
+        let err = match result {
+            Ok(_) => panic!("interval 0 must be rejected"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    /// A `DataSource` whose connection has succeeded (`list_tables` works) but
+    /// whose `row_count` fails on a specific table -- modelling a locked table or
+    /// a transient plugin RPC error after a successful open.
+    struct FlakyRowCount {
+        tables: Vec<String>,
+        fail_on: &'static str,
+    }
+
+    impl DataSource for FlakyRowCount {
+        async fn list_tables(&self) -> error::Result<Vec<String>> {
+            Ok(self.tables.clone())
+        }
+
+        async fn table_info(&self, _table: &str) -> error::Result<TableInfo> {
+            unreachable!("status does not call table_info")
+        }
+
+        async fn get_row_metadata(
+            &self,
+            _table: &str,
+            _timestamp_column: &str,
+            _exclude_columns: &[String],
+        ) -> error::Result<HashMap<String, RowMeta>> {
+            unreachable!("status does not call get_row_metadata")
+        }
+
+        async fn get_rows(
+            &self,
+            _table: &str,
+            _pk_values: &[String],
+        ) -> error::Result<Vec<HashMap<String, JsonValue>>> {
+            unreachable!("status does not call get_rows")
+        }
+
+        async fn upsert_rows(
+            &self,
+            _table: &str,
+            _rows: &[HashMap<String, JsonValue>],
+        ) -> error::Result<usize> {
+            unreachable!("status does not call upsert_rows")
+        }
+
+        async fn row_count(&self, table: &str) -> error::Result<usize> {
+            if table == self.fail_on {
+                Err(error::SyncError::Config(format!(
+                    "table '{table}' is locked"
+                )))
+            } else {
+                Ok(7)
+            }
+        }
+    }
+
+    fn test_config() -> Config {
+        Config {
+            cloudflare_account_id: None,
+            cloudflare_api_token: None,
+            database_id: None,
+            local_db: Some("game.db".to_string()),
+            sync: smugglr_core::config::SyncConfig::default(),
+            stash: None,
+            target: None,
+            broadcast: None,
+        }
+    }
+
+    /// Regression for #192: a post-connection failure (row_count erroring) must
+    /// not abort the whole status report. `gather_status` reports the side as
+    /// connected with an error string instead of bubbling the error out.
+    #[tokio::test]
+    async fn gather_status_reports_partial_on_row_count_error() {
+        let db = FlakyRowCount {
+            tables: vec!["abilities".into(), "items".into()],
+            fail_on: "items",
+        };
+        let config = test_config();
+
+        let status = gather_status(&db, &config).await;
+
+        assert!(
+            status.connected,
+            "connection succeeded, so connected stays true"
+        );
+        assert!(
+            status.error.is_some(),
+            "the row_count failure must surface as an error string"
+        );
+        // The table counted before the failure is preserved.
+        assert_eq!(status.tables.len(), 1);
+        assert_eq!(status.tables[0].name, "abilities");
+        assert_eq!(status.tables[0].rows, 7);
+    }
+
+    /// Companion to #192: when every table counts cleanly, the status is fully
+    /// connected with no error.
+    #[tokio::test]
+    async fn gather_status_reports_all_tables_on_success() {
+        let db = FlakyRowCount {
+            tables: vec!["abilities".into(), "items".into()],
+            fail_on: "__none__",
+        };
+        let config = test_config();
+
+        let status = gather_status(&db, &config).await;
+
+        assert!(status.connected);
+        assert!(status.error.is_none());
+        assert_eq!(status.tables.len(), 2);
+    }
 }

--- a/crates/smugglr/src/output.rs
+++ b/crates/smugglr/src/output.rs
@@ -309,11 +309,11 @@ impl DiffOutput {
 }
 
 impl WatchTickOutput {
-    pub fn from_results(tick: u64, results: &[SyncResult]) -> Self {
+    pub fn from_results(tick: u64, results: &[SyncResult], dry_run: bool) -> Self {
         Self {
             command: "watch",
             tick,
-            status: Status::Ok,
+            status: if dry_run { Status::DryRun } else { Status::Ok },
             tables: results
                 .iter()
                 .filter(|r| r.has_changes())
@@ -419,7 +419,7 @@ mod tests {
             diff_detail: None,
         }];
 
-        let out = WatchTickOutput::from_results(5, &results);
+        let out = WatchTickOutput::from_results(5, &results, false);
         let json = serde_json::to_string(&out).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
 
@@ -783,13 +783,36 @@ mod tests {
             diff_stats: None,
             diff_detail: None,
         }];
-        let out = WatchTickOutput::from_results(5, &results);
+        let out = WatchTickOutput::from_results(5, &results, false);
         assert_eq!(
             serde_json::to_value(&out).unwrap(),
             json!({
                 "command": "watch",
                 "tick": 5,
                 "status": "ok",
+                "tables": [{ "name": "t", "rows_pushed": 3, "rows_pulled": 7 }]
+            })
+        );
+    }
+
+    #[test]
+    fn golden_watch_tick_dry_run_output() {
+        // Regression for #193: a dry-run watch tick must report status
+        // "dry_run", matching every other command's dry-run JSON contract.
+        let results = vec![SyncResult {
+            table: "t".into(),
+            rows_pushed: 3,
+            rows_pulled: 7,
+            diff_stats: None,
+            diff_detail: None,
+        }];
+        let out = WatchTickOutput::from_results(5, &results, true);
+        assert_eq!(
+            serde_json::to_value(&out).unwrap(),
+            json!({
+                "command": "watch",
+                "tick": 5,
+                "status": "dry_run",
                 "tables": [{ "name": "t", "rows_pushed": 3, "rows_pulled": 7 }]
             })
         );

--- a/crates/smugglr/src/watch.rs
+++ b/crates/smugglr/src/watch.rs
@@ -48,6 +48,11 @@ pub async fn run_watch(
         None
     };
 
+    // `tokio::time::interval` panics on a zero period; clamp defensively so a
+    // `--interval 0` (or any path that bypasses clap's range validation) cannot
+    // crash the daemon.
+    let interval_secs = interval_secs.max(1);
+
     let mut tick_count: u64 = 0;
     let mut interval = time::interval(Duration::from_secs(interval_secs));
 
@@ -76,7 +81,7 @@ pub async fn run_watch(
                         let total_pulled: usize = results.iter().map(|r| r.rows_pulled).sum();
 
                         if fmt == OutputFormat::Json {
-                            let out = WatchTickOutput::from_results(tick_count, &results);
+                            let out = WatchTickOutput::from_results(tick_count, &results, dry_run);
                             println!("{}", serde_json::to_string(&out).expect("WatchTickOutput is always serializable"));
                         } else if total_pushed > 0 || total_pulled > 0 {
                             info!(
@@ -104,8 +109,14 @@ pub async fn run_watch(
                         } else {
                             error!("Fatal error on tick #{}: {}", tick_count, e);
                             if fmt == OutputFormat::Json {
+                                // In JSON mode the WatchTickOutput error line is the single
+                                // failure record for this stream. Exit directly with the
+                                // SyncError's code rather than returning Err, which would make
+                                // main's `exit_json_error` emit a second, differently-shaped
+                                // ErrorOutput line for the same failure.
                                 let out = WatchTickOutput::from_error(tick_count, &e.to_string());
                                 println!("{}", serde_json::to_string(&out).expect("WatchTickOutput is always serializable"));
+                                std::process::exit(e.exit_code());
                             }
                             return Err(e);
                         }

--- a/crates/smugglr/tests/watch_json_fatal_error.rs
+++ b/crates/smugglr/tests/watch_json_fatal_error.rs
@@ -1,0 +1,90 @@
+//! Regression test for #191: `watch --json` must emit exactly ONE JSON record
+//! on a fatal error, not two.
+//!
+//! Before the fix, a fatal (non-transient) error on a watch tick in JSON mode
+//! printed a `WatchTickOutput` error line from the tick handler AND then
+//! returned `Err`, which made `main` print a SECOND, differently-shaped
+//! `ErrorOutput` line for the same failure. The fix (crates/smugglr/src/watch.rs)
+//! prints the single `WatchTickOutput` error record and exits directly with the
+//! error's code, so downstream JSON consumers see one record per failure.
+//!
+//! This test drives the real binary at a config whose local/target databases
+//! are not valid SQLite files. The two `LocalDb::open` calls succeed (the files
+//! exist and SQLite opens lazily), so the failure surfaces from `sync_all` on
+//! the first tick -- exactly the fatal-in-tick path #191 is about, which is why
+//! the emitted record is a `WatchTickOutput` (it carries a `tick` field) rather
+//! than an `ErrorOutput`.
+
+use std::fs;
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn watch_json_fatal_error_emits_single_record() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let local_db = dir.path().join("local.db");
+    let target_db = dir.path().join("target.db");
+    let config_path = dir.path().join("config.toml");
+
+    // Files exist so `open_with_flags(READ_WRITE)` succeeds, but their contents
+    // are not a valid SQLite database, so the first `list_tables()` inside
+    // `sync_all` fails fatally on tick #1.
+    fs::write(&local_db, b"not a sqlite database").expect("write local db");
+    fs::write(&target_db, b"not a sqlite database").expect("write target db");
+
+    let config = format!(
+        "local_db = {local:?}\n\n[target]\ntype = \"sqlite\"\ndatabase = {target:?}\n",
+        local = local_db.to_str().expect("utf8 path"),
+        target = target_db.to_str().expect("utf8 path"),
+    );
+    fs::write(&config_path, config).expect("write config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_smugglr"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--output")
+        .arg("json")
+        .arg("watch")
+        .arg("--interval")
+        .arg("1")
+        .output()
+        .expect("run smugglr");
+
+    // The fatal error must terminate the daemon with a non-zero code.
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, got {:?}",
+        output.status
+    );
+
+    // stdout carries only JSON (tracing logs go to stderr). #191: there must be
+    // exactly one record. Pre-fix this had two lines (WatchTickOutput +
+    // ErrorOutput); post-fix it has one.
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "expected exactly one JSON record on stdout, got {}:\n{stdout}",
+        lines.len()
+    );
+
+    // The single record is the tick-error `WatchTickOutput`: it carries a `tick`
+    // field and reports the error status. The pre-fix second line was an
+    // `ErrorOutput` (no `tick` field), so requiring the sole line to be a
+    // WatchTickOutput also proves we exercised the fatal-in-tick path.
+    let record: Value = serde_json::from_str(lines[0]).expect("stdout line is JSON");
+    assert_eq!(record["command"], "watch");
+    assert_eq!(record["status"], "error");
+    assert!(
+        record.get("tick").and_then(Value::as_u64).is_some(),
+        "single record must be a WatchTickOutput (has `tick`), got: {}",
+        lines[0]
+    );
+    assert!(
+        record.get("error").and_then(Value::as_str).is_some(),
+        "record must carry an error message, got: {}",
+        lines[0]
+    );
+}


### PR DESCRIPTION
## Summary

CLI audit fixes for the `cli` cluster, closing #190 #191 #192 #193 #194.

- **#190 / #194 -- `--interval 0` panics `tokio::time::interval`, and unbounded interval overflows `peer_ttl`.** Both `watch --interval` (`crates/smugglr/src/main.rs:309`) and `broadcast --interval` (`crates/smugglr/src/main.rs:344`) now carry `value_parser = clap::value_parser!(u64).range(1..=86400)`, rejecting `0` (and absurd upper bounds) at parse time. Defense-in-depth `.max(1)` clamps guard the config-file path that bypasses clap in `run_watch` (`crates/smugglr/src/watch.rs:52`) and `run_broadcast` (`crates/smugglr/src/broadcast.rs:47`). `BroadcastConfig::peer_ttl` (`crates/smugglr-core/src/broadcast.rs:110`) uses `saturating_mul` so an operator-controlled interval can no longer overflow `u64`.
- **#192 -- `status` aborts on a post-connection failure instead of degrading.** `gather_status` (`crates/smugglr/src/main.rs:804`) no longer returns `Result`; a `list_tables`/`row_count` error after a successful `open` is captured as `connected: true` with an `error` string plus the counts gathered so far, mirroring the disconnected `StatusDb` the caller builds when `open` fails.
- **#193 -- dry-run watch tick reported `status: "ok"`.** `WatchTickOutput::from_results` (`crates/smugglr/src/output.rs:312`) now takes `dry_run` and emits `Status::DryRun`, matching every other command's dry-run JSON contract.
- **#191 -- duplicate JSON error line on a fatal watch tick.** The JSON error branch in `run_watch` (`crates/smugglr/src/watch.rs:119`) now `std::process::exit(e.exit_code())` after printing the single `WatchTickOutput` error line, instead of returning `Err` and letting `main`'s `exit_json_error` emit a second, differently-shaped `ErrorOutput` line for the same failure.

## Acceptance criteria mapping

### All tests pass (including a regression test that fails before the fix)

Every regression this diff adds reproduces its defect before the fix and passes after it, and the rest of the suite is green. The two interval-parse tests fail against pre-fix code because `--interval 0` parsed cleanly and reached the panicking `tokio::time::interval`; they now assert clap rejects it. The `peer_ttl` test panics on the pre-fix debug-overflow multiply and now passes via `saturating_mul`. The `status` partial-report and dry-run golden tests cover #192 and #193 respectively. The only non-passing tests are the pre-existing `multicast::tests` socket-bind flake, which this diff does not touch.

Evidence: `watch_interval_zero_is_rejected_at_parse` / `broadcast_interval_zero_is_rejected_at_parse` (`crates/smugglr/src/main.rs:1174`, `:1201`) assert `ErrorKind::ValueValidation`; `peer_ttl_saturates_instead_of_overflowing` (`crates/smugglr-core/src/broadcast.rs:837`) pins `u64::MAX` to `Duration::from_secs(u64::MAX)`; `gather_status_reports_partial_on_row_count_error` (`crates/smugglr/src/main.rs`) and `golden_watch_tick_dry_run_output` (`crates/smugglr/src/output.rs:798`) pass under `cargo test --workspace`, whose only failures are the 5 `multicast::tests` on `bind: Address already in use (os error 48)`.

### Simplify pass completed

The simplify pass ran on this branch HEAD and recorded a clean gate with a per-file articulation for all five changed files. It specifically evaluated the two `.max(1)` clamps and the two identical clap `value_parser` annotations and judged them deliberate defense-in-depth / inline-expression choices below the abstraction-worth threshold rather than extractable duplication.

Evidence: `legion quality-gate check --skill legion-simplify --result clean` recorded gate id `019f1ed2-87c1-7962-9637-9b63565af7ca` covering `crates/smugglr-core/src/broadcast.rs` and `crates/smugglr/src/{broadcast.rs,main.rs,output.rs,watch.rs}`.

### Review pass completed and issues fixed

This criterion is not yet satisfied at PR-open time and is tracked under `## Not done`. The quality pipeline runs `simplify -> pr-write -> review -> verify`, so the `legion-review` stage executes against this PR only after it is opened; it will complete this criterion on this PR's HEAD. The build gate that review depends on is already green, so review starts from a compiling, lint-clean, formatted tree.

Evidence: `cargo build`, `cargo clippy --workspace --all-targets -- -D warnings` (clean), `cargo fmt -- --check` (clean), and `cargo build -p smugglr-wasm --target wasm32-unknown-unknown` all pass on HEAD `03d7b57`.

### PR created and linked to this issue

This PR carries the issue number in its title and closes the issue via its trailer, which is what links it to #190 on GitHub. Merge is explicitly deferred, but the link is established at open time.

Evidence: PR title `fix(#190): cli audit fixes` and the `## Closes` trailer `Closes #190 #191 #192 #193 #194` below, which GitHub resolves to link and (on merge) close the issue.

## Not done

- The `legion-review` pass (`Review pass completed and issues fixed`) has not run yet -- it executes against this PR after it is opened, per the `simplify -> pr-write -> review -> verify` pipeline. This PR is explicitly not being merged.
- No broader structural extraction of the interval-clamp or `status` degrade logic: #190's "Out of Scope" note defers any such refactor to a separate issue, so the two `.max(1)` sites and the two clap `value_parser` annotations are left as sited, self-documenting duplication rather than hoisted into shared helpers.
- The pre-existing `multicast::tests` "Address already in use" flake is not addressed; it is environmental (loopback socket bind contention) and outside this cluster's scope.

## Closes

Closes #190 #191 #192 #193 #194