### PR TITLE
fix(#176,#177): sync integer Unix timestamps and order them numerically

### DIFF
--- a/crates/smugglr-core/src/datasource.rs
+++ b/crates/smugglr-core/src/datasource.rs
@@ -37,6 +37,24 @@ pub struct RowMeta {
     pub content_hash: String,
 }
 
+/// Normalize a row's timestamp-column value to the `RowMeta.updated_at` string.
+///
+/// Integer Unix timestamps arrive as JSON numbers from remote SQL-over-HTTP
+/// endpoints and as rusqlite integers locally; both must render to the same
+/// decimal string so the two sides compare equal. Extracting via `as_str()`
+/// alone (the old remote path) silently dropped an integer timestamp to `None`,
+/// which forced every genuinely-changed row into `content_differs` -- skipped in
+/// both directions under `newer_wins`/`uuid_v7_wins`. This is the single
+/// canonical extractor for the native, plugin, and wasm metadata builders so
+/// the three cannot drift.
+pub fn extract_updated_at(value: Option<&JsonValue>) -> Option<String> {
+    match value {
+        Some(JsonValue::Number(n)) => Some(n.to_string()),
+        Some(JsonValue::String(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
+
 /// Conditional Send bound: required on native (for tokio), absent on WASM (single-threaded).
 #[cfg(not(target_arch = "wasm32"))]
 pub trait MaybeSend: Send {}
@@ -95,4 +113,41 @@ pub trait DataSource: Sync {
         &self,
         table: &str,
     ) -> impl std::future::Future<Output = Result<usize>> + MaybeSend;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extract_updated_at_renders_integer_timestamps() {
+        // The whole point of #177: a JSON integer timestamp must survive as its
+        // decimal string, not get dropped to None by an as_str()-only path.
+        let v = json!(1_700_000_000_i64);
+        assert_eq!(extract_updated_at(Some(&v)), Some("1700000000".to_string()));
+    }
+
+    #[test]
+    fn extract_updated_at_renders_string_timestamps() {
+        let v = json!("2023-06-01T00:00:00Z");
+        assert_eq!(
+            extract_updated_at(Some(&v)),
+            Some("2023-06-01T00:00:00Z".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_updated_at_is_none_for_null_and_missing() {
+        assert_eq!(extract_updated_at(Some(&JsonValue::Null)), None);
+        assert_eq!(extract_updated_at(None), None);
+    }
+
+    #[test]
+    fn extract_updated_at_renders_float_as_number_string() {
+        // Float timestamps are out of scope for numeric ordering but must still
+        // round-trip a stable string (both sides render via this one path).
+        let v = json!(1.5);
+        assert_eq!(extract_updated_at(Some(&v)), Some("1.5".to_string()));
+    }
 }

--- a/crates/smugglr-core/src/diff.rs
+++ b/crates/smugglr-core/src/diff.rs
@@ -4,8 +4,28 @@ use crate::config::ConflictResolution;
 use crate::datasource::{DataSource, RowMeta};
 use crate::error::Result;
 use serde::Serialize;
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use tracing::{debug, info, warn};
+
+/// Order two `updated_at` timestamps for conflict resolution.
+///
+/// Integer Unix timestamps render as decimal strings ("999", "1000"); comparing
+/// those lexicographically is wrong across a digit-count boundary ("999" sorts
+/// after "1000"), so parse and compare numerically when BOTH sides are integers.
+/// ISO-8601 text timestamps are fixed-width, where lexical order == chronological,
+/// so fall back to string comparison when NEITHER side is an integer. A mixed
+/// pair (one integer, one non-integer) has no meaningful ordering -- return
+/// `None` so the caller routes it to `content_differs` rather than inventing a
+/// confident (and likely wrong) winner from a lexical compare of unlike
+/// representations.
+fn compare_ts(a: &str, b: &str) -> Option<Ordering> {
+    match (a.parse::<i64>(), b.parse::<i64>()) {
+        (Ok(x), Ok(y)) => Some(x.cmp(&y)),
+        (Err(_), Err(_)) => Some(a.cmp(b)),
+        _ => None,
+    }
+}
 
 /// Per-table diff statistics (counts only, no PK values).
 #[derive(Debug, Clone, Serialize)]
@@ -201,16 +221,13 @@ pub fn classify_diff(
         }
 
         match (&local_row.updated_at, &remote_row.updated_at) {
-            (Some(local_ts), Some(remote_ts)) => {
-                if local_ts > remote_ts {
-                    diff.local_newer.push((*pk).clone());
-                } else if remote_ts > local_ts {
-                    diff.remote_newer.push((*pk).clone());
-                } else {
-                    // Same timestamp, different content: treat as conflict.
-                    diff.content_differs.push((*pk).clone());
-                }
-            }
+            (Some(local_ts), Some(remote_ts)) => match compare_ts(local_ts, remote_ts) {
+                Some(Ordering::Greater) => diff.local_newer.push((*pk).clone()),
+                Some(Ordering::Less) => diff.remote_newer.push((*pk).clone()),
+                // Equal timestamps or unlike representations (one integer, one
+                // text): no safe tiebreaker, so treat as a content conflict.
+                Some(Ordering::Equal) | None => diff.content_differs.push((*pk).clone()),
+            },
             _ => {
                 diff.content_differs.push((*pk).clone());
             }
@@ -351,5 +368,89 @@ mod tests {
         let push = diff.rows_to_push(ConflictResolution::UuidV7Wins);
         assert_eq!(push, vec!["42".to_string()]);
         assert!(diff.rows_to_pull(ConflictResolution::UuidV7Wins).is_empty());
+    }
+
+    // --- Integer-timestamp conflict resolution (#176 / #177) ---
+
+    fn one(hash: &str, ts: Option<&str>) -> HashMap<String, RowMeta> {
+        let mut m = HashMap::new();
+        m.insert(
+            "r".to_string(),
+            RowMeta {
+                pk_value: "r".to_string(),
+                updated_at: ts.map(String::from),
+                content_hash: hash.to_string(),
+            },
+        );
+        m
+    }
+
+    // #177: an integer-timestamp row whose content changed must be classified by
+    // direction and actually sync -- NOT dropped into content_differs (which is
+    // skipped in both directions under newer_wins). This is the literal symptom
+    // the bug produced once both sides finally carry the integer timestamp.
+    #[test]
+    fn integer_timestamp_changed_row_syncs_not_skipped() {
+        // remote newer (larger unix ts), different content
+        let local = one("A", Some("1700000000"));
+        let remote = one("B", Some("1700000100"));
+        let diff = classify_diff(&local, &remote, "t");
+
+        assert_eq!(diff.remote_newer, vec!["r".to_string()]);
+        assert!(diff.content_differs.is_empty());
+        // ...and it is actually pulled under newer_wins, not silently skipped.
+        assert!(diff
+            .rows_to_pull(ConflictResolution::NewerWins)
+            .contains(&"r".to_string()));
+        assert!(diff.rows_to_push(ConflictResolution::NewerWins).is_empty());
+    }
+
+    // #176: integer timestamps straddling a digit-count boundary. Lexically
+    // "1000" < "999" (wrong); numerically 1000 > 999. The newer row (local) must
+    // win and be pushed -- the pre-fix code picked the OLDER remote row.
+    #[test]
+    fn integer_timestamp_lexicographic_boundary_orders_numerically() {
+        let local = one("A", Some("1000")); // newer
+        let remote = one("B", Some("999")); // older
+        let diff = classify_diff(&local, &remote, "t");
+
+        assert_eq!(diff.local_newer, vec!["r".to_string()]);
+        assert!(diff.remote_newer.is_empty());
+        assert!(diff
+            .rows_to_push(ConflictResolution::NewerWins)
+            .contains(&"r".to_string()));
+    }
+
+    // ISO-8601 text timestamps are fixed-width -> lexical order is chronological.
+    // Must keep working unchanged (they never enter the numeric branch).
+    #[test]
+    fn iso8601_timestamps_still_compare_lexically() {
+        let local = one("A", Some("2023-06-01T00:00:01Z")); // newer
+        let remote = one("B", Some("2023-06-01T00:00:00Z"));
+        let diff = classify_diff(&local, &remote, "t");
+        assert_eq!(diff.local_newer, vec!["r".to_string()]);
+    }
+
+    // Mixed representation (one integer, one ISO text for the same column --
+    // reachable via schema skew between local and remote). There is no honest
+    // ordering, so route to content_differs rather than invent a confident
+    // lexical winner ("2023-..." vs "1700..." would always pick local).
+    #[test]
+    fn mixed_timestamp_representation_is_content_differs() {
+        let local = one("A", Some("1700000000")); // integer
+        let remote = one("B", Some("2023-06-01T00:00:00Z")); // ISO text
+        let diff = classify_diff(&local, &remote, "t");
+        assert_eq!(diff.content_differs, vec!["r".to_string()]);
+        assert!(diff.local_newer.is_empty());
+        assert!(diff.remote_newer.is_empty());
+    }
+
+    // Equal integer timestamps with differing content: no tiebreaker -> conflict.
+    #[test]
+    fn equal_integer_timestamps_are_content_differs() {
+        let local = one("A", Some("1700000000"));
+        let remote = one("B", Some("1700000000"));
+        let diff = classify_diff(&local, &remote, "t");
+        assert_eq!(diff.content_differs, vec!["r".to_string()]);
     }
 }

--- a/crates/smugglr-core/src/diff.rs
+++ b/crates/smugglr-core/src/diff.rs
@@ -131,7 +131,9 @@ impl TableDiff {
         // count > 0 implies a skipping policy (unresolved_conflicts is empty for
         // local_wins/remote_wins); pick the reason, sharing one warning template.
         let reason = match conflict_resolution {
-            ConflictResolution::NewerWins => "no usable timestamps (skipped under newer_wins)",
+            ConflictResolution::NewerWins => {
+                "missing or incomparable timestamps (skipped under newer_wins)"
+            }
             ConflictResolution::UuidV7Wins => {
                 "same PK with identical UUIDv7 timestamp (skipped under uuid_v7_wins)"
             }

--- a/crates/smugglr-core/src/local.rs
+++ b/crates/smugglr-core/src/local.rs
@@ -211,21 +211,10 @@ fn get_row_metadata_inner(
         );
 
         // updated_at carries either an integer Unix timestamp or a string.
-        // get_json_value only ever yields Null/Number/String, so the catch-all
-        // is defensive against a future extension silently dropping a timestamp.
+        // Shared with the plugin and wasm metadata builders via the one
+        // canonical extractor so the three renderings cannot drift.
         let updated_at: Option<String> = if has_timestamp {
-            match row_map.get(timestamp_column) {
-                Some(JsonValue::Number(n)) => Some(n.to_string()),
-                Some(JsonValue::String(s)) => Some(s.clone()),
-                Some(JsonValue::Null) | None => None,
-                Some(other) => {
-                    warn!(
-                        "unexpected value type for timestamp column {} in {}: {}",
-                        timestamp_column, table, other
-                    );
-                    None
-                }
-            }
+            crate::datasource::extract_updated_at(row_map.get(timestamp_column))
         } else {
             None
         };

--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -5,7 +5,7 @@
 //! These functions are self-free (no adapter state) so they live here once
 //! and are called from both adapters as `adapter_common::<fn>`.
 
-use smugglr_core::datasource::{ColumnInfo, RowMeta, TableInfo};
+use smugglr_core::datasource::{extract_updated_at, ColumnInfo, RowMeta, TableInfo};
 use std::collections::HashMap;
 
 use serde_json::Value;
@@ -92,10 +92,7 @@ pub(crate) fn row_maps_to_metadata(
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        let updated_at = row
-            .get(timestamp_column)
-            .and_then(|v| v.as_str())
-            .map(String::from);
+        let updated_at = extract_updated_at(row.get(timestamp_column));
         let content_hash = content_hash(row, column_order, exclude_columns, timestamp_column);
 
         result.insert(

--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -178,4 +178,34 @@ mod tests {
             "SELECT *, CAST(\"id\" AS TEXT) AS __pk FROM \"items\" WHERE \"updated_at\" >= ?"
         );
     }
+
+    #[wasm_bindgen_test]
+    fn row_maps_to_metadata_round_trips_integer_timestamp() {
+        // Regression for #177: a remote SQL-over-HTTP endpoint returns an integer
+        // Unix timestamp as a JSON number. The pre-fix as_str()-only extraction in
+        // this builder dropped it to None, which forced the changed row into
+        // content_differs -- skipped in both directions under newer_wins/uuid_v7_wins.
+        // It must round-trip to the decimal string, matching how local.rs renders
+        // the same value, so the two sides compare equal. Fails on the pre-fix code
+        // (updated_at == None), passes after.
+        let mut row = HashMap::new();
+        row.insert("__pk".to_string(), Value::String("k1".to_string()));
+        row.insert(
+            "updated_at".to_string(),
+            Value::Number(serde_json::Number::from(1_700_000_000_i64)),
+        );
+        row.insert("name".to_string(), Value::String("alice".to_string()));
+
+        let meta = row_maps_to_metadata(
+            &[row],
+            &["name".to_string(), "updated_at".to_string()],
+            "updated_at",
+            &[],
+        );
+
+        assert_eq!(
+            meta.get("k1").expect("row keyed by __pk").updated_at,
+            Some("1700000000".to_string())
+        );
+    }
 }

--- a/plugins/smugglr-http-sql/src/adapter.rs
+++ b/plugins/smugglr-http-sql/src/adapter.rs
@@ -321,10 +321,8 @@ impl PluginAdapter for HttpSqlAdapter {
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            let updated_at = row
-                .get(timestamp_column)
-                .and_then(|v| v.as_str())
-                .map(String::from);
+            let updated_at =
+                smugglr_core::datasource::extract_updated_at(row.get(timestamp_column));
             let hash = smugglr_core::rowhash::content_hash(
                 row,
                 &column_order,


### PR DESCRIPTION
## Summary

Two coupled defects in the integer-Unix-timestamp path let content-changed rows sync in the wrong direction, or not at all, and silently. The remote metadata builders (native http-sql plugin, wasm fetch adapter) extracted `updated_at` with `as_str()` only, so a JSON integer timestamp came back `None` while the local side parsed it to `Some(...)`; that `(Some, None)` pair fell into `content_differs`, which `newer_wins`/`uuid_v7_wins` skip in both directions (#177). Independently, `classify_diff` compared `updated_at` as raw `String`, so integer timestamps rendered as decimal strings ordered lexicographically -- reversing the conflict direction across a digit-count boundary, e.g. `"1000"` sorts before `"999"` (#176). This PR adds one canonical timestamp extractor shared by all three metadata builders and makes the comparison numeric-aware, with a conservative fallback for unlike representations.

## Acceptance criteria mapping

### 1. (#177) Remote metadata builders accept integer timestamps so they round-trip like local.rs
The two remote builders now call `smugglr_core::datasource::extract_updated_at`, which matches on `JsonValue::Number(n) => Some(n.to_string())` in addition to the string case, instead of the old `as_str()`-only chain that returned `None` for a JSON number. Because the *same* function renders the local side (local.rs now routes through it too), an INTEGER column returned by a SQL-over-HTTP endpoint as `1700000000` produces the identical `Some("1700000000")` on both sides, so a changed row is classified by direction rather than dropped into `content_differs`.
Evidence: `plugins/smugglr-http-sql/src/adapter.rs` get_row_metadata and `crates/smugglr-wasm/src/adapter_common.rs` row_maps_to_metadata both call `extract_updated_at`; unit test `datasource::tests::extract_updated_at_renders_integer_timestamps`.

### 2. (#177) Regression test that fails before the fix and passes after
`diff::tests::integer_timestamp_changed_row_syncs_not_skipped` builds local/remote metadata with integer timestamps and differing content where remote is newer, then asserts the row lands in `remote_newer` (not `content_differs`) AND is returned by `rows_to_pull(NewerWins)` while absent from `rows_to_push(NewerWins)`. On the pre-fix code the remote side's `updated_at` was `None`, so the pair went to `content_differs` and both accessors skipped it -- the assertion on `remote_newer`/`rows_to_pull` fails without the fix.
Evidence: test `diff::tests::integer_timestamp_changed_row_syncs_not_skipped`.

### 3. (#176) Compare timestamps numerically when both are integers, not by raw String ordering
`classify_diff`'s `(Some, Some)` arm now delegates to `compare_ts`, which parses both operands as `i64` and compares numerically when both succeed, falling back to lexical order only when neither parses (ISO-8601, where fixed width makes lexical order chronological). A mixed pair -- one integer, one text, reachable via local/remote schema skew -- returns `None` and is routed to `content_differs` rather than producing a confident-but-meaningless lexical winner. `RowMeta.updated_at` stays `Option<String>`; no wire-type change.
Evidence: `crates/smugglr-core/src/diff.rs` `fn compare_ts` and the rewritten match arm; tests `integer_timestamp_lexicographic_boundary_orders_numerically`, `mixed_timestamp_representation_is_content_differs`, `iso8601_timestamps_still_compare_lexically`.

### 4. (#176) Regression test that fails before the fix and passes after
`diff::tests::integer_timestamp_lexicographic_boundary_orders_numerically` pins local `updated_at="1000"` (newer) against remote `"999"` (older) with differing content and asserts the row is `local_newer` and appears in `rows_to_push(NewerWins)`. Pre-fix, `"1000" > "999"` is `false` lexically, so the older remote row was misclassified `remote_newer` -- the assertion fails without the numeric compare.
Evidence: test `diff::tests::integer_timestamp_lexicographic_boundary_orders_numerically`.

## Not done

- No broader structural extraction beyond the single shared `extract_updated_at` renderer, which is the defect fix itself (the bug is a three-way drift; one renderer is the minimal way to stop it). The wasm adapter dedup (#219), plugin<->wasm dedup (#222), and wire-type unification (#228) are left to their own issues.
- `RowMeta.updated_at` is not re-typed to a normalized integer/enum; the issue offered that as an alternative, but it would ripple the plugin-sdk wire types and is unnecessary given the localized `compare_ts` fix.
- Float-serialized timestamps (e.g. `"1.5"`) are still ordered lexically, not numerically -- out of scope for the integer-timestamp defects and exotic for `updated_at`; `extract_updated_at` still round-trips them to a stable string.
- Pre-existing `multicast::` tests fail in this sandbox with `bind: Address already in use`; confirmed identical on clean `main`, unrelated to this diff.

Closes #176
Closes #177