### PR TITLE
fix(#231): NULL-PK skip + duplicate-PK warning parity in plugin and wasm metadata paths

### DIFF
--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -84,25 +84,44 @@ pub(crate) fn row_maps_to_metadata(
     column_order: &[String],
     timestamp_column: &str,
     exclude_columns: &[String],
+    table: &str,
 ) -> HashMap<String, RowMeta> {
     let mut result = HashMap::with_capacity(maps.len());
     for row in maps {
-        let pk = row
-            .get("__pk")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
+        // Parity with core local.rs: a NULL rendered __pk (a NULL part in a
+        // composite PK propagates through `||`) cannot key pk-based sync.
+        // Coercing it to "" would collapse every such row onto one entry --
+        // silently dropping rows and provoking spurious deletes. Skip and warn.
+        let pk = match row.get("__pk").and_then(|v| v.as_str()) {
+            Some(pk) => pk.to_string(),
+            None => {
+                web_sys::console::warn_1(
+                    &format!("smugglr: skipping row in {} with NULL primary key", table).into(),
+                );
+                continue;
+            }
+        };
         let updated_at = extract_updated_at(row.get(timestamp_column));
         let content_hash = content_hash(row, column_order, exclude_columns, timestamp_column);
 
-        result.insert(
+        if let Some(prev) = result.insert(
             pk.clone(),
             RowMeta {
-                pk_value: pk,
+                pk_value: pk.clone(),
                 updated_at,
                 content_hash,
             },
-        );
+        ) {
+            // Two rows rendering to the same PK text means the PK is not unique
+            // as encoded -- the metadata map silently lost `prev`. Surface it.
+            web_sys::console::warn_1(
+                &format!(
+                    "smugglr: duplicate primary key {} in {} -- a row was overwritten in change metadata (prev hash {})",
+                    pk, table, prev.content_hash
+                )
+                .into(),
+            );
+        }
     }
     result
 }
@@ -201,11 +220,35 @@ mod tests {
             &["name".to_string(), "updated_at".to_string()],
             "updated_at",
             &[],
+            "items",
         );
 
         assert_eq!(
             meta.get("k1").expect("row keyed by __pk").updated_at,
             Some("1700000000".to_string())
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn row_maps_to_metadata_skips_null_primary_key() {
+        // Regression for #231: a NULL rendered __pk (e.g. a NULL part of a
+        // composite PK, since `||` propagates NULL) must be skipped, not coerced
+        // to "". Two such rows previously collapsed onto a single "" key --
+        // silently dropping one and provoking spurious deletes. Pre-fix this
+        // returns 1 entry (keyed ""); after the fix it returns 0.
+        let mut a = HashMap::new();
+        a.insert("__pk".to_string(), Value::Null);
+        a.insert("name".to_string(), Value::String("alice".to_string()));
+        let mut b = HashMap::new();
+        b.insert("__pk".to_string(), Value::Null);
+        b.insert("name".to_string(), Value::String("bob".to_string()));
+
+        let meta = row_maps_to_metadata(&[a, b], &["name".to_string()], "updated_at", &[], "items");
+
+        assert!(
+            meta.is_empty(),
+            "NULL-__pk rows must be skipped, not collapsed onto one key; got {} entries",
+            meta.len()
         );
     }
 }

--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -224,6 +224,7 @@ impl FetchDataSource {
             &column_order,
             timestamp_column,
             exclude_columns,
+            table,
         ))
     }
 
@@ -304,6 +305,7 @@ impl DataSource for FetchDataSource {
             &column_order,
             timestamp_column,
             exclude_columns,
+            table,
         ))
     }
 

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -117,6 +117,7 @@ impl LocalSqlDataSource {
             &column_order,
             timestamp_column,
             exclude_columns,
+            table,
         ))
     }
 
@@ -194,6 +195,7 @@ impl DataSource for LocalSqlDataSource {
             &column_order,
             timestamp_column,
             exclude_columns,
+            table,
         ))
     }
 

--- a/plugins/smugglr-http-sql/src/adapter.rs
+++ b/plugins/smugglr-http-sql/src/adapter.rs
@@ -313,34 +313,13 @@ impl PluginAdapter for HttpSqlAdapter {
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
         let maps = self.rows_to_maps(&columns, &rows);
-
-        let mut result = HashMap::new();
-        for row in &maps {
-            let pk = row
-                .get("__pk")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let updated_at =
-                smugglr_core::datasource::extract_updated_at(row.get(timestamp_column));
-            let hash = smugglr_core::rowhash::content_hash(
-                row,
-                &column_order,
-                exclude_columns,
-                timestamp_column,
-            );
-
-            result.insert(
-                pk.clone(),
-                RowMeta {
-                    pk_value: pk,
-                    updated_at,
-                    content_hash: hash,
-                },
-            );
-        }
-
-        Ok(result)
+        Ok(build_row_metadata(
+            &maps,
+            &column_order,
+            timestamp_column,
+            exclude_columns,
+            table,
+        ))
     }
 
     async fn get_rows(
@@ -415,9 +394,98 @@ impl PluginAdapter for HttpSqlAdapter {
     }
 }
 
+/// Build the PK-keyed RowMeta map from result rows carrying a synthetic `__pk`
+/// column. Extracted from the async/HTTP-bound `get_row_metadata` so the
+/// NULL-/duplicate-PK guard is host-testable. Plugin-local only -- this is NOT
+/// the cross-crate dedup tracked by #222.
+///
+/// Parity with core `local.rs`: a NULL rendered `__pk` (a NULL part of a
+/// composite PK propagates through `||`) cannot key pk-based sync, and coercing
+/// it to "" would collapse every such row onto one entry -- silently dropping
+/// rows and provoking spurious deletes. Skip and warn; likewise surface a
+/// duplicate PK-text that overwrites an existing entry.
+fn build_row_metadata(
+    maps: &[HashMap<String, Value>],
+    column_order: &[String],
+    timestamp_column: &str,
+    exclude_columns: &[String],
+    table: &str,
+) -> HashMap<String, RowMeta> {
+    let mut result = HashMap::new();
+    for row in maps {
+        let pk = match row.get("__pk").and_then(|v| v.as_str()) {
+            Some(pk) => pk.to_string(),
+            None => {
+                eprintln!(
+                    "smugglr-http-sql: skipping row in {} with NULL primary key",
+                    table
+                );
+                continue;
+            }
+        };
+        let updated_at = smugglr_core::datasource::extract_updated_at(row.get(timestamp_column));
+        let content_hash = smugglr_core::rowhash::content_hash(
+            row,
+            column_order,
+            exclude_columns,
+            timestamp_column,
+        );
+
+        if let Some(prev) = result.insert(
+            pk.clone(),
+            RowMeta {
+                pk_value: pk.clone(),
+                updated_at,
+                content_hash,
+            },
+        ) {
+            eprintln!(
+                "smugglr-http-sql: duplicate primary key {} in {} -- a row was overwritten in change metadata (prev hash {})",
+                pk, table, prev.content_hash
+            );
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_row_metadata_skips_null_primary_key() {
+        // Regression for #231 (plugin path): a NULL rendered __pk must be skipped,
+        // not coerced to "". Two NULL-pk rows previously collapsed onto a single
+        // "" key -- silently dropping one. Pre-fix this returns 1 entry (keyed
+        // ""); after the fix it returns 0.
+        let mut a = HashMap::new();
+        a.insert("__pk".to_string(), Value::Null);
+        a.insert("name".to_string(), Value::from("alice"));
+        let mut b = HashMap::new();
+        b.insert("__pk".to_string(), Value::Null);
+        b.insert("name".to_string(), Value::from("bob"));
+
+        let meta = build_row_metadata(&[a, b], &["name".to_string()], "updated_at", &[], "items");
+
+        assert!(
+            meta.is_empty(),
+            "NULL-__pk rows must be skipped, not collapsed onto one key; got {} entries",
+            meta.len()
+        );
+    }
+
+    #[test]
+    fn build_row_metadata_keeps_valid_rows() {
+        // Guard against over-skipping: a normal string __pk is retained.
+        let mut a = HashMap::new();
+        a.insert("__pk".to_string(), Value::from("k1"));
+        a.insert("name".to_string(), Value::from("alice"));
+
+        let meta = build_row_metadata(&[a], &["name".to_string()], "updated_at", &[], "items");
+
+        assert_eq!(meta.len(), 1);
+        assert!(meta.contains_key("k1"));
+    }
 
     #[test]
     fn test_content_hash_excludes_timestamp() {


### PR DESCRIPTION
## Summary

Core `local.rs` guards two pk-metadata hazards: it skips a row whose rendered `__pk` is NULL (a NULL part of a composite PK propagates through `||`, and coercing it to `""` collapses every such row onto one map key -- silently dropping rows and provoking spurious deletes), and it warns when a duplicate PK-text overwrites an existing `RowMeta`. The http-sql plugin and both wasm adapters had neither guard: they did `row.get("__pk").and_then(|v| v.as_str()).unwrap_or("")` and inserted unconditionally. This PR brings both paths to parity.

## Acceptance criteria mapping

### 1. Plugin and wasm metadata paths skip a NULL rendered `__pk` with a warning (parity with core local.rs)
Both builders now `match row.get("__pk").and_then(|v| v.as_str())` and, on `None` (a JSON `null` `__pk`, or a missing/non-text one), emit a warning and `continue` instead of coercing to `""`. The wasm path (the shared `row_maps_to_metadata`, used by both `FetchDataSource` and `LocalSqlDataSource`) warns via `web_sys::console::warn_1`; the plugin path warns via `eprintln!` to stderr, which the host surfaces because it spawns the plugin with `stderr(Stdio::inherit())` (crates/smugglr-core/src/plugin.rs:140). A `table` argument was threaded into `row_maps_to_metadata` (through its 4 callers) so the message names the table, matching core.
Evidence: crates/smugglr-wasm/src/adapter_common.rs `row_maps_to_metadata` (the `None =>` arm); plugins/smugglr-http-sql/src/adapter.rs `build_row_metadata` (the `None =>` arm).

### 2. A duplicate PK-text that overwrites an existing RowMeta entry is surfaced with a warning
Each builder now inspects the return of `result.insert(...)`; a `Some(prev)` means two rows rendered the same PK text and the map silently lost `prev`, so it emits a warning naming the pk, table, and the overwritten hash -- mirroring core local.rs. This is a diagnostic side-effect with no change to the returned map (last-writer still wins, as before), so there is no fails-before behavioral test for it -- consistent with core, whose own dup-warn (local.rs:232) is likewise not behaviorally unit-tested (its metadata loop is rusqlite-bound). Evidenced by the emission site.
Evidence: crates/smugglr-wasm/src/adapter_common.rs the `if let Some(prev) = result.insert(...)` block; plugins/smugglr-http-sql/src/adapter.rs the same block in `build_row_metadata`; parity with crates/smugglr-core/src/local.rs:222-236.

### 3. Regression test in each path that fails before the fix
NULL-skip is the behavioral fix, so each path has a fails-before test asserting that two NULL-`__pk` rows produce an empty map (pre-fix they collapse onto a single `""` key -> 1 entry). The plugin path is host-testable because the loop was extracted into the pure `build_row_metadata`; I confirmed it fails-before by reverting only the guard (keeping the extraction) and observing "got 1 entries". The wasm path runs under `wasm-pack test --node`.
Evidence: plugins/smugglr-http-sql/src/adapter.rs::tests::build_row_metadata_skips_null_primary_key (host; empirically fails on the guard-reverted helper); crates/smugglr-wasm/src/adapter_common.rs::tests::row_maps_to_metadata_skips_null_primary_key (wasm-pack, passing).

### 4. Simplify + review passes completed
`/legion-simplify` recorded a clean gate on this HEAD (4 per-file articulation entries, 0 findings). `/legion-review` runs after the PR opens; this section is completed when that gate is clean.
Evidence: legion-simplify quality-gate row for HEAD 213c083 (gate 019f5cc9-05a2-7401-b49c-42b3f8398258); the legion-review gate on the PR.

### 5. PR created and linked to this issue
Opened via `legion pr create --task <card>` and the body closes the issue.
Evidence: PR body contains "Closes #231"; card linked via --task.

## Not done

- No cross-crate deduplication of the plugin and wasm metadata builders (they still hold parallel copies of the loop). That is the separate #222; the `build_row_metadata` extraction here is plugin-local and test-motivated only.
- `RowMeta.updated_at`/pk rendering is unchanged; this PR only adds the skip + warn guards.
- The duplicate-PK warning is not behaviorally tested (see criterion 2) -- it has no observable effect on the returned map, only on the log stream.
- Exact byte-parity with core is not claimed: core does `row.get::<_, Option<String>>(0)?` (which errors on a non-text `__pk`), whereas these paths treat a non-string `__pk` as a NULL-skip. Unreachable in practice since `pk_text_expr` CASTs `__pk` to TEXT.

Closes #231