### PR TITLE
fix(#201): reject parameterized queries on the datasette profile instead of dropping params

### DIFF
--- a/crates/smugglr-core/src/profile.rs
+++ b/crates/smugglr-core/src/profile.rs
@@ -5,6 +5,7 @@
 //! so both the http-sql plugin (reqwest) and the WASM adapter (fetch)
 //! can share profile definitions without duplication.
 
+use crate::error::SyncError;
 use serde_json::Value;
 
 /// How to talk to a specific HTTP SQL endpoint.
@@ -35,7 +36,8 @@ pub enum RequestFormat {
     Turso,
     /// rqlite: `[["<sql>", ...params]]`
     Rqlite,
-    /// Datasette: `{"sql": "<sql>", "params": {...}}`
+    /// Datasette: `{"sql": "<sql>", "_shape": "array"}`. No positional bind API,
+    /// so `build_request` errors rather than drop bound params (see #201).
     Datasette,
     /// Flat JSON: `{"sql": "<sql>", "params": [...]}`. Shared by Cloudflare D1,
     /// the http-sql v0.1 spec, and generic endpoints -- they emit this exact
@@ -154,8 +156,14 @@ impl Profile {
     }
 
     /// Build the request body for a SQL query.
-    pub fn build_request(&self, sql: &str, params: &[Value]) -> Value {
-        match self.request_format {
+    ///
+    /// Errors for the datasette profile when `params` is non-empty: Datasette's
+    /// HTTP API has no positional (`?`) bind mechanism, so the previous behavior
+    /// silently dropped the bound values and sent SQL with unbound `?`
+    /// placeholders (endpoint error or, worse, a mis-bind). Surfacing the
+    /// incompatibility as an error is the fix for #201.
+    pub fn build_request(&self, sql: &str, params: &[Value]) -> Result<Value, SyncError> {
+        let body = match self.request_format {
             RequestFormat::Turso => {
                 if params.is_empty() {
                     serde_json::json!({
@@ -197,6 +205,15 @@ impl Profile {
                 }
             }
             RequestFormat::Datasette => {
+                if !params.is_empty() {
+                    return Err(SyncError::Config(format!(
+                        "the datasette profile does not support parameterized queries: {} bind \
+                         parameter(s) would be silently dropped. Datasette has no positional bind \
+                         API; use a profile with parameter support (turso, rqlite, generic) for \
+                         this endpoint.",
+                        params.len()
+                    )));
+                }
                 serde_json::json!({"sql": sql, "_shape": "array"})
             }
             RequestFormat::Generic => {
@@ -206,7 +223,8 @@ impl Profile {
                     serde_json::json!({"sql": sql, "params": params})
                 }
             }
-        }
+        };
+        Ok(body)
     }
 
     /// Navigate a JSON path to extract a nested value.
@@ -230,7 +248,7 @@ mod tests {
     #[test]
     fn test_turso_request_no_params() {
         let p = Profile::turso();
-        let body = p.build_request("SELECT 1", &[]);
+        let body = p.build_request("SELECT 1", &[]).unwrap();
         assert!(body["requests"][0]["stmt"]["sql"]
             .as_str()
             .unwrap()
@@ -240,10 +258,12 @@ mod tests {
     #[test]
     fn test_turso_request_with_params() {
         let p = Profile::turso();
-        let body = p.build_request(
-            "SELECT * FROM users WHERE id = ?",
-            &[Value::String("42".into())],
-        );
+        let body = p
+            .build_request(
+                "SELECT * FROM users WHERE id = ?",
+                &[Value::String("42".into())],
+            )
+            .unwrap();
         let args = &body["requests"][0]["stmt"]["args"];
         assert_eq!(args[0]["type"], "text");
         assert_eq!(args[0]["value"], "42");
@@ -252,14 +272,14 @@ mod tests {
     #[test]
     fn test_rqlite_request() {
         let p = Profile::rqlite();
-        let body = p.build_request("SELECT 1", &[]);
+        let body = p.build_request("SELECT 1", &[]).unwrap();
         assert_eq!(body[0][0], "SELECT 1");
     }
 
     #[test]
     fn test_generic_request() {
         let p = Profile::generic();
-        let body = p.build_request("SELECT 1", &[]);
+        let body = p.build_request("SELECT 1", &[]).unwrap();
         assert_eq!(body["sql"], "SELECT 1");
     }
 
@@ -287,16 +307,35 @@ mod tests {
     #[test]
     fn test_d1_request() {
         let p = Profile::d1();
-        let body = p.build_request("SELECT 1", &[]);
+        let body = p.build_request("SELECT 1", &[]).unwrap();
         assert_eq!(body["sql"], "SELECT 1");
     }
 
     #[test]
     fn test_datasette_request() {
         let p = Profile::datasette();
-        let body = p.build_request("SELECT 1", &[]);
+        let body = p.build_request("SELECT 1", &[]).unwrap();
         assert_eq!(body["sql"], "SELECT 1");
         assert_eq!(body["_shape"], "array");
+    }
+
+    #[test]
+    fn datasette_rejects_parameterized_query() {
+        // Regression for #201: Datasette has no positional bind API, so the
+        // pre-fix build_request silently DROPPED params and emitted
+        // {"sql": ..., "_shape": "array"} with unbound `?` placeholders (endpoint
+        // error or mis-bind). It must now return an error instead of a
+        // silently-misbinding body. Paramless datasette still works
+        // (test_datasette_request above).
+        let p = Profile::datasette();
+        let result = p.build_request(
+            "SELECT * FROM t WHERE id IN (?)",
+            &[Value::String("k1".into())],
+        );
+        assert!(
+            result.is_err(),
+            "datasette must reject bound params, not silently drop them"
+        );
     }
 
     #[test]
@@ -320,7 +359,7 @@ mod tests {
     #[test]
     fn test_http_sql_request_no_params() {
         let p = Profile::http_sql();
-        let body = p.build_request("SELECT 1", &[]);
+        let body = p.build_request("SELECT 1", &[]).unwrap();
         assert_eq!(body["sql"], "SELECT 1");
         assert!(body.get("params").is_none());
     }
@@ -328,10 +367,12 @@ mod tests {
     #[test]
     fn test_http_sql_request_with_params() {
         let p = Profile::http_sql();
-        let body = p.build_request(
-            "SELECT * FROM notes WHERE id = ?",
-            &[Value::String("42".into())],
-        );
+        let body = p
+            .build_request(
+                "SELECT * FROM notes WHERE id = ?",
+                &[Value::String("42".into())],
+            )
+            .unwrap();
         assert_eq!(body["sql"], "SELECT * FROM notes WHERE id = ?");
         assert_eq!(body["params"][0], "42");
     }

--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -41,7 +41,7 @@ impl FetchDataSource {
     }
 
     async fn execute(&self, sql: &str, params: &[Value]) -> Result<Value> {
-        let body = self.profile.build_request(sql, params);
+        let body = self.profile.build_request(sql, params)?;
         let body_str =
             serde_json::to_string(&body).map_err(|e| SyncError::Remote(e.to_string()))?;
 

--- a/plugins/smugglr-http-sql/src/adapter.rs
+++ b/plugins/smugglr-http-sql/src/adapter.rs
@@ -44,7 +44,10 @@ impl HttpSqlAdapter {
             .as_ref()
             .ok_or_else(|| PluginError::new("not initialized"))?;
 
-        let body = self.profile.build_request(sql, params);
+        let body = self
+            .profile
+            .build_request(sql, params)
+            .map_err(|e| PluginError::new(e.to_string()))?;
         let mut req = client.post(&self.url).json(&body);
 
         req = match self.profile.auth_format {


### PR DESCRIPTION
## Summary

`Profile::build_request`'s Datasette arm emitted `{"sql": ..., "_shape": "array"}` and discarded the `params` slice entirely. Datasette has no positional (`?`) bind API, and the plugin's `get_rows` builds `... WHERE <pk> IN (?, ?)` (+ a params vec) while `upsert_rows` builds `INSERT ... VALUES (?, ?)` -- so on the datasette profile those `?` placeholders went out with zero bound values, giving an endpoint error or a silent mis-bind, with no read-only/param gating anywhere. This PR makes the drop impossible by surfacing it as an error.

## Acceptance criteria mapping

### 1. Behavior: reject params for the datasette profile (instead of silently dropping them)
`build_request` now returns `Result<Value, SyncError>` and the `RequestFormat::Datasette` arm does an early `return Err(SyncError::Config(...))` when `params` is non-empty, naming the dropped-parameter count and the param-supporting profiles (turso, rqlite, generic). The issue offered two options -- inline the params, or error -- and error is the correct one here: Datasette's HTTP API is named-param/read-only with no positional bind, so a `?`->`:name` rewrite could not be verified against a live endpoint and would just relocate the silent mis-bind. The two call sites are updated: the native plugin `execute` bridges the error to `PluginError`, the wasm `fetch_adapter::execute` propagates via `?`. Semantic narrowing (stated deliberately): Datasette stays usable for the paramless paths -- `list_tables`, `table_info`, `get_row_metadata` (its `SELECT *, <pk> AS __pk FROM ...` full scan carries no params), `row_count` -- so change *detection* still works; only the parameterized `get_rows`/`upsert` now error clearly.
Evidence: crates/smugglr-core/src/profile.rs build_request (RequestFormat::Datasette arm); plugins/smugglr-http-sql/src/adapter.rs execute (.map_err to PluginError); crates/smugglr-wasm/src/fetch_adapter.rs execute (`?`).

### 2. Regression test that fails before the fix and passes after
`profile::tests::datasette_rejects_parameterized_query` asserts a parameterized datasette request returns `Err`. Because the fix changes the return type, the same assertion cannot compile against the pre-fix `-> Value` signature; instead I isolated the guard from the type change by reverting only the Datasette arm's behavior (`Err(...)` -> drop-and-`Ok`) while keeping the `Result` signature, and observed the test FAIL, then restored. Paramless datasette is unaffected (`test_datasette_request` still asserts the `{"sql", "_shape"}` body).
Evidence: test crates/smugglr-core/src/profile.rs::tests::datasette_rejects_parameterized_query (empirically fails on the drop-behavior revert); test_datasette_request for the paramless Ok path.

### 3. All tests pass
`cargo test -p smugglr-core -p smugglr-http-sql`: 207 passed; the only failures are 5 pre-existing `multicast::` tests that fail in this sandbox with `bind: Address already in use` (environmental, reproduce identically on clean main, untouched by this diff). Plugin and wasm32 both build; fmt + clippy `--all-targets` clean on host and wasm32.
Evidence: cargo test output (207 pass); CI on the PR (Test ubuntu/macos/windows, Clippy, Format).

### 4. Simplify + review passes completed
`/legion-simplify` recorded clean on this HEAD (3 per-file entries, 0 findings). `/legion-review` runs after the PR opens.
Evidence: legion-simplify gate for HEAD b07cdcc (019f5cda-8d49-7df2-9882-7a3804495704); the legion-review gate on the PR.

### 5. PR created and linked to this issue
The PR is opened via `legion pr create --task <card-id>`, which stores the PR URL on the kanban card and establishes the card<->PR link the verify gate reads; the body's `Closes #201` trailer makes a merge to the default branch auto-close the issue, keeping the GitHub issue state and the kanban card consistent after merge.
Evidence: PR body contains "Closes #201"; the PR is linked to card 019e98dc-b730-7980-9f9f-24181999a46b via --task and appears in `legion pr list`.

## Not done

- Option 1 (inline params so datasette works with bound values) was deliberately not taken -- see criterion 1. Making datasette fully parameterizable would require a verified `?`->named rewrite against a real Datasette and is out of scope for this defect.
- No change to the other profiles' request bodies (Turso/Rqlite/Generic arms are byte-unchanged) or to read-only gating beyond the param rejection.
- The parameterized `get_rows`/`upsert` paths on datasette now return an error rather than syncing; this is the intended narrowing (they previously mis-bound), not a separate regression.

Closes #201