### PR TITLE
fix(#198): guard the empty-primary-key case in get_rows across all three adapters

### DIFF
--- a/crates/smugglr-core/src/rowhash.rs
+++ b/crates/smugglr-core/src/rowhash.rs
@@ -22,6 +22,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::config::column_excluded;
+use crate::error::SyncError;
 
 /// Columns never folded into the content hash: they carry change-tracking
 /// timestamps, not content. A row whose only delta is its timestamp must NOT
@@ -136,6 +137,33 @@ pub fn pk_text_expr(primary_key: &[String]) -> String {
         .map(|k| format!("CAST(\"{}\" AS TEXT)", k))
         .collect::<Vec<_>>()
         .join(" || '|' || ")
+}
+
+/// Build the `SELECT * ... WHERE <pk> IN (?, ...)` query the adapters use to
+/// fetch full rows by primary key, guarding the empty-primary-key case.
+///
+/// `pk_text_expr` returns "" for an empty primary key, which would splice into
+/// `WHERE  IN (?, ?)` -- malformed SQL that fails with an opaque remote/executor
+/// error. `get_row_metadata` guards this; `get_rows` did not, across all three
+/// adapters (native http-sql, wasm fetch, wasm local). This is the one guarded
+/// builder they now share, so the guard cannot drift or be forgotten (#198).
+pub fn pk_in_query(
+    table: &str,
+    primary_key: &[String],
+    pk_count: usize,
+) -> Result<String, SyncError> {
+    if primary_key.is_empty() {
+        return Err(SyncError::Config(format!(
+            "no primary key for table: {table}"
+        )));
+    }
+    let placeholders = vec!["?"; pk_count].join(", ");
+    Ok(format!(
+        "SELECT * FROM \"{}\" WHERE {} IN ({})",
+        table,
+        pk_text_expr(primary_key),
+        placeholders
+    ))
 }
 
 #[cfg(test)]
@@ -282,6 +310,26 @@ mod tests {
         assert_eq!(
             pk_text_expr(&["a".to_string(), "b".to_string()]),
             "CAST(\"a\" AS TEXT) || '|' || CAST(\"b\" AS TEXT)"
+        );
+    }
+
+    #[test]
+    fn pk_in_query_rejects_empty_primary_key() {
+        // Regression for #198: an empty primary key renders pk_text_expr to "",
+        // which splices into malformed `WHERE  IN (?, ?)`. The builder must error
+        // rather than emit that SQL (which get_rows previously sent verbatim).
+        assert!(
+            pk_in_query("items", &[], 2).is_err(),
+            "empty primary key must be rejected, not spliced into malformed SQL"
+        );
+    }
+
+    #[test]
+    fn pk_in_query_builds_select_for_valid_pk() {
+        let sql = pk_in_query("notes", &["id".to_string()], 2).unwrap();
+        assert_eq!(
+            sql,
+            "SELECT * FROM \"notes\" WHERE CAST(\"id\" AS TEXT) IN (?, ?)"
         );
     }
 }

--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -319,16 +319,8 @@ impl DataSource for FetchDataSource {
         }
 
         let info = self.cached_table_info(table).await?;
-        let pk_expr = adapter_common::build_pk_text_expr(&info.primary_key);
-
-        let placeholders: Vec<String> = pk_values.iter().map(|_| "?".to_string()).collect();
+        let sql = smugglr_core::rowhash::pk_in_query(table, &info.primary_key, pk_values.len())?;
         let params: Vec<Value> = pk_values.iter().map(|v| Value::String(v.clone())).collect();
-        let sql = format!(
-            "SELECT * FROM \"{}\" WHERE {} IN ({})",
-            table,
-            pk_expr,
-            placeholders.join(", ")
-        );
 
         let response = self.execute(&sql, &params).await?;
         let columns = self.extract_columns(&response)?;

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -209,16 +209,8 @@ impl DataSource for LocalSqlDataSource {
         }
 
         let info = self.cached_table_info(table).await?;
-        let pk_expr = adapter_common::build_pk_text_expr(&info.primary_key);
-
-        let placeholders: Vec<String> = pk_values.iter().map(|_| "?".to_string()).collect();
+        let sql = smugglr_core::rowhash::pk_in_query(table, &info.primary_key, pk_values.len())?;
         let params: Vec<Value> = pk_values.iter().map(|v| Value::String(v.clone())).collect();
-        let sql = format!(
-            "SELECT * FROM \"{}\" WHERE {} IN ({})",
-            table,
-            pk_expr,
-            placeholders.join(", ")
-        );
 
         let result = self.run(&sql, &params).await?;
         Ok(adapter_common::rows_to_maps(&result.columns, &result.rows))

--- a/plugins/smugglr-http-sql/src/adapter.rs
+++ b/plugins/smugglr-http-sql/src/adapter.rs
@@ -335,16 +335,9 @@ impl PluginAdapter for HttpSqlAdapter {
         }
 
         let info = self.cached_table_info(table).await?;
-        let pk_expr = smugglr_core::rowhash::pk_text_expr(&info.primary_key);
-
-        let placeholders: Vec<String> = pk_values.iter().map(|_| "?".to_string()).collect();
+        let sql = smugglr_core::rowhash::pk_in_query(table, &info.primary_key, pk_values.len())
+            .map_err(|e| PluginError::new(e.to_string()))?;
         let params: Vec<Value> = pk_values.iter().map(|v| Value::String(v.clone())).collect();
-        let sql = format!(
-            "SELECT * FROM \"{}\" WHERE {} IN ({})",
-            table,
-            pk_expr,
-            placeholders.join(", ")
-        );
 
         let response = self.execute(&sql, &params).await?;
         let columns = self.extract_columns(&response)?;


### PR DESCRIPTION
## Summary

`get_rows` built its `WHERE <pk> IN (?, ...)` query with `pk_text_expr(&info.primary_key)` and no `info.primary_key.is_empty()` guard -- unlike `get_row_metadata`, which guards. On an empty primary key, `pk_text_expr` returns `""`, splicing into `SELECT * FROM "t" WHERE  IN (?, ?)` -- malformed SQL sent verbatim to the endpoint/executor, failing with an opaque error. It is latent in normal flow (both `get_sync_tables` and `get_stash_tables` filter PK-less tables) but reachable via a direct `get_rows` call or a table that loses its PK mid-session, and all three adapters shared the gap. This PR closes it in one shared, guarded builder.

## Acceptance criteria mapping

### 1. All tests pass (including a regression test that fails before the fix)
The guarded builder `smugglr_core::rowhash::pk_in_query` returns `Err(SyncError::Config("no primary key for table: ..."))` on an empty primary key instead of emitting malformed SQL. `rowhash::tests::pk_in_query_rejects_empty_primary_key` asserts that empty-PK path is an error; I confirmed it genuinely fails-before by deleting only the guard line and observing the test FAIL (it returned `Ok("... WHERE  IN (?, ?)")`), then restored. `pk_in_query_builds_select_for_valid_pk` pins the exact SQL for the normal path. Full suites pass: `cargo test -p smugglr-core -p smugglr-http-sql` green except the 5 pre-existing `multicast::` socket-bind flakes (reproduce on clean main); plugin + wasm32 build; fmt + clippy `--all-targets` clean on host and wasm32.
Evidence: tests crates/smugglr-core/src/rowhash.rs::tests::pk_in_query_rejects_empty_primary_key (empirically fails on the guard-removed builder) and pk_in_query_builds_select_for_valid_pk.

### 2. Simplify pass completed
`/legion-simplify` recorded clean on this HEAD -- 4 per-file entries, 0 findings -- with the extraction justified as the fix mechanism (one shared guard the three adapters cannot diverge on) rather than churn, and noted that it removes the byte-identical triplicate SQL build.
Evidence: legion-simplify gate for HEAD 1831d52 (019f5d07-354e-7ea1-977b-521ec9e958a1).

### 3. Review pass completed and issues fixed
An independent `/legion-review` runs against the open PR and must record a clean gate on this HEAD; any findings will be fixed and re-verified before merge. This entry is satisfied when that gate is clean.
Evidence: the legion-review quality-gate row recorded for HEAD 1831d52 on PR (to be linked).

### 4. PR created and linked to this issue
Opened via `legion pr create --task <card-id>`, which stores the PR URL on the kanban card and establishes the card<->PR link the verify gate reads; the body's `Closes #198` trailer makes a merge to the default branch auto-close the issue, keeping GitHub and the kanban board consistent.
Evidence: PR body contains "Closes #198"; the PR is linked to card 019e98dc-b732-7eb0-8c59-3cfbae9ac82d via --task and appears in `legion pr list`.

## Not done

- The `pk_in_query` extraction dedups the three `get_rows` SQL builds as a side effect, but this is scoped to `get_rows` only -- it is NOT the broader plugin<->wasm adapter dedup tracked by #222 (which targets generate_batch_sql/rows_to_maps and other bodies).
- `get_row_metadata`'s existing inline empty-PK guard is left as-is (it already guards correctly); this PR only brings `get_rows` to parity, it does not re-route metadata through the new helper.
- No behavioral change for a non-empty primary key: `pk_in_query` emits the identical SQL the three adapters built before (pinned by `pk_in_query_builds_select_for_valid_pk`).

Closes #198