### PR TITLE
fix(#180): error on non-UTF-8 text in get_json_value instead of folding to NULL

### DIFF
--- a/crates/smugglr-core/src/local.rs
+++ b/crates/smugglr-core/src/local.rs
@@ -350,25 +350,33 @@ fn upsert_rows_inner(
     Ok(count)
 }
 
-/// Helper to convert row value to JSON
+/// Convert a row value to JSON by its SQLite storage class.
+///
+/// Inspecting the `ValueRef` once distinguishes a genuine SQL NULL (-> JSON
+/// null) from a value that fails to decode. Previously every branch was a
+/// `get::<T>` whose `Err` was discarded, so a TEXT column holding non-UTF-8
+/// bytes fell through all four and was returned as NULL -- folding into the
+/// content hash indistinguishably from a real NULL (a stable-but-wrong hash,
+/// silent divergence). Such a value now surfaces a conversion error instead of
+/// being silently swallowed. (#180)
+///
+/// Behavior is otherwise unchanged: Integer/Real become JSON numbers, valid
+/// UTF-8 Text becomes a JSON string, Blob becomes lowercase hex (the rowhash
+/// wire contract) -- identical to the previous typed reads.
 fn get_json_value(row: &Row, idx: usize) -> Result<JsonValue> {
-    // Try in order: NULL, integer, real, text, blob
-    if let Ok(v) = row.get::<_, Option<i64>>(idx) {
-        return Ok(v.map(JsonValue::from).unwrap_or(JsonValue::Null));
+    use rusqlite::types::{Type, ValueRef};
+    match row.get_ref(idx)? {
+        ValueRef::Null => Ok(JsonValue::Null),
+        ValueRef::Integer(i) => Ok(JsonValue::from(i)),
+        ValueRef::Real(f) => Ok(JsonValue::from(f)),
+        ValueRef::Text(bytes) => match std::str::from_utf8(bytes) {
+            Ok(s) => Ok(JsonValue::from(s.to_string())),
+            Err(e) => {
+                Err(rusqlite::Error::FromSqlConversionFailure(idx, Type::Text, Box::new(e)).into())
+            }
+        },
+        ValueRef::Blob(b) => Ok(JsonValue::String(hex::encode(b))),
     }
-    if let Ok(v) = row.get::<_, Option<f64>>(idx) {
-        return Ok(v.map(JsonValue::from).unwrap_or(JsonValue::Null));
-    }
-    if let Ok(v) = row.get::<_, Option<String>>(idx) {
-        return Ok(v.map(JsonValue::from).unwrap_or(JsonValue::Null));
-    }
-    if let Ok(v) = row.get::<_, Option<Vec<u8>>>(idx) {
-        // Encode blobs as hex
-        return Ok(v
-            .map(|b| JsonValue::String(hex::encode(b)))
-            .unwrap_or(JsonValue::Null));
-    }
-    Ok(JsonValue::Null)
 }
 
 /// Wrapper to allow JSON values as SQL parameters
@@ -394,5 +402,72 @@ impl rusqlite::ToSql for JsonToSql {
                 Ok(ToSqlOutput::Owned(Value::Text(self.0.to_string())))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn one_row_conn(value_sql: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            "CREATE TABLE t (v); INSERT INTO t VALUES ({});",
+            value_sql
+        ))
+        .unwrap();
+        conn
+    }
+
+    fn get_col0(conn: &Connection) -> Result<JsonValue> {
+        let mut stmt = conn.prepare("SELECT v FROM t").unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        let row = rows.next().unwrap().unwrap();
+        get_json_value(row, 0)
+    }
+
+    #[test]
+    fn get_json_value_errors_on_non_utf8_text() {
+        // Regression for #180: a TEXT column holding non-UTF-8 bytes (a lone 0xFF
+        // cast to TEXT) previously fell through every typed read and was returned
+        // as NULL -- hashing identically to a real NULL. It must now surface an
+        // error instead of being silently swallowed.
+        let conn = one_row_conn("CAST(x'ff' AS TEXT)");
+        assert!(
+            get_col0(&conn).is_err(),
+            "non-UTF-8 text must error, not fold to NULL"
+        );
+    }
+
+    #[test]
+    fn get_json_value_null_stays_null() {
+        // The other side of the distinction: a genuine SQL NULL is still Ok(Null),
+        // not an error -- the fix does not conflate empty with unreadable.
+        let conn = one_row_conn("NULL");
+        assert_eq!(get_col0(&conn).unwrap(), JsonValue::Null);
+    }
+
+    #[test]
+    fn get_json_value_preserves_normal_types() {
+        // Behavior preservation: int/real/text/blob render exactly as the prior
+        // typed reads did, so content hashes are unchanged.
+        assert_eq!(
+            get_col0(&one_row_conn("42")).unwrap(),
+            JsonValue::from(42i64)
+        );
+        assert_eq!(
+            get_col0(&one_row_conn("2.5")).unwrap(),
+            JsonValue::from(2.5f64)
+        );
+        assert_eq!(
+            get_col0(&one_row_conn("'hello'")).unwrap(),
+            JsonValue::from("hello")
+        );
+        // Blob x'01ff' hashes as lowercase hex "01ff".
+        assert_eq!(
+            get_col0(&one_row_conn("x'01ff'")).unwrap(),
+            JsonValue::from("01ff")
+        );
     }
 }


### PR DESCRIPTION
## Summary

`get_json_value` (the native rusqlite -> JSON converter that feeds the content hash) tried `Option<i64>`, `Option<f64>`, `Option<String>`, `Option<Vec<u8>>` in turn, discarding each read's `Err`, then returned `Ok(JsonValue::Null)`. A TEXT column holding non-UTF-8 bytes fails the `String` read (invalid UTF-8) and is not a blob, so it fell through to NULL -- folding into the content hash indistinguishably from a real SQL NULL. The result is a stable-but-wrong hash (silent divergence) instead of a surfaced error. This PR makes the converter inspect the value's storage class once and error on the truly-undecodable case.

## Acceptance criteria mapping

### 1. All tests pass (including a regression test that fails before the fix)
`get_json_value` now does `match row.get_ref(idx)?` on the `ValueRef`: `Null` -> JSON null, `Integer`/`Real` -> JSON number, valid-UTF-8 `Text` -> JSON string, `Blob` -> lowercase hex, and a `Text` value that is not valid UTF-8 -> `Err(FromSqlConversionFailure)` (into `SyncError::LocalDb`) rather than being swallowed. That error propagates through `get_row_metadata_inner` (local.rs:203 uses `?`). Regression test `get_json_value_errors_on_non_utf8_text` inserts a lone `0xFF` byte via `CAST(x'ff' AS TEXT)` and asserts the read is an error; I confirmed it genuinely fails-before by reverting only that arm to `Ok(JsonValue::Null)` (the old swallow) and watching the test FAIL, then restored. `get_json_value_null_stays_null` and `get_json_value_preserves_normal_types` pin the other side (NULL is still Ok(Null); int/real/text/blob render exactly as before). Full core suite passes bar the 5 pre-existing multicast socket-bind flakes; wasm32 still builds (local.rs is native-gated); fmt + clippy clean.
Evidence: tests crates/smugglr-core/src/local.rs::tests::get_json_value_errors_on_non_utf8_text (empirically fails on the reverted arm), get_json_value_null_stays_null, get_json_value_preserves_normal_types.

### 2. Simplify pass completed
`/legion-simplify` recorded clean on this HEAD (1 file entry, 0 findings), articulating that the rewrite removes the error-swallowing chain, preserves the JSON mapping for every normal storage class (so content hashes are unchanged), and changes behavior only for the non-UTF-8 text case.
Evidence: legion-simplify gate for HEAD a80d387 (019f5d15-f696-71f0-a578-bdc7acad2bee).

### 3. Review pass completed and issues fixed
An independent `/legion-review` runs against the open PR and must record a clean gate on this HEAD; any findings will be fixed and re-verified before merge. This entry is satisfied when that gate is clean.
Evidence: the legion-review quality-gate row recorded for HEAD a80d387 on the PR.

### 4. PR created and linked to this issue
The PR is opened via `legion pr create --task <card-id>`, which stores the PR URL on the kanban card and establishes the card<->PR link the verify gate reads; the body's `Closes #180` trailer makes a merge to the default branch auto-close the issue, keeping GitHub and the kanban board consistent.
Evidence: PR body contains "Closes #180"; the PR is linked to card 019e98dc-b745-7690-96a3-a5b0e6e1852d via --task and appears in `legion pr list`.

## Not done

- Behavior for a non-UTF-8 text value is to ERROR (per the issue's "error on the truly-unexpected case"), not to coerce it to hex or lossy-decode it. A TEXT column with non-UTF-8 bytes cannot round-trip through the JSON-based remote/wasm paths anyway, so erroring is the honest surface.
- No change to the content-hash byte format: every normal storage class maps to the identical `JsonValue` the prior typed reads produced, so existing synced data re-hashes to the same value (no migration).
- Native path only. The plugin and wasm adapters build their row maps from parsed JSON (always valid UTF-8), so `get_json_value` and this defect are exclusive to `local.rs`.

Closes #180