### PR TITLE
fix(#241): order float-serialized timestamps numerically in compare_ts

### DIFF
--- a/crates/smugglr-core/src/diff.rs
+++ b/crates/smugglr-core/src/diff.rs
@@ -10,20 +10,28 @@ use tracing::{debug, info, warn};
 
 /// Order two `updated_at` timestamps for conflict resolution.
 ///
-/// Integer Unix timestamps render as decimal strings ("999", "1000"); comparing
-/// those lexicographically is wrong across a digit-count boundary ("999" sorts
-/// after "1000"), so parse and compare numerically when BOTH sides are integers.
-/// ISO-8601 text timestamps are fixed-width, where lexical order == chronological,
-/// so fall back to string comparison when NEITHER side is an integer. A mixed
-/// pair (one integer, one non-integer) has no meaningful ordering -- return
-/// `None` so the caller routes it to `content_differs` rather than inventing a
-/// confident (and likely wrong) winner from a lexical compare of unlike
-/// representations.
+/// Timestamps arrive as strings in three shapes: integer Unix time ("999",
+/// "1000"), float Unix time ("2.5", "10.5" -- a REAL column rendered through
+/// `f64::to_string` by `extract_updated_at`), and fixed-width ISO-8601 text.
+/// Comparing any numeric form lexically is wrong across a digit-count boundary
+/// ("1000" sorts before "999"; "10.5" before "2.5"), so parse numerically
+/// first: an exact `i64` compare when BOTH sides are integers (preserving
+/// precision for large millisecond/nanosecond timestamps that `f64` would
+/// round), else an `f64` compare when BOTH sides parse as floats (covering
+/// float/float and integer/float pairs). ISO-8601 text is fixed-width, so
+/// lexical order == chronological -- fall back to string comparison when
+/// NEITHER side is numeric. A numeric-vs-text pair (integer or float on one
+/// side, ISO on the other) has no meaningful ordering -- return `None` so the
+/// caller routes it to `content_differs` rather than inventing a confident
+/// winner from a lexical compare of unlike representations.
 fn compare_ts(a: &str, b: &str) -> Option<Ordering> {
     match (a.parse::<i64>(), b.parse::<i64>()) {
         (Ok(x), Ok(y)) => Some(x.cmp(&y)),
-        (Err(_), Err(_)) => Some(a.cmp(b)),
-        _ => None,
+        _ => match (a.parse::<f64>(), b.parse::<f64>()) {
+            (Ok(x), Ok(y)) => x.partial_cmp(&y),
+            (Err(_), Err(_)) => Some(a.cmp(b)),
+            _ => None,
+        },
     }
 }
 
@@ -226,7 +234,7 @@ pub fn classify_diff(
             (Some(local_ts), Some(remote_ts)) => match compare_ts(local_ts, remote_ts) {
                 Some(Ordering::Greater) => diff.local_newer.push((*pk).clone()),
                 Some(Ordering::Less) => diff.remote_newer.push((*pk).clone()),
-                // Equal timestamps or unlike representations (one integer, one
+                // Equal timestamps or unlike representations (one numeric, one
                 // text): no safe tiebreaker, so treat as a content conflict.
                 Some(Ordering::Equal) | None => diff.content_differs.push((*pk).clone()),
             },
@@ -454,5 +462,43 @@ mod tests {
         let remote = one("B", Some("1700000000"));
         let diff = classify_diff(&local, &remote, "t");
         assert_eq!(diff.content_differs, vec!["r".to_string()]);
+    }
+
+    // --- Float-serialized timestamps (#241) ---
+
+    // A REAL/float timestamp column renders through f64::to_string ("2.5",
+    // "10.5"). Pre-fix compare_ts fell straight to lexical for any non-i64 pair,
+    // so "10.5" sorted BEFORE "2.5" (byte '1' < '2') -- the reverse of the true
+    // chronological order. Pin the numeric ordering directly.
+    #[test]
+    fn compare_ts_orders_float_timestamps_numerically() {
+        assert_eq!(compare_ts("2.5", "10.5"), Some(Ordering::Less));
+        assert_eq!(compare_ts("10.5", "2.5"), Some(Ordering::Greater));
+        assert_eq!(compare_ts("2.5", "2.5"), Some(Ordering::Equal));
+    }
+
+    // Schema skew: one row's column reads as INTEGER, the other as REAL for the
+    // same logical timestamp. Both are numeric, so they compare numerically
+    // (this pair returned None pre-fix -- now an honest ordering, not a conflict).
+    #[test]
+    fn compare_ts_orders_integer_against_float_numerically() {
+        assert_eq!(compare_ts("1000", "1000.5"), Some(Ordering::Less));
+        assert_eq!(compare_ts("1001", "1000.5"), Some(Ordering::Greater));
+    }
+
+    // classify_diff over float timestamps: the larger float is newer and must be
+    // classified by direction (and actually sync), not dropped to content_differs.
+    // Pre-fix the lexical compare put the newer "10.5" row in remote_newer.
+    #[test]
+    fn float_timestamp_newer_row_syncs_not_skipped() {
+        let local = one("A", Some("10.5")); // newer
+        let remote = one("B", Some("2.5")); // older
+        let diff = classify_diff(&local, &remote, "t");
+        assert_eq!(diff.local_newer, vec!["r".to_string()]);
+        assert!(diff.remote_newer.is_empty());
+        assert!(diff.content_differs.is_empty());
+        assert!(diff
+            .rows_to_push(ConflictResolution::NewerWins)
+            .contains(&"r".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

`compare_ts` ordered numeric timestamps correctly only when BOTH operands parsed as `i64`;
every other pair fell through to a lexical string compare. But `extract_updated_at` renders a
JSON `Number` float via `f64::to_string` (a REAL timestamp column becomes e.g. `"2.5"`), so a
float-serialized timestamp reached `compare_ts` as a non-integer string and was ordered
lexically -- `"10.5"` sorts before `"2.5"` on the leading byte, the reverse of chronological
order. This PR inserts an `f64` tier between the exact-`i64` path and the ISO-8601 lexical
fallback, so any numeric timestamp compares numerically while integer and ISO behavior are
unchanged.

## Acceptance criteria mapping

### 1. compare_ts orders numeric timestamps correctly whether integer- or float-serialized
The match now has three tiers (diff.rs `compare_ts`, lines 27-33): both-`i64` keeps the exact
integer compare; otherwise it parses both sides as `f64` and compares with `partial_cmp`; only
when neither side is numeric does it fall back to lexical. So a float pair (`"2.5"`, `"10.5"`)
reaches the f64 arm and orders by value. The i64 fast path is retained deliberately -- large
millisecond/nanosecond Unix timestamps exceed f64's exact-integer range (2^53), and comparing
those as i64 avoids the rounding an f64 compare would introduce.
Evidence: `compare_ts_orders_float_timestamps_numerically` asserts `compare_ts("2.5","10.5") == Some(Less)` and the reverse.

### 2. Regression test pinning compare_ts("2.5","10.5") and a float classify_diff case
Two tests cover this. `compare_ts_orders_float_timestamps_numerically` pins the direct call
(Less / Greater / Equal). `float_timestamp_newer_row_syncs_not_skipped` drives it through
`classify_diff`: a `"10.5"` local row vs `"2.5"` remote lands in `local_newer` (and is pushed
under newer_wins), not dropped to `content_differs`. Both were run against the pre-fix body and
fail there (the direct test returns `Some(Greater)`; the classify test files the newer row under
`remote_newer`), proving they catch the bug.
Evidence: tests `diff::tests::compare_ts_orders_float_timestamps_numerically`, `diff::tests::float_timestamp_newer_row_syncs_not_skipped`.

### 3. No change to integer or ISO-8601 behavior
Integer-vs-integer pairs still hit the first arm `(Ok(x), Ok(y)) => Some(x.cmp(&y))` unchanged;
ISO-vs-ISO pairs fail both i64 and f64 parses and hit `(Err(_), Err(_)) => Some(a.cmp(b))`, the
same lexical compare as before; a numeric-vs-ISO pair still returns `None`. The pre-existing
tests (`integer_timestamp_*`, `iso8601_timestamps_still_compare_lexically`,
`mixed_timestamp_representation_is_content_differs`, `equal_integer_timestamps_are_content_differs`)
all still pass unchanged.
Evidence: full `diff::tests` module is green (12 passed); the four named integer/ISO tests are unmodified.

### 4. simplify + review; PR linked
Simplify gate recorded clean on HEAD (one file entry, `diff.rs`). This body is the pr-write
gate. Review runs after the PR opens. The PR links issue #241 via the title and `--task`.
Evidence: simplify gate id 019f61b4-8a80-7363-91bd-3cf0abac5bd9.

## Not done

One intentional semantic change beyond "fix floats," surfaced so review does not have to catch
it: an **integer-vs-float** pair (e.g. `"1000"` vs `"1000.5"`, reachable via schema skew where
one row's column reads INTEGER and the other REAL) previously returned `None -> content_differs`
and now compares numerically (`1000 < 1000.5`). This is an improvement -- both operands are
genuine numeric timestamps, so an honest ordering beats a manufactured conflict, and it avoids
the ugly asymmetry where `"1000"` vs `"1000.5"` would be incomparable while `"1000.0"` vs
`"1000.5"` compares. Integer-vs-*integer* is untouched (criterion 3). Pinned intentional by
`compare_ts_orders_integer_against_float_numerically`. No defensive NaN/inf rejection was added:
JSON numbers cannot be NaN/inf, and a pathological `"NaN"` string parses to `partial_cmp -> None`,
which routes safely to `content_differs`.