### PR TITLE
chore(#155): gate clippy on the wasm32 target in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
+      # smugglr-wasm is #![cfg(target_arch = "wasm32")], so the host clippy run
+      # above compiles it to nothing -- its lints never gate. Run clippy against
+      # the wasm32 target explicitly so wasm-only lints are caught (#155).
+      - name: Clippy (wasm32)
+        run: cargo clippy -p smugglr-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
 
   shellcheck:
     name: ShellCheck


### PR DESCRIPTION
## Summary

CI's Clippy job ran `cargo clippy --all-targets -- -D warnings` only on the host default
target. `smugglr-wasm` is `#![cfg(target_arch = "wasm32")]`, so on the host it compiles to
nothing and its lints never gated -- which is how ~10 `needless_borrow` lints accumulated in
`lib.rs` unnoticed (the finding that opened this issue). This PR adds the
`wasm32-unknown-unknown` target to the Clippy job and a second step that runs clippy against
that target, so wasm-only lints gate on every PR going forward. The lints themselves were
already cleared by the wasm audit, so this is a CI-gating change with no source edit.

## Acceptance criteria mapping

### 1. wasm32 clippy -D warnings clean
The wasm crate already passes `cargo clippy -p smugglr-wasm --target wasm32-unknown-unknown
-- -D warnings` with no warnings -- the borrow lints named in the issue were cleared by the
earlier wasm audit (#237). I verified locally in both the plain form and the `--all-targets`
form the new CI step uses; both finish clean. This PR does not need to edit `lib.rs` because
there is nothing left to fix; it exists to keep the target clean.
Evidence: local `cargo clippy -p smugglr-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings` finishes with no warnings; the same command runs green in CI on this PR (Clippy job).

### 2. CI gates wasm-target clippy
The Clippy job's toolchain now installs `wasm32-unknown-unknown` (ci.yml:40), and a new
`Clippy (wasm32)` step (ci.yml:42-47) runs `cargo clippy -p smugglr-wasm --target
wasm32-unknown-unknown --all-targets -- -D warnings`. Because `-D warnings` promotes lints to
errors, any future wasm-only lint fails the Clippy job and blocks the PR. It is folded into
the existing Clippy job (reusing its toolchain + Swatinem cache) rather than a separate job.
Evidence: ci.yml diff -- the `Clippy (wasm32)` step; the job runs and passes on this PR.

### 3. simplify + review passes, issues fixed
Simplify gate recorded clean on HEAD (one file entry, ci.yml, with located evidence). This
body is the pr-write gate. An independent legion-review pass runs after the PR opens. There
are no code issues to fix -- the change is CI-config only and the wasm target is already
lint-clean.
Evidence: simplify gate id 019f61bd-e685-7c60-81a0-019e20458186.

### 4. PR linked to this issue
The PR title carries `(#155)` and it is linked to the card via `legion pr create --task`,
which records the card<->PR link.
Evidence: `legion pr create --task 019e843d-f5aa-7020-866e-028a59e65dfb` (this card).

## Not done

No source change. The issue's original symptom (needless-borrow lints in lib.rs) was already
resolved by the wasm audit before this PR, so the only remaining work was the CI gate. I did
not restructure the Clippy job into a wasm-specific matrix or add wasm clippy to the release
workflow -- out of scope; the single added step on the existing job is sufficient to gate the
target. I used `--all-targets` (beyond the issue's literal command) so the wasm crate's test
code is linted too, consistent with the host clippy step; verified clean locally.