### PR TITLE
refactor(#214): drop the unreachable column_glob_match arm

### DIFF
--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -181,8 +181,10 @@ fn column_glob_match(pattern: &str, value: &str) -> bool {
             // Exact match: "vector"
             pattern == value
         }
-        (true, true) if pattern.len() >= 2 => {
-            // Contains: "*embed*"
+        (true, true) => {
+            // Contains: "*embed*". The pattern == "*" case is intercepted
+            // above, so every pattern reaching here has len() >= 2 and the
+            // slice below never panics.
             let inner = &pattern[1..pattern.len() - 1];
             value.contains(inner)
         }
@@ -194,7 +196,6 @@ fn column_glob_match(pattern: &str, value: &str) -> bool {
             // Prefix: "embedding_*"
             value.starts_with(&pattern[..pattern.len() - 1])
         }
-        _ => false,
     }
 }
 
@@ -1020,6 +1021,39 @@ local_db = "game.db"
         assert!(column_excluded("blob_data", &patterns));
         assert!(!column_excluded("name", &patterns));
         assert!(!column_excluded("id", &patterns));
+    }
+
+    // Pins column_glob_match's behavior across the (starts_star, ends_star)
+    // boundary cases -- in particular the bare "*" short-circuit and the
+    // (true, true) "contains" arm, whose now-unreachable length guard and
+    // dead fallback arm were removed as part of #214. This is a
+    // behavior-preservation pin, not a fails-before-the-fix regression test:
+    // the removed guard and arm were provably unreachable, so there is no
+    // prior state in which these assertions could have failed.
+    #[test]
+    fn test_column_glob_match_boundary_cases() {
+        // Bare "*" matches anything, including the empty string.
+        assert!(column_glob_match("*", "anything"));
+        assert!(column_glob_match("*", ""));
+
+        // Leading star: suffix match.
+        assert!(column_glob_match("*_embedding", "title_embedding"));
+        assert!(!column_glob_match("*_embedding", "embedding_title"));
+
+        // Trailing star: prefix match.
+        assert!(column_glob_match("embedding_*", "embedding_title"));
+        assert!(!column_glob_match("embedding_*", "title_embedding"));
+
+        // Both star (len >= 2): contains match, including the len == 2
+        // "**" case where inner is empty and matches everything.
+        assert!(column_glob_match("*embed*", "title_embedding"));
+        assert!(!column_glob_match("*embed*", "title_vector"));
+        assert!(column_glob_match("**", "anything"));
+        assert!(column_glob_match("**", ""));
+
+        // No star: exact match only.
+        assert!(column_glob_match("vector", "vector"));
+        assert!(!column_glob_match("vector", "vectors"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`column_glob_match` in `crates/smugglr-core/src/config.rs` matched on
`(starts_star, ends_star)` with a guard `(true, true) if pattern.len() >= 2`
(old config.rs:184) and a trailing `_ => false` (old config.rs:197) that
existed only to catch `(true, true)` with `len() < 2`. The only string that
both starts and ends with `*` and has `len() < 2` is `"*"` itself, which is
already returned `true` at the top of the function (old config.rs:172-174)
before the `match` is ever entered. So the guard could never fail for a value
that reaches that arm, and the `_ => false` fallback was unreachable dead
code. This PR drops the guard and the dead arm, leaving an exhaustive match
over the four `(bool, bool)` combinations. Behavior is unchanged.

## Acceptance criteria mapping

### All tests pass (including a regression test that fails before the fix)

Not applicable as literally stated, and the issue's own audit evidence says
so: this is a provably behavior-preserving removal of unreachable code, not
a bug fix. There is no prior input for which the old code and new code
produce different output, so no test can be written that fails on the old
code and passes on the new code -- writing one would require constructing a
call that reaches the `(true, true)` arm with `pattern.len() < 2`, and no
such call exists (the only candidate, `"*"`, is intercepted earlier in the
function). Instead, I added `test_column_glob_match_boundary_cases`, which
pins the function's observable behavior across every `(starts_star,
ends_star)` combination directly against `column_glob_match` (not just
through `column_excluded`): bare `"*"` matching anything including `""`,
leading-star suffix matching, trailing-star prefix matching, both-star
"contains" matching (including the `len == 2` `"**"` edge case where the
inner slice is empty and `contains("")` is `true`), and the plain
exact-match case. All existing tests plus this new one pass:
`cargo test -p smugglr-core --lib config` -- 40 passed, 0 failed. Also ran
`cargo clippy --all-targets -- -D warnings` (clean) and
`cargo fmt --all -- --check` (clean); clippy accepting the match without a
wildcard arm is itself confirmation that the four explicit arms are now
exhaustive.

### Simplify pass completed

Ran `/legion-simplify` against the diff and recorded a clean result via
`legion quality-gate check --skill legion-simplify --result clean
--findings-count 0 --articulation-file /tmp/simplify-214.md`. Gate id:
`019f61d3-f547-77f1-b9ef-48e8b990f3ae`. The articulation cites the exact
pre-change lines (`config.rs:184` guard, `config.rs:197` dead arm) and
explains why the guard was tautologically true and the wildcard arm
unreachable.

### Review pass completed and issues fixed

Not done in this run. Per the task scope for this pipeline stage, I stop at
PR creation; the review stage (`legion-review`) and any resulting fixes run
as the next step in the pipeline, after this PR is opened. I did not run
`legion verify` and did not mark the card done.

Evidence: no `legion-review` gate has been recorded for this card as of PR
creation -- this PR intentionally opens before that stage runs.

### PR created and linked to this issue

This PR is opened against issue #214 via `legion pr create --repo smugglr
--task 019e98dc-b727-77b1-b429-b393227af015`, which links it to the card and
issue.

Evidence: PR created from branch `refactor/214-column-glob-unreachable-arm`
with `--task 019e98dc-b727-77b1-b429-b393227af015`; the resulting PR number
and URL are reported once `legion pr create` returns.

## Not done

- Review pass (`legion-review`) has not been run; it is the next pipeline
  stage after this PR is opened, not part of this change.
- `legion verify` was not run and the card was not marked done, per the
  explicit scope of this task.
- No behavior change was made or attempted -- this is a pure dead-code
  removal, so there is nothing else in scope per the issue's "Out of Scope"
  note (no broader structural extraction).