### PR TITLE
refactor(#211): reuse the recv buffer across datagrams

### DIFF
--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -56,7 +56,10 @@ use tracing::{debug, warn};
 pub const DEFAULT_GROUP: Ipv4Addr = Ipv4Addr::new(239, 255, 43, 21);
 
 /// Receive buffer: the largest datagram we will accept (one full UDP payload).
-const RECV_BUF: usize = 65_536;
+///
+/// `pub` so callers of [`Gossip::recv_and_handle`] can size the reusable buffer
+/// they hoist out of their receive loop (see that method's doc comment).
+pub const RECV_BUF: usize = 65_536;
 
 /// Wire headroom reserved when chunking deltas for multicast: the `Msg` JSON
 /// wrapper (`{"version":N,"body":{"t":"Delta",...}}`, a fixed ~35 bytes) plus the
@@ -412,11 +415,20 @@ impl Gossip {
     /// This is the whole peer-symmetric loop body: a `Digest` we hear may make us
     /// send a `Want`; a `Want` we hear may make us send a `Delta`; a `Delta` we
     /// hear we apply idempotently.
-    pub async fn recv_and_handle(&self, local: &LocalDb, config: &Config) -> Result<GossipEvent> {
-        let mut buf = vec![0u8; RECV_BUF];
+    ///
+    /// `buf` is a scratch receive buffer owned by the caller, at least
+    /// [`RECV_BUF`] bytes -- callers running a receive loop should allocate it
+    /// once outside the loop and pass the same buffer on every call, so a
+    /// steady-state gossip listener does not allocate+zero 64 KiB per datagram.
+    pub async fn recv_and_handle(
+        &self,
+        buf: &mut [u8],
+        local: &LocalDb,
+        config: &Config,
+    ) -> Result<GossipEvent> {
         let (n, _addr) = self
             .socket
-            .recv_from(&mut buf)
+            .recv_from(buf)
             .await
             .map_err(|e| SyncError::Broadcast(format!("multicast recv: {e}")))?;
         let (event, out) = self.handle(&buf[..n], local, config).await?;
@@ -979,10 +991,11 @@ mod tests {
         let (a, a_cfg, a_local, b, b_cfg, b_local) = two_nodes(&a_path, &b_path).await;
 
         a.broadcast_digests(&a_local, &a_cfg).await.unwrap();
+        let mut recv_buf = vec![0u8; RECV_BUF];
         loop {
             let ev = tokio::time::timeout(
                 std::time::Duration::from_secs(5),
-                b.recv_and_handle(&b_local, &b_cfg),
+                b.recv_and_handle(&mut recv_buf, &b_local, &b_cfg),
             )
             .await
             .expect("multicast recv timed out")

--- a/crates/smugglr/src/broadcast.rs
+++ b/crates/smugglr/src/broadcast.rs
@@ -14,7 +14,7 @@ use smugglr_core::broadcast::{broadcast_pid_lock_path, BroadcastConfig};
 use smugglr_core::config::Config;
 use smugglr_core::daemon::PidLock;
 use smugglr_core::error::Result;
-use smugglr_core::multicast::{Gossip, GossipEvent, DEFAULT_GROUP};
+use smugglr_core::multicast::{Gossip, GossipEvent, DEFAULT_GROUP, RECV_BUF};
 use smugglr_core::LocalDb;
 use std::sync::Arc;
 use std::time::Duration;
@@ -76,8 +76,13 @@ pub async fn run_broadcast(
         let local = local.clone();
         let config = config.clone();
         tokio::spawn(async move {
+            // Allocated once, reused across every datagram: `recv_and_handle`
+            // previously allocated+zeroed a fresh RECV_BUF-sized (64 KiB) buffer
+            // per call, which churned the allocator on every packet in this
+            // steady-state gossip loop.
+            let mut recv_buf = vec![0u8; RECV_BUF];
             loop {
-                match gossip.recv_and_handle(&local, &config).await {
+                match gossip.recv_and_handle(&mut recv_buf, &local, &config).await {
                     Ok(GossipEvent::Applied { table, rows }) if rows > 0 => {
                         info!("Applied {} row(s) to '{}'", rows, table)
                     }


### PR DESCRIPTION
## Summary

`Gossip::recv_and_handle` (`crates/smugglr-core/src/multicast.rs`) allocated a
fresh `vec![0u8; RECV_BUF]` (64 KiB) on every call -- once per received
datagram. The CLI's steady-state gossip listener (`crates/smugglr/src/broadcast.rs`,
the `tokio::spawn` loop around line 80) calls this in an unbounded loop, so
every inbound packet churned a 64 KiB heap allocation+zero. This PR hoists
that allocation out of the per-call path: `recv_and_handle` now takes the
receive buffer as a `&mut [u8]` parameter, and each caller allocates it once
before its loop and reuses it across iterations.

## Acceptance criteria mapping

### 1. All tests pass (including a regression test that fails before the fix)

This criterion's second clause is N/A here: this is a behavior-preserving
performance refactor (hoisting an allocation), not a defect fix, so there is
no incorrect behavior to reproduce with a failing test -- the pre-change code
was functionally correct, only allocation-heavy. No fabricated
"fails-before" test was written to check the box.

What was verified instead: the existing multicast protocol/round-trip tests
in `crates/smugglr-core/src/multicast.rs` continue to exercise
`recv_and_handle` unchanged in behavior, updated only for the new signature.
`live_multicast_digest_delivers` (multicast.rs, near line 991) now allocates
its own reusable `recv_buf` once before its polling loop and passes `&mut
recv_buf` on each call, mirroring the production caller exactly.

Evidence: `cargo test -p smugglr-core -- --skip multicast` -- 214 passed, 0
failed. `cargo test -p smugglr-core multicast -- --test-threads=1` -- 3
passed (`multicast::tests::msg_tag_roundtrip`,
`multicast::tests::split_digest_chunks_large_maps`,
`multicast::tests::want_set_lacks_and_differs`), 5 failed, 1 ignored. All 5
failures are the pre-existing `Broadcast("bind: Address already in use (os
error 48)")` panic at `multicast.rs:781:50` -- a UDP-port-bind flake on this
machine (multiple tests in the suite bind the same fixed multicast port and
collide when run in the same process), unrelated to this change and called
out as a known issue in the task brief. `cargo build -p smugglr` succeeds.
`cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --all --
--check` clean.

### 2. Simplify pass completed

Evidence: `legion quality-gate check --skill legion-simplify --result clean
--findings-count 0 --articulation-file /tmp/simplify-211.md` accepted, gate
id `019f61d7-a781-71f2-b87d-0b1dff3891ca` (recorded against HEAD `902f09c7`).
The articulation covers both
changed files (`multicast.rs`, `broadcast.rs`) with per-file prose on why no
duplicate logic, dead code, or unnecessary abstraction was introduced -- the
change is a signature widening plus one hoisted allocation at each of the two
call sites, confirmed exhaustive via `legion sym refs recv_and_handle`
(returns exactly `broadcast.rs:80` and `multicast.rs:991`).

### 3. Review pass completed and issues fixed

Pending as of this PR body -- pipeline order is simplify -> pr-write ->
review -> verify, and this PR is being opened specifically so the review step
can run against a real open PR next, per that ordering. Not claimed complete;
tracked in "Not done" below rather than hidden.

Evidence: no `legion-review` quality-gate record exists for this branch yet
(only the `legion-simplify` gate, id `019f61d7-a781-71f2-b87d-0b1dff3891ca`,
has been recorded so far) -- `/legion-review` is the next step after this PR
opens, and the review pass's own findings/fixes and gate id will supersede
this entry once it runs.

### 4. PR created and linked to this issue

This criterion is satisfied by the act of opening this PR against issue #211:
the PR body and title reference issue #211 directly, and `legion pr create`
is invoked with `--task 019e98dc-b72b-7572-a8db-1541fa1a410b`, the kanban
card bound to this issue, so the PR is linked both to the GitHub issue and to
the legion card tracking it.

Evidence: PR opened from branch `refactor/211-reuse-recv-buffer` against
issue #211, via `legion pr create --repo smugglr --title "refactor(#211):
reuse the recv buffer across datagrams" --task
019e98dc-b72b-7572-a8db-1541fa1a410b`.

## Not done

- `/legion-review` has not run yet -- next step after this PR opens, per
  pipeline order (simplify -> pr-write -> review -> verify).
- No fails-before regression test was added; criterion 1 above explains why
  it does not apply to a behavior-preserving perf hoist.
- Buffer size was deliberately left at `RECV_BUF` (65,536) rather than
  shrunk to `SAFE_PACKET_SIZE`, and `Gossip::handle`'s protocol logic was not
  touched -- both are out of scope for this issue; see below.

## What changed

- `crates/smugglr-core/src/multicast.rs`: `RECV_BUF` widened from a private
  `const` to `pub const` (line 59) so callers can size their reused buffer
  correctly without duplicating the magic number. `recv_and_handle` signature
  changed from `(&self, local: &LocalDb, config: &Config)` to `(&self, buf:
  &mut [u8], local: &LocalDb, config: &Config)` (line 425); the internal `let
  mut buf = vec![0u8; RECV_BUF]` allocation was removed, and
  `self.socket.recv_from(buf)` now writes into the caller-supplied slice. The
  `handle()` call and `self.emit(out).await?` tail are unchanged. A doc
  comment states the size invariant (>= `RECV_BUF`) and the reuse rationale.
  `live_multicast_digest_delivers` (line ~991), the only other call site,
  now allocates `recv_buf` once before its polling loop and passes `&mut
  recv_buf`.
- `crates/smugglr/src/broadcast.rs`: imports `RECV_BUF` (line 17) alongside
  the existing `Gossip`/`GossipEvent`/`DEFAULT_GROUP` imports. Inside the
  `tokio::spawn(async move { ... })` block running the continuous gossip
  listener, `let mut recv_buf = vec![0u8; RECV_BUF];` is now allocated once
  immediately before the `loop {}` (line ~80), and each iteration calls
  `gossip.recv_and_handle(&mut recv_buf, &local, &config).await` instead of
  the old two-argument call. This is the hot-loop call site named in the
  issue.

## Behavior preservation

Datagram handling and bounds are identical: `recv_from` still writes at most
`buf.len()` bytes (still exactly `RECV_BUF` = 65,536 at both call sites, so
no truncation-behavior change for any datagram size), `n` is still the
actual byte count returned by the kernel, and `handle()` still sees
`&buf[..n]` -- the same slice content as before. The only observable
difference is that the buffer's backing allocation now happens once per
receive loop instead of once per datagram; no wire behavior, no truncation,
no error path changed.

## What I deliberately did not do

- Did not shrink the buffer below `RECV_BUF` (e.g. to `SAFE_PACKET_SIZE` =
  1400). The issue's verified-evidence section notes a smaller buffer would
  only change truncation behavior for oversized foreign datagrams that
  already fail AEAD and get dropped as `Ignored` -- but changing the
  truncation boundary at all is a behavior change outside a "reuse the
  allocation" perf fix, and the issue explicitly scopes this to
  hoisting/reuse, not resizing.
- Did not touch `Gossip::handle` or the `on_digest`/`on_want`/`on_delta`
  protocol logic -- out of scope per the issue ("Fix only the defect
  described here").
- Did not add a `RecvBuffer` newtype/wrapper to encapsulate the size
  invariant; a bare `&mut [u8]` with a documented invariant matches the
  existing idiom in this codebase and the stdlib (`Read::read`), and a new
  type for one documented invariant would be the kind of unnecessary
  abstraction the simplify pass checks for.