### PR TITLE
refactor(#219): hoist cached_table_info into adapter_common

### DIFF
--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -6,7 +6,10 @@
 //! and are called from both adapters as `adapter_common::<fn>`.
 
 use smugglr_core::datasource::{extract_updated_at, ColumnInfo, RowMeta, TableInfo};
+use smugglr_core::error::Result;
 use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Mutex;
 
 use serde_json::Value;
 
@@ -147,6 +150,37 @@ pub(crate) fn incremental_metadata_sql(
         table,
         timestamp_column
     )
+}
+
+/// Look up `table` in `cache`, computing and memoizing it via `fetch` on a
+/// miss.
+///
+/// Shared by both adapters' `cached_table_info` inherent methods, which
+/// differ only in how they obtain a fresh [`TableInfo`] on a cache miss
+/// (`self.table_info(table)`, a `DataSource` trait method both implement).
+/// `fetch` is passed as an already-constructed future rather than a closure:
+/// futures are lazy, so `self.table_info(table)` at the call site does no
+/// work until this function `.await`s it -- meaning the miss-only fetch
+/// semantics are identical to the pre-extraction inline code. The
+/// non-atomic check-then-insert (a benign duplicate-fetch race window) is
+/// preserved exactly, as is clone-on-hit / insert-then-clone-return on miss.
+pub(crate) async fn cached_table_info<F>(
+    cache: &Mutex<HashMap<String, TableInfo>>,
+    table: &str,
+    fetch: F,
+) -> Result<TableInfo>
+where
+    F: Future<Output = Result<TableInfo>>,
+{
+    if let Some(info) = cache.lock().unwrap().get(table) {
+        return Ok(info.clone());
+    }
+    let info = fetch.await?;
+    cache
+        .lock()
+        .unwrap()
+        .insert(table.to_string(), info.clone());
+    Ok(info)
 }
 
 /// Build an `INSERT OR REPLACE` batch statement plus its flattened params.

--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -229,15 +229,8 @@ impl FetchDataSource {
     }
 
     async fn cached_table_info(&self, table: &str) -> Result<TableInfo> {
-        if let Some(info) = self.table_info_cache.lock().unwrap().get(table) {
-            return Ok(info.clone());
-        }
-        let info = self.table_info(table).await?;
-        self.table_info_cache
-            .lock()
-            .unwrap()
-            .insert(table.to_string(), info.clone());
-        Ok(info)
+        adapter_common::cached_table_info(&self.table_info_cache, table, self.table_info(table))
+            .await
     }
 
     fn max_rows_per_batch(num_columns: usize, max_bind_params: usize) -> Option<usize> {

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -122,15 +122,8 @@ impl LocalSqlDataSource {
     }
 
     async fn cached_table_info(&self, table: &str) -> Result<TableInfo> {
-        if let Some(info) = self.table_info_cache.lock().unwrap().get(table) {
-            return Ok(info.clone());
-        }
-        let info = self.table_info(table).await?;
-        self.table_info_cache
-            .lock()
-            .unwrap()
-            .insert(table.to_string(), info.clone());
-        Ok(info)
+        adapter_common::cached_table_info(&self.table_info_cache, table, self.table_info(table))
+            .await
     }
 }
 


### PR DESCRIPTION
## Summary

`FetchDataSource::cached_table_info` (crates/smugglr-wasm/src/fetch_adapter.rs) and `LocalSqlDataSource::cached_table_info` (crates/smugglr-wasm/src/local_adapter.rs) were byte-identical: the same lock/get-or-insert pattern over an identically-typed `Mutex<HashMap<String, TableInfo>>` cache, differing only in the `self.table_info(table)` call -- a `DataSource` trait method both structs already implement independently.

Hoisted the shared logic into a new free function `adapter_common::cached_table_info(cache, table, fetch)` (crates/smugglr-wasm/src/adapter_common.rs:167-184). It takes the fetch as an already-constructed `impl Future<Output = Result<TableInfo>>` rather than a closure or async closure, since `table_info` is itself `async fn` on the `DataSource` trait -- passing `self.table_info(table)` unawaited works because Rust futures are lazy, so no work happens until `adapter_common::cached_table_info` awaits it on a cache miss.

Both adapters' inherent `cached_table_info` methods now reduce to one delegating line:
- `FetchDataSource::cached_table_info` (fetch_adapter.rs:231-234)
- `LocalSqlDataSource::cached_table_info` (local_adapter.rs:124-127)

Behavior-preserving: same non-atomic check-then-insert, same clone-on-hit / insert-then-return-on-miss, same lock scoping (guard dropped before the awaited fetch). No public API, trait contract, or caching semantics changed.

## Acceptance criteria mapping

### All tests pass (including a regression test that fails before the fix)

N/A for the regression-test half -- this is a pure behavior-preserving dedup of an inherent, non-trait, internally-called method (all six call sites are `self.cached_table_info(...)` inside the two adapter files; no external or dyn callers exist), so there is no observable defect to regress-test against. There is no pre-existing test exercising `cached_table_info`'s caching behavior specifically (the existing adapter tests cover batching limits, incremental-SQL predicate, and row-metadata shaping, not the cache itself), so none needed updating. Proof of correctness instead is the wasm32 compile/clippy/test triad below, which exercises the crate as a whole (including the extracted helper's own module) after the change.

Evidence: `cargo check -p smugglr-wasm --target wasm32-unknown-unknown` and `cargo clippy -p smugglr-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings` both exit 0; `wasm-pack test --node crates/smugglr-wasm` reports "test result: ok. 6 passed; 0 failed" (adapter_common::tests::incremental_metadata_sql_uses_inclusive_predicate, adapter_common::tests::row_maps_to_metadata_round_trips_integer_timestamp, adapter_common::tests::row_maps_to_metadata_skips_null_primary_key, local_adapter::tests::max_rows_per_batch_respects_variable_limit, local_adapter::tests::upsert_batching_keeps_each_statement_under_sqlite_var_limit, tests::boundary_tick_row_is_admitted_via_inclusive_incremental). Host `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` also exit 0 (smugglr-wasm is `#![cfg(target_arch = "wasm32")]`-gated so the host build excludes it, per issue #155).

### Simplify pass completed

Yes. The extraction is a like-for-like hoist: `adapter_common::cached_table_info` (adapter_common.rs:167-184) has exactly two call sites, `FetchDataSource::cached_table_info` (fetch_adapter.rs:231-234) and `LocalSqlDataSource::cached_table_info` (local_adapter.rs:124-127), each now a single delegating line replacing an 11-line inline lock/get/insert body. No premature generalization -- checked for a second check-then-insert cache pattern elsewhere in the crate and found none, so this stays a two-call-site helper matching the file's existing free-function style (`parse_table_info`, `rows_to_maps`, `row_maps_to_metadata`, `incremental_metadata_sql`, `generate_batch_sql`).

Evidence: `legion quality-gate check --skill legion-simplify --result clean --findings-count 0 --articulation-file /tmp/simplify-219.md` recorded a clean result with a 3-file articulation, gate id `019f61d6-b240-79a2-9ad6-94467d4675b6`.

### Review pass completed and issues fixed

Not run as part of this pass. The task governing this branch explicitly scopes this pipeline stage to build through PR creation only ("Do NOT merge, do NOT run `legion verify`, do NOT mark done"); code review is the next doctrine stage after this PR is opened, run independently against the diff on GitHub.

Evidence: task instructions for card `019e98dc-b725-72d2-aaf1-eec0f5dfccab`, step 5-9 (build/verify-locally -> simplify gate -> pr-write gate -> PR create), with review explicitly deferred to a later stage not covered by this run.

### PR created and linked to this issue

This PR is opened from branch `refactor/219-dedup-cached-table-info` against `main`, titled to reference #219, and created with `--task 019e98dc-b725-72d2-aaf1-eec0f5dfccab` so the card links back to it.

Evidence: `git log --oneline -1` on this branch shows commit 7e1ed22 "refactor(#219): hoist cached_table_info into adapter_common"; `legion pr create --repo smugglr --issue 219 --task 019e98dc-b725-72d2-aaf1-eec0f5dfccab` is the next command run after this gate passes.

## Not done

- Did not add a new regression test for `cached_table_info`'s cache-hit/cache-miss behavior. This is a pure dedup of identical code with no defect being fixed; adding a test would be testing the extraction mechanism itself, not a bug. wasm32 compile + clippy + full test-suite pass is the invariant proof (see first mapping entry above).
- Did not touch `FetchDataSource::max_rows_per_batch` (fetch_adapter.rs) or the module-level `max_rows_per_batch` (local_adapter.rs) even though they are structurally similar (both cap batch size against a bind-parameter limit) -- issue #219 explicitly scopes this fix to `cached_table_info` only; any further extraction is tracked separately per the issue's "Out of Scope" section.
- Did not change the non-atomic check-then-insert race window in the cache (two concurrent misses can both fetch and insert). This is pre-existing behavior on wasm32 (effectively single-threaded per the `unsafe impl Send/Sync for LocalSqlDataSource` comment in local_adapter.rs) and out of scope for a behavior-preserving refactor.

## What I deliberately did NOT do

- Did not add a new regression test for `cached_table_info`'s cache-hit/cache-miss behavior. This is a pure dedup of identical code with no defect being fixed; adding a test would be testing the extraction mechanism itself, not a bug. wasm32 compile + clippy + full test-suite pass is the invariant proof.
- Did not touch `max_rows_per_batch` (fetch_adapter.rs) or `max_rows_per_batch` (local_adapter.rs, module-level fn) even though they are structurally similar (both cap batch size against a bind-parameter limit) -- issue #219 explicitly scopes this fix to `cached_table_info` only; any further extraction is out of scope per the issue's "Out of Scope" section and tracked separately.
- Did not change the non-atomic check-then-insert race window in the cache (two concurrent misses can both fetch and insert). This is pre-existing behavior on wasm32 (effectively single-threaded per the `unsafe impl Send/Sync for LocalSqlDataSource` comment in local_adapter.rs) and out of scope for a behavior-preserving refactor.

## Test plan

- [x] `cargo check -p smugglr-wasm --target wasm32-unknown-unknown` -- clean
- [x] `cargo clippy -p smugglr-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings` -- clean
- [x] `cargo clippy --all-targets -- -D warnings` (host workspace) -- clean
- [x] `cargo fmt --all -- --check` -- clean
- [x] `wasm-pack test --node crates/smugglr-wasm` -- 6 passed, 0 failed