### PR TITLE
refactor(#216): one home for the no-primary-key skip warning

### DIFF
--- a/crates/smugglr-core/src/stash.rs
+++ b/crates/smugglr-core/src/stash.rs
@@ -326,13 +326,12 @@ async fn get_stash_tables(
             Ok(info) if !info.primary_key.is_empty() => {
                 syncable.push(table.clone());
             }
-            Ok(_) => {
-                warn!(
-                    "Skipping table '{}': no primary key (required for change detection)",
-                    table
-                );
-            }
-            Err(SyncError::NoPrimaryKey(_)) => {
+            // An `Ok` with an empty primary key and `Err(NoPrimaryKey)` are two
+            // encodings of the same "no PK" state (the former is exhaustiveness
+            // coverage for the `Result` match; `LocalDb::table_info` itself only
+            // ever returns `Err(NoPrimaryKey)` for a missing PK). Both route
+            // through one warn+skip so the message can't drift between them.
+            Ok(_) | Err(SyncError::NoPrimaryKey(_)) => {
                 warn!(
                     "Skipping table '{}': no primary key (required for change detection)",
                     table
@@ -1228,6 +1227,48 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].table, "items");
         assert_eq!(results[0].rows_pulled, 1); // only "beta" is new
+    }
+
+    // Invariant for #216: get_stash_tables must skip a table with no primary
+    // key and warn exactly once, no matter which of the two "no PK" shapes
+    // `table_info` reports it through (an `Ok(TableInfo)` with an empty
+    // `primary_key`, or `Err(SyncError::NoPrimaryKey)`). `LocalDb::table_info`
+    // only ever produces the `Err` shape (see `table_info_inner` in local.rs),
+    // so this pins the behavior for the live path; the `Ok(_)` arm exists
+    // purely for match exhaustiveness over other `DataSource` impls.
+    #[tokio::test]
+    async fn test_get_stash_tables_skips_table_without_primary_key() {
+        let dir = TempDir::new().unwrap();
+        let source_path = dir.path().join("source.sqlite");
+        let dest_path = dir.path().join("dest.sqlite");
+
+        // Source has one table with a primary key and one without.
+        let conn = Connection::open(&source_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, updated_at TEXT);
+             CREATE TABLE logs (message TEXT, updated_at TEXT);",
+        )
+        .unwrap();
+        drop(conn);
+
+        // Dest must have both tables too, or they would be skipped for a
+        // different reason ("exists only in source").
+        let conn = Connection::open(&dest_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, updated_at TEXT);
+             CREATE TABLE logs (message TEXT, updated_at TEXT);",
+        )
+        .unwrap();
+        drop(conn);
+
+        let source = LocalDb::open(&source_path).unwrap();
+        let dest = LocalDb::open(&dest_path).unwrap();
+
+        let tables = get_stash_tables(&source, &dest, None, &[]).await.unwrap();
+
+        // "logs" has no primary key and must be excluded; "items" is the only
+        // syncable table.
+        assert_eq!(tables, vec!["items".to_string()]);
     }
 
     // Regression for #185: a first upload (etag == None) must not blindly


### PR DESCRIPTION
## Summary

`get_stash_tables` in `crates/smugglr-core/src/stash.rs` had two match arms that
emitted the byte-identical `"Skipping table '{}': no primary key (required for
change detection)"` warning: the `Ok(_)` fallthrough (previously line 329) and a
separate `Err(SyncError::NoPrimaryKey(_))` arm (previously line 335). Both are two
encodings of the same "no PK" state, and the warning text was copy-pasted between
them. Collapsed both into a single arm via an or-pattern,
`Ok(_) | Err(SyncError::NoPrimaryKey(_)) =>`, now at stash.rs:329, so the
warn-and-skip behavior has exactly one home. The `Err(e) => propagate` arm is
untouched.

## Acceptance criteria mapping

### 1. All tests pass (including a regression test that fails before the fix)

"Fails before the fix" does not apply here: this is a behavior-preserving dedup,
not a bug fix, so there is no observable behavior for a "before" test to fail on.
I traced the concrete call path to confirm this rather than assume it:
`get_stash_tables` is always called with `source: &LocalDb`, and
`LocalDb::table_info` (crates/smugglr-core/src/local.rs:63-66, delegating to
`table_info_inner` at local.rs:118-151) only ever returns
`Err(SyncError::NoPrimaryKey(_))` for a missing primary key -- it never returns
`Ok(TableInfo)` with an empty `primary_key`. So the old `Ok(_)` arm was dead code
for every real caller. In place of a fails-before test, I added
`test_get_stash_tables_skips_table_without_primary_key`, which pins the
"no PK -> skip" invariant directly: a source/dest pair with one PK'd table
(`items`) and one PK-less table (`logs`) must yield `["items"]` from
`get_stash_tables`. I verified this test passes on both the pre-edit two-arm
code and the post-edit collapsed code (checked by temporarily reverting only the
match-arm collapse, running the test, then restoring the fix) -- exactly the
behavior a correct behavior-preserving refactor should produce: the invariant
holds unchanged across the edit, rather than flipping from red to green.
Evidence: `cargo test -p smugglr-core -- --skip multicast` -- 203 passed, 0
failed (multicast::tests skipped: pre-existing UDP-bind flake unrelated to this
change, confirmed by running it in isolation before this branch's edits).
`cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --all -- --check`
clean.

### 2. Simplify pass completed

Ran `/legion-simplify` scope over the diff: one function (`get_stash_tables`)
and one new test. The articulation traced both former arms to their origin in
`local.rs` and confirmed the retained `Ok(_)` half of the collapsed or-pattern
exists only for `Result` match exhaustiveness (guarding future `DataSource`
impls), not as live duplicated logic. No further duplication, unnecessary
abstraction, or stringly-typed state was found in the diff. Evidence:
`legion quality-gate check --skill legion-simplify --result clean
--findings-count 0` recorded gate id `019f61f3-2b1a-73d2-896d-64797a3a39ea`.

### 3. Review pass completed and issues fixed

Not done. This PR's scope, per the task driving this change, stops at
`legion pr create` -- the review stage (`legion-review` / `/review-pr`) and
`legion verify` are the next steps in the pipeline and were deliberately not
run here. Listed again under "Not done" below.
Evidence: no `legion-review` gate has been recorded for this branch -- this
mapping entry documents that absence rather than a completed step.

### 4. PR created and linked to this issue

This PR, opened against issue #216, with title referencing `#216` and card
`019e98dc-b725-72d2-aaf1-eeffa8516aa8` passed via `--task`.
Evidence: `legion pr create --repo smugglr --title
"refactor(#216): one home for the no-primary-key skip warning" --task
019e98dc-b725-72d2-aaf1-eeffa8516aa8`, run immediately after this gate
passes.

## Not done

- Review pass (`legion-review`) and `legion verify` were not run. They are the
  next stage of the pipeline after this PR is opened; explicitly out of scope
  for this task.
- No merge was performed.
- No issue other than #216 and no file other than
  `crates/smugglr-core/src/stash.rs` was touched.
- The broader "stringly/duplicated state wants one home" structural extraction
  the issue's verified evidence alludes to is out of scope per the issue's own
  "Out of Scope" section and was not attempted.