### PR TITLE
refactor(#225): collapse SDK param extractors and output from_sync_results

### DIFF
--- a/crates/smugglr-plugin-sdk/src/lib.rs
+++ b/crates/smugglr-plugin-sdk/src/lib.rs
@@ -30,6 +30,7 @@
 //! }
 //! ```
 
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -260,19 +261,20 @@ fn param_str_slice(params: &Value, key: &str) -> Result<Vec<String>, PluginError
         .collect()
 }
 
-fn param_rows(params: &mut Value) -> Result<Vec<HashMap<String, Value>>, PluginError> {
-    match params.get_mut("rows").map(Value::take) {
-        None => Err(PluginError::with_code("missing param: rows", -32602)),
+/// Take a JSON-RPC param by key and deserialize it into `T`, leaving `Value::Null`
+/// behind in `params` in its place (see [`Value::take`]).
+///
+/// Distinguishes "key absent" (missing param) from "key present but the wrong
+/// shape" (invalid param) so callers get an accurate error message instead of
+/// a misleading "missing" for malformed-but-present data.
+fn param_de<T: DeserializeOwned>(params: &mut Value, key: &str) -> Result<T, PluginError> {
+    match params.get_mut(key).map(Value::take) {
+        None => Err(PluginError::with_code(
+            format!("missing param: {}", key),
+            -32602,
+        )),
         Some(v) => serde_json::from_value(v)
-            .map_err(|e| PluginError::with_code(format!("invalid param: rows: {}", e), -32602)),
-    }
-}
-
-fn param_config(params: &mut Value) -> Result<HashMap<String, String>, PluginError> {
-    match params.get_mut("config").map(Value::take) {
-        None => Err(PluginError::with_code("missing param: config", -32602)),
-        Some(v) => serde_json::from_value(v)
-            .map_err(|e| PluginError::with_code(format!("invalid param: config: {}", e), -32602)),
+            .map_err(|e| PluginError::with_code(format!("invalid param: {}: {}", key, e), -32602)),
     }
 }
 
@@ -284,7 +286,7 @@ async fn dispatch(
 ) -> Result<Value, PluginError> {
     match req.method.as_str() {
         "initialize" => {
-            let config = param_config(&mut req.params)?;
+            let config: HashMap<String, String> = param_de(&mut req.params, "config")?;
             adapter.initialize(config).await?;
             Ok(Value::Bool(true))
         }
@@ -312,7 +314,7 @@ async fn dispatch(
         }
         "upsert_rows" => {
             let table = param_str(&req.params, "table")?;
-            let rows = param_rows(&mut req.params)?;
+            let rows: Vec<HashMap<String, Value>> = param_de(&mut req.params, "rows")?;
             let count = adapter.upsert_rows(&table, &rows).await?;
             Ok(serde_json::to_value(count).unwrap())
         }
@@ -448,7 +450,7 @@ mod tests {
     fn test_param_rows_malformed_reports_invalid_not_missing() {
         // rows present but an object instead of an array.
         let mut params = serde_json::json!({"rows": {"id": 1}});
-        let err = param_rows(&mut params).unwrap_err();
+        let err = param_de::<Vec<HashMap<String, Value>>>(&mut params, "rows").unwrap_err();
         assert_eq!(err.code, -32602);
         assert!(
             err.message.contains("invalid param: rows"),
@@ -461,7 +463,7 @@ mod tests {
     #[test]
     fn test_param_rows_missing_still_reports_missing() {
         let mut params = serde_json::json!({});
-        let err = param_rows(&mut params).unwrap_err();
+        let err = param_de::<Vec<HashMap<String, Value>>>(&mut params, "rows").unwrap_err();
         assert!(
             err.message.contains("missing param: rows"),
             "{}",
@@ -475,7 +477,7 @@ mod tests {
     fn test_param_config_malformed_reports_invalid_not_missing() {
         // config present but a string instead of a map.
         let mut params = serde_json::json!({"config": "not-a-map"});
-        let err = param_config(&mut params).unwrap_err();
+        let err = param_de::<HashMap<String, String>>(&mut params, "config").unwrap_err();
         assert_eq!(err.code, -32602);
         assert!(
             err.message.contains("invalid param: config"),
@@ -523,7 +525,7 @@ mod tests {
     #[test]
     fn test_param_config_extraction() {
         let mut params = serde_json::json!({"config": {"url": "http://localhost", "token": "abc"}});
-        let config = param_config(&mut params).unwrap();
+        let config = param_de::<HashMap<String, String>>(&mut params, "config").unwrap();
         assert_eq!(config.get("url").unwrap(), "http://localhost");
         assert_eq!(config.get("token").unwrap(), "abc");
     }
@@ -531,7 +533,7 @@ mod tests {
     #[test]
     fn test_param_rows_extraction() {
         let mut params = serde_json::json!({"rows": [{"id": 1, "name": "alice"}]});
-        let rows = param_rows(&mut params).unwrap();
+        let rows = param_de::<Vec<HashMap<String, Value>>>(&mut params, "rows").unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].get("name").unwrap(), "alice");
     }

--- a/crates/smugglr/src/output.rs
+++ b/crates/smugglr/src/output.rs
@@ -48,6 +48,21 @@ fn is_zero(n: &usize) -> bool {
     *n == 0
 }
 
+/// Build the per-table output rows shared by [`CommandOutput::from_sync_results`]
+/// and [`WatchTickOutput::from_results`]: tables with no pushed/pulled rows are
+/// dropped so JSON output only reports what actually changed.
+fn table_outputs(results: &[SyncResult]) -> Vec<TableOutput> {
+    results
+        .iter()
+        .filter(|r| r.has_changes())
+        .map(|r| TableOutput {
+            name: r.table.clone(),
+            rows_pushed: r.rows_pushed,
+            rows_pulled: r.rows_pulled,
+        })
+        .collect()
+}
+
 #[derive(Serialize)]
 pub struct DiffOutput {
     pub command: &'static str,
@@ -163,15 +178,7 @@ impl CommandOutput {
         Self {
             command,
             status: Status::Ok,
-            tables: results
-                .iter()
-                .filter(|r| r.has_changes())
-                .map(|r| TableOutput {
-                    name: r.table.clone(),
-                    rows_pushed: r.rows_pushed,
-                    rows_pulled: r.rows_pulled,
-                })
-                .collect(),
+            tables: table_outputs(results),
             error: None,
         }
     }
@@ -314,15 +321,7 @@ impl WatchTickOutput {
             command: "watch",
             tick,
             status: if dry_run { Status::DryRun } else { Status::Ok },
-            tables: results
-                .iter()
-                .filter(|r| r.has_changes())
-                .map(|r| TableOutput {
-                    name: r.table.clone(),
-                    rows_pushed: r.rows_pushed,
-                    rows_pulled: r.rows_pulled,
-                })
-                .collect(),
+            tables: table_outputs(results),
             error: None,
         }
     }


### PR DESCRIPTION
Collapses two copy-paste clusters identified in #225: the SDK's mutating
param-extraction pair, and the CLI's per-table sync-result output builder.
Behavior-preserving -- no public API, wire format, or error message changes.

## Acceptance criteria mapping

### param_rows + param_config replaced by one generic take-and-deserialize helper; param_str and param_str_slice left untouched

`crates/smugglr-plugin-sdk/src/lib.rs`: `param_rows` and `param_config` were
identical except for the key string baked into three spots (the `get_mut`
lookup and both error messages). Replaced both with one generic helper,
`fn param_de<T: DeserializeOwned>(params: &mut Value, key: &str) -> Result<T, PluginError>`,
that takes the key as a parameter. The two `dispatch` call sites
(`"initialize"` and `"upsert_rows"`) now call `param_de(&mut req.params, "config")`
and `param_de(&mut req.params, "rows")` with the target type pinned by the
`let` binding. Error strings are unchanged: `format!("missing param: {}", key)`
and `format!("invalid param: {}: {}", key, e)` produce the exact same text as
the old hardcoded literals since `key` is always `"rows"` or `"config"` at
those call sites -- verified by running the five existing param_rows/param_config
tests (`test_param_rows_malformed_reports_invalid_not_missing`,
`test_param_rows_missing_still_reports_missing`,
`test_param_config_malformed_reports_invalid_not_missing`,
`test_param_config_extraction`, `test_param_rows_extraction`), updated only to
call `param_de::<...>()` instead of the removed function names, unchanged
assertions, all passing.

`param_str` and `param_str_slice` are not touched by this diff at all --
`git diff` shows zero hunks inside either function. They take `&Value` (no
`take()`/mutation needed) rather than `&mut Value`, a materially different
shape from the take-and-deserialize pair, so they were correctly excluded per
the issue's explicit instruction.

### from_sync_results duplication in output.rs collapsed

`crates/smugglr/src/output.rs`: `CommandOutput::from_sync_results` and
`WatchTickOutput::from_results` built their `tables` field with byte-identical
logic -- `results.iter().filter(|r| r.has_changes()).map(|r| TableOutput { name:
r.table.clone(), rows_pushed: r.rows_pushed, rows_pulled: r.rows_pulled }).collect()`.
This is the duplication the issue title calls out ("dedup CLI table_outputs").
Extracted a private `fn table_outputs(results: &[SyncResult]) -> Vec<TableOutput>`
and both call sites now just call `table_outputs(results)`, keeping their own
independent `command`/`status`/`tick` construction.

Deliberately not touched: the two `DryRunOutput::from_sync_results` impls
(`DryRunOutput<DryRunTableOutput>` and `DryRunOutput<DryRunVerboseTableOutput>`)
share the same name but are not copy-pasted -- they already delegate their
common iteration/accumulation to a private `DryRunOutput::<T>::build` helper
and differ only in the per-row closure (compact diff counts vs. verbose PK
lists), a genuine type-level difference. `git diff` confirms no hunks touch
either impl; they were already DRY before this PR.

### no behavioral change; build/test/clippy/fmt pass

`param_de` and `table_outputs` are both private functions -- no public API
surface moved. Golden wire tests in `output.rs`
(`golden_command_output`, `golden_command_output_no_changed_table`,
`golden_watch_tick_output`, `golden_watch_tick_dry_run_output`,
`golden_dry_run_output_compact`, `golden_dry_run_output_verbose`) assert the
full serialized JSON shape via `serde_json::to_value` against a `json!`
literal and pass unchanged, locking the observable output byte-identical to
before. Ran clean:
- `cargo build -p smugglr-plugin-sdk -p smugglr`
- `cargo test -p smugglr-plugin-sdk` -- 23 passed, 1 doc-test passed
- `cargo test -p smugglr -- --skip multicast` -- 26 unit + 1 integration test passed
- `cargo clippy --all-targets -- -D warnings` -- zero warnings
- `cargo fmt --all -- --check` -- clean

This is a behavior-preserving refactor (no new/changed observable behavior),
so a fails-before regression test is not applicable; the golden wire tests and
unchanged param_* test assertions above are the evidence that behavior is
byte-identical pre/post change.

### simplify + review passes, issues fixed

Simplify gate ran against both changed files, articulating what was collapsed
(the `param_de` and `table_outputs` helpers) and what was deliberately left
alone (`param_str`/`param_str_slice`, the two `DryRunOutput::from_sync_results`
impls) and why, and was accepted with zero findings. The review pass runs
after this PR opens, per the plugin quality pipeline (simplify -> pr-write ->
review -> verify); any findings it raises will be fixed on this branch before
requesting sign-off.
Evidence: `legion quality-gate check --skill legion-simplify --result clean
--findings-count 0 --articulation-file /tmp/simplify-225.md` returned
"articulation accepted for skill 'legion-simplify' (result 'clean', 2 file
entries, 0 skill findings)", gate id `019f61f7-03f2-7173-865d-12d56c6bb2af`
(recorded against commit 988082f, the HEAD of this branch).

### PR linked to this issue

This PR is opened with `legion pr create --repo smugglr --task
019e98dc-b721-75b0-ab7a-de2fa3209bc6`, which attaches the PR to kanban card
019e98dc-b721-75b0-ab7a-de2fa3209bc6 (issue #225), and the title is prefixed
`refactor(#225): ...` per repo convention, so GitHub auto-links the PR to
issue #225 on merge.
Evidence: PR title `refactor(#225): collapse SDK param extractors and output
from_sync_results` and the `--task 019e98dc-b721-75b0-ab7a-de2fa3209bc6` flag
passed to `legion pr create`, which is the same card id returned by `legion
kanban accept --id 019e98dc-b721-75b0-ab7a-de2fa3209bc6` at the start of this
work.

## Not done

Deliberately left out of scope, and why:

- `param_str` and `param_str_slice` in `crates/smugglr-plugin-sdk/src/lib.rs`
  are untouched. They borrow `&Value` and return owned copies without needing
  `Value::take()`, a materially different shape from the take-and-deserialize
  pair (`param_rows`/`param_config`) that this PR collapses. The issue
  explicitly says to leave them alone; `git diff` confirms zero hunks inside
  either function.
- The two `DryRunOutput<T>::from_sync_results` impls in
  `crates/smugglr/src/output.rs` (compact and verbose) are untouched. They
  share a name with each other but are not copy-pasted: both already delegate
  their common iteration/accumulation to a private `DryRunOutput::<T>::build`
  helper and differ only in the per-row closure (diff-count summary vs.
  full PK-list breakdown) -- a genuine type-level difference, not
  duplication. Collapsing them further would erase that distinction for no
  benefit, so this PR only collapses the pair that was actually duplicated:
  `CommandOutput::from_sync_results` and `WatchTickOutput::from_results`.
- No new tests were added. This is a behavior-preserving refactor with full
  existing coverage (including golden wire tests that lock the exact JSON
  shape); adding tests wasn't necessary to demonstrate the "no behavioral
  change" acceptance criterion, and none of the acceptance criteria call for
  new test coverage.