### PR TITLE
refactor(#226): unify is_transient_error onto is_retryable

### DIFF
--- a/crates/smugglr-core/src/daemon.rs
+++ b/crates/smugglr-core/src/daemon.rs
@@ -204,15 +204,68 @@ pub fn epoch_days_to_date(days: u64) -> (u64, u64, u64) {
 }
 
 /// Check if an error is transient (should retry on next tick) vs fatal (should exit).
+///
+/// This delegates to [`SyncError::is_retryable`], the canonical retry policy also
+/// used by the native one-shot retry loop (see `sync::upsert_with_retry`), so the
+/// same error is never "retry" in the daemon and "fatal" in the CLI (issue #226).
+/// Delegating narrows two cases that this function previously matched more
+/// broadly on its own: `SyncError::Http(_)` is now transient only for the
+/// timeout/connect subset `is_retryable` recognizes (a decode, builder, or
+/// other non-transport HTTP failure is now fatal instead of looping forever),
+/// and `SyncError::ServerError { status, .. }` is transient only for `status
+/// >= 500`, matching the variant's documented "5xx" contract instead of
+/// treating every `ServerError` as transient regardless of status.
+///
+/// One documented daemon-specific delta: `ConcurrentWrite` is additionally treated
+/// as transient here, even though `is_retryable` reports it as non-retryable. In
+/// the native path a concurrent-write conflict is surfaced directly to the
+/// operator, who must manually re-run the stash command to pull the latest relay
+/// and merge -- there's no automatic "next attempt" within a single invocation.
+/// The daemon, by contrast, already has a wait-and-try-again tick loop: skipping to
+/// the next tick after a backoff will re-download the latest relay and can resolve
+/// the conflict without operator intervention, so retrying on `ConcurrentWrite` is
+/// the right call for this loop specifically, and only this loop.
 pub fn is_transient_error(err: &SyncError) -> bool {
-    matches!(
-        err,
-        SyncError::RateLimited { .. }
-            | SyncError::ServerError { .. }
-            | SyncError::ConnectionTimeout
-            | SyncError::Http(_)
-            | SyncError::ConcurrentWrite
-    )
+    err.is_retryable() || matches!(err, SyncError::ConcurrentWrite)
+}
+
+/// Compile-time guard: an exhaustive, non-wildcard match over every
+/// `SyncError` variant. This function is never called -- its only purpose is
+/// that adding a new `SyncError` variant makes it fail to compile, forcing
+/// whoever adds the variant to also add a case to
+/// `test_retry_verdict_enumerates_every_variant` below rather than letting it
+/// silently fall on the wrong side of the retry policy (issue #226).
+#[allow(dead_code, clippy::match_same_arms)]
+fn _assert_every_variant_is_enumerated_in_retry_verdict_test(err: &SyncError) {
+    match err {
+        SyncError::Config(_) => {}
+        SyncError::ConfigEnvVar(_) => {}
+        SyncError::LocalDb(_) => {}
+        SyncError::Remote(_) => {}
+        SyncError::Http(_) => {}
+        SyncError::Json(_) => {}
+        SyncError::Io(_) => {}
+        SyncError::TableNotFound(_) => {}
+        SyncError::NoPrimaryKey(_) => {}
+        SyncError::D1Api { .. } => {}
+        SyncError::ConfigNotFound(_) => {}
+        SyncError::RateLimited { .. } => {}
+        SyncError::ServerError { .. } => {}
+        SyncError::ConnectionTimeout => {}
+        SyncError::BadRequest { .. } => {}
+        SyncError::RetryExhausted { .. } => {}
+        SyncError::InvalidTableName { .. } => {}
+        SyncError::ObjectStore(_) => {}
+        SyncError::Stash(_) => {}
+        SyncError::InvalidUrl(_) => {}
+        SyncError::RelayNotFound(_) => {}
+        SyncError::ConcurrentWrite => {}
+        SyncError::ParamLimitExceeded { .. } => {}
+        SyncError::Broadcast(_) => {}
+        SyncError::Plugin(_) => {}
+    }
+    // No `_` arm above: a new SyncError variant must be added to the match
+    // (and to the enumeration test) or this file fails to compile.
 }
 
 #[cfg(test)]
@@ -398,5 +451,180 @@ database = "backup.db""#
 
         assert!(!is_transient_error(&SyncError::Config("bad".into())));
         assert!(!is_transient_error(&SyncError::TableNotFound("x".into())));
+    }
+
+    /// Build a `reqwest::Error` that is neither `is_timeout()` nor `is_connect()`.
+    ///
+    /// Requesting an unsupported URL scheme fails at request-build time inside
+    /// `send()`, before any socket is touched, so this is deterministic and
+    /// works fully offline -- it never performs network I/O.
+    async fn non_network_http_error() -> reqwest::Error {
+        let err = reqwest::Client::new()
+            .get("not-a-real-scheme://host")
+            .send()
+            .await
+            .expect_err("unsupported scheme must fail request construction");
+        assert!(
+            !err.is_timeout() && !err.is_connect(),
+            "test fixture must produce a non-timeout, non-connect HTTP error"
+        );
+        err
+    }
+
+    /// Regression guard for #226.
+    ///
+    /// Before the fix, `is_transient_error` matched `SyncError::Http(_)`
+    /// unconditionally, while `is_retryable` only treated timeout/connect
+    /// `reqwest::Error`s as retryable. That meant a non-network HTTP failure
+    /// (bad scheme, decode error, builder error, etc.) was "retry forever" in
+    /// the daemon but "fatal" in the native retry loop. Confirmed this test
+    /// fails on the pre-change `is_transient_error` (see PR description for
+    /// the observed failure).
+    #[tokio::test]
+    async fn test_is_transient_error_matches_is_retryable_for_non_network_http_error() {
+        let err = SyncError::Http(non_network_http_error().await);
+
+        assert!(
+            !err.is_retryable(),
+            "fixture must be non-retryable per is_retryable's timeout/connect-only policy"
+        );
+        assert_eq!(
+            is_transient_error(&err),
+            err.is_retryable(),
+            "is_transient_error must delegate to is_retryable for Http errors"
+        );
+    }
+
+    /// Enumerates every `SyncError` variant and pins both classifiers' verdicts,
+    /// so a newly added variant -- or a change to either function -- cannot
+    /// silently fall on the wrong side of the retry policy (issue #226).
+    ///
+    /// `is_transient_error` is defined as `is_retryable() || ConcurrentWrite`,
+    /// so every variant here must agree between the two functions except
+    /// `ConcurrentWrite`, which is the one documented daemon-specific delta.
+    #[tokio::test]
+    async fn test_retry_verdict_enumerates_every_variant() {
+        let db_err = {
+            let conn = rusqlite::Connection::open_in_memory().unwrap();
+            conn.execute("SELECT * FROM no_such_table_226", [])
+                .unwrap_err()
+        };
+        let store_err = object_store::parse_url(&url::Url::parse("bogus-scheme://bucket").unwrap())
+            .expect_err("unsupported object store scheme must fail to parse");
+        let http_err = non_network_http_error().await;
+
+        // (name, error, expected is_retryable() verdict)
+        let cases: Vec<(&str, SyncError, bool)> = vec![
+            ("Config", SyncError::Config("x".into()), false),
+            ("ConfigEnvVar", SyncError::ConfigEnvVar("x".into()), false),
+            ("LocalDb", SyncError::LocalDb(db_err), false),
+            ("Remote", SyncError::Remote("x".into()), false),
+            ("Http (non-network)", SyncError::Http(http_err), false),
+            (
+                "Json",
+                SyncError::Json(serde_json::from_str::<i32>("not json").unwrap_err()),
+                false,
+            ),
+            ("Io", SyncError::Io(std::io::Error::other("x")), false),
+            ("TableNotFound", SyncError::TableNotFound("t".into()), false),
+            ("NoPrimaryKey", SyncError::NoPrimaryKey("t".into()), false),
+            (
+                "D1Api",
+                SyncError::D1Api {
+                    message: "x".into(),
+                    code: Some(1),
+                },
+                false,
+            ),
+            (
+                "ConfigNotFound",
+                SyncError::ConfigNotFound("x".into()),
+                false,
+            ),
+            (
+                "RateLimited",
+                SyncError::RateLimited { retry_after: None },
+                true,
+            ),
+            (
+                "ServerError 5xx",
+                SyncError::ServerError {
+                    status: 503,
+                    message: "down".into(),
+                },
+                true,
+            ),
+            (
+                // is_retryable's status >= 500 guard is the canonical policy;
+                // a mislabeled ServerError below 500 must not be retried.
+                "ServerError below 500",
+                SyncError::ServerError {
+                    status: 404,
+                    message: "not actually a server error".into(),
+                },
+                false,
+            ),
+            ("ConnectionTimeout", SyncError::ConnectionTimeout, true),
+            (
+                "BadRequest",
+                SyncError::BadRequest {
+                    status: 400,
+                    message: "x".into(),
+                },
+                false,
+            ),
+            (
+                "RetryExhausted",
+                SyncError::RetryExhausted {
+                    attempts: 3,
+                    last_error: "x".into(),
+                },
+                false,
+            ),
+            (
+                "InvalidTableName",
+                SyncError::InvalidTableName {
+                    name: "x".into(),
+                    available: "a, b".into(),
+                },
+                false,
+            ),
+            ("ObjectStore", SyncError::ObjectStore(store_err), false),
+            ("Stash", SyncError::Stash("x".into()), false),
+            ("InvalidUrl", SyncError::InvalidUrl("x".into()), false),
+            ("RelayNotFound", SyncError::RelayNotFound("x".into()), false),
+            (
+                "ParamLimitExceeded",
+                SyncError::ParamLimitExceeded {
+                    table: "t".into(),
+                    row_count: 1,
+                    col_count: 1,
+                    limit: 1,
+                },
+                false,
+            ),
+            ("Broadcast", SyncError::Broadcast("x".into()), false),
+            ("Plugin", SyncError::Plugin("x".into()), false),
+        ];
+
+        for (name, err, expected_retryable) in cases {
+            assert_eq!(
+                err.is_retryable(),
+                expected_retryable,
+                "is_retryable() verdict changed for {name}"
+            );
+            assert_eq!(
+                is_transient_error(&err),
+                expected_retryable,
+                "is_transient_error() diverged from is_retryable() for {name} \
+                 with no documented delta"
+            );
+        }
+
+        // The one documented delta: ConcurrentWrite is fatal per is_retryable
+        // (the native path can't retry within a single invocation) but
+        // transient per is_transient_error (the daemon's tick loop can).
+        assert!(!SyncError::ConcurrentWrite.is_retryable());
+        assert!(is_transient_error(&SyncError::ConcurrentWrite));
     }
 }

--- a/crates/smugglr-core/src/error.rs
+++ b/crates/smugglr-core/src/error.rs
@@ -105,11 +105,19 @@ pub enum SyncError {
 impl SyncError {
     /// Check if this error is retryable with exponential backoff.
     ///
+    /// This is the canonical retry classifier for `SyncError`: the native
+    /// one-shot retry loop (`sync::upsert_with_retry`) and the daemon's
+    /// `daemon::is_transient_error` both key off this method so the same
+    /// error carries the same retry verdict everywhere (issue #226). Anyone
+    /// adding a caller-specific delta (like the daemon's `ConcurrentWrite`
+    /// carve-out) must build on top of this, not maintain a second
+    /// independent classification.
+    ///
     /// Retryable errors:
     /// - 429 rate limits
     /// - 5xx server errors
     /// - Connection timeouts
-    /// - Network connectivity issues
+    /// - Network connectivity issues (HTTP timeout/connect failures)
     pub fn is_retryable(&self) -> bool {
         match self {
             SyncError::RateLimited { .. } => true,


### PR DESCRIPTION
## Summary

Reconciles the two independent retry classifiers for `SyncError` --
`SyncError::is_retryable` (`crates/smugglr-core/src/error.rs:113`) and the
daemon's `is_transient_error` (`crates/smugglr-core/src/daemon.rs:221`) -- so
the same error can no longer be "retry" in the daemon and "fatal" in the
native one-shot loop. `is_transient_error` now delegates to `is_retryable`
plus one explicit, documented daemon-specific delta.

## Policy decision

**Canonical classifier: `SyncError::is_retryable`.** Per the issue, `is_transient_error`
now reads:

```rust
pub fn is_transient_error(err: &SyncError) -> bool {
    err.is_retryable() || matches!(err, SyncError::ConcurrentWrite)
}
```

I read both functions and enumerated every variant where they disagreed before
this change. There were three divergences; each was a deliberate call, not a
silent drop:

1. **`SyncError::Http(reqwest::Error)`.** `is_retryable` only treats it as
   retryable when `e.is_timeout() || e.is_connect()` (error.rs:119).
   `is_transient_error` previously matched `Http(_)` unconditionally --
   *any* reqwest error (a decode failure, a builder error from a malformed
   URL, a TLS failure, etc.) was treated as "retry on next tick." **Resolved
   in favor of `is_retryable`'s narrower policy**: a non-transport HTTP
   failure is not something retrying will fix, and the daemon looping on it
   forever (previously) is worse than exiting. This is a real behavior
   change for the daemon: it will now exit instead of loop on this class of
   error. Documented at daemon.rs:206-211.

2. **`SyncError::ServerError { status, .. }`.** `is_retryable` only treats it
   as retryable when `status >= 500` (error.rs:116), matching the variant's
   own doc comment ("HTTP 5xx server error"). `is_transient_error` previously
   matched `ServerError { .. }` for any status. **Resolved in favor of
   `is_retryable`'s guard**: the type is documented as 5xx-only, so a
   mislabeled sub-500 `ServerError` should not be retried either place. Also
   a real (if narrow/edge-case) behavior change for the daemon. Documented at
   daemon.rs:206-211.

3. **`SyncError::ConcurrentWrite`.** `is_retryable` reports `false` (it's not
   in `is_retryable`'s match at all, falls to `_ => false`).
   `is_transient_error` reported `true`. **Kept as an explicit, documented
   daemon-specific delta**, per the issue's own suggested resolution. The
   reasoning: in the native one-shot path, a concurrent-write conflict is
   surfaced directly to the operator, who must manually re-run the stash
   command to pull the latest relay and merge -- there is no automatic "next
   attempt" within a single invocation, so `is_retryable() == false` is
   correct there. The daemon already has a wait-and-try-again tick loop:
   retrying on the next tick will naturally re-download the latest relay and
   can resolve the conflict without operator intervention, so treating it as
   transient is the right call for the daemon specifically -- and only the
   daemon. This preserves prior daemon behavior (was transient, stays
   transient); it's the one non-narrowing case. Documented at daemon.rs:212-220.

All other variants agreed before and after (both `false`): `Config`,
`ConfigEnvVar`, `LocalDb`, `Remote`, `Json`, `Io`, `TableNotFound`,
`NoPrimaryKey`, `D1Api`, `ConfigNotFound`, `BadRequest`, `RetryExhausted`,
`InvalidTableName`, `ObjectStore`, `Stash`, `InvalidUrl`, `RelayNotFound`,
`ParamLimitExceeded`, `Broadcast`, `Plugin`. `RateLimited` and
`ConnectionTimeout` agreed as `true`.

## Regression test that fails before the fix

`daemon::tests::test_is_transient_error_matches_is_retryable_for_non_network_http_error`
(daemon.rs) constructs a real, non-timeout/non-connect `reqwest::Error` (a
failed request to an unsupported URL scheme -- fails at request-build time,
fully offline, no network I/O) wrapped in `SyncError::Http`, then asserts
`is_transient_error(&err) == err.is_retryable()`.

I proved this fails on the pre-change code by temporarily reverting
`is_transient_error`'s body to the original `matches!` (unconditional
`Http(_)` arm), running the test, and restoring the fix afterward. Observed
failure on the pre-change code:

```
thread 'daemon::tests::test_is_transient_error_matches_is_retryable_for_non_network_http_error' panicked at crates/smugglr-core/src/daemon.rs:452:9:
assertion `left == right` failed: is_transient_error must delegate to is_retryable for Http errors
  left: true
 right: false
```

`daemon::tests::test_retry_verdict_enumerates_every_variant` failed the same
way on the same revert (same divergence, enumerated alongside every other
variant):

```
thread 'daemon::tests::test_retry_verdict_enumerates_every_variant' panicked at crates/smugglr-core/src/daemon.rs:577:13:
assertion `left == right` failed: is_transient_error() diverged from is_retryable() for Http (non-network) with no documented delta
  left: true
 right: false
```

## Error handling / future-proofing

Added `_assert_every_variant_is_enumerated_in_retry_verdict_test` (daemon.rs)
-- a never-called function containing an exhaustive, non-wildcard `match` over
every `SyncError` variant. It exists purely so adding a new variant fails to
compile, forcing the author to also extend
`test_retry_verdict_enumerates_every_variant`, per the issue's "future
variants cannot silently fall on the wrong side" requirement. The enumeration
test itself constructs a real instance of every variant (including a live
`rusqlite::Error`, `object_store::Error`, and `reqwest::Error`, not stubs) and
pins both `is_retryable()` and `is_transient_error()`'s verdict for each. This
is what satisfies the issue's "Error Handling" requirement to enumerate each
variant so future ones can't silently fall on the wrong side.

## Acceptance criteria mapping

### 1. All tests pass (including a regression test that fails before the fix)

Satisfied by `daemon::tests::test_is_transient_error_matches_is_retryable_for_non_network_http_error`
and `daemon::tests::test_retry_verdict_enumerates_every_variant`
(`crates/smugglr-core/src/daemon.rs`), both of which I proved fail on the
pre-change `is_transient_error` body (observed panics quoted above under
"Regression test that fails before the fix"). Full suite is green:
`cargo test -p smugglr-core -- --skip multicast` reports 204 passed, 0
failed, and `cargo test --workspace -- --skip multicast` is green across
every crate. `cargo clippy --all-targets -- -D warnings` and `cargo fmt
--all -- --check` are both clean.

Evidence: `crates/smugglr-core/src/daemon.rs:452` (fails-before panic quoted
above), `cargo test -p smugglr-core -- --skip multicast` -> 204 passed, 0 failed.

### 2. Simplify pass completed

Ran `/legion-simplify` over both changed files
(`crates/smugglr-core/src/error.rs`, `crates/smugglr-core/src/daemon.rs`);
gate recorded clean with 0 findings, articulation in `/tmp/simplify-226.md`
with line references for each file. The simplify pass is also what the "one
canonical classifier" behavior requirement produces structurally:
`is_transient_error` (daemon.rs:221-223) is now `err.is_retryable() ||
matches!(err, SyncError::ConcurrentWrite)` instead of a second,
independently-maintained `matches!` block -- zero duplicated match arms.

Evidence: gate id `019f61fb-99a0-7960-9df0-11cb6d4f7374` (result clean,
0 findings).

### 3. Review pass completed and issues fixed

To be run via `legion-review` after this PR is opened, per the standard
simplify -> pr-write -> review -> verify pipeline; not yet executed at the
time of writing this body, since review requires an open PR to review
against.

Evidence: none yet -- this criterion is completed in a follow-on step after
`legion pr create`, not before it.

### 4. PR created and linked to this issue

This PR, opened against issue #226 via `legion pr create --repo smugglr
--task 019e98dc-b721-75b0-ab7a-de15d2c38cb9`.

Evidence: the PR itself, plus the `--task 019e98dc-b721-75b0-ab7a-de15d2c38cb9`
linkage to the kanban card for issue #226.

## Not done

- Did not add any new `SyncError` variants or change any variant's fields.
- Did not touch `SyncError::exit_code` (error.rs:146) -- separate, intentionally
  distinct policy (CLI exit code, not a retry verdict).
- Did not change `sync::upsert_with_retry`'s use of `is_retryable` -- the
  native path was already correct; only the daemon needed reconciling.
- Did not touch `retry_after_ms` (error.rs:128) -- unrelated to the
  retry/transient verdict.
- Did not run `legion verify` or merge -- out of scope per task instructions;
  review and verify are separate follow-on steps.

## Test plan

- [x] `cargo test -p smugglr-core -- --skip multicast` -- 204 passed, 0 failed
- [x] `cargo test --workspace -- --skip multicast` -- all crates green
- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] `cargo fmt --all -- --check` -- clean
- [x] Fails-before regression test proven against pre-change code (see above)