### PR TITLE
refactor(#217): open local DB read-only in dry-run watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,7 @@ version = "0.4.2"
 dependencies = [
  "clap",
  "indicatif",
+ "rusqlite",
  "serde",
  "serde_json",
  "smugglr-core",

--- a/crates/smugglr/Cargo.toml
+++ b/crates/smugglr/Cargo.toml
@@ -44,3 +44,8 @@ tokio = { version = "1", features = ["full"] }
 [dev-dependencies]
 # Isolated temp dirs for subprocess integration tests
 tempfile = "3"
+
+# Building fixture SQLite databases directly in watch.rs's dry-run/read-only
+# regression tests (smugglr-core's LocalDb intentionally exposes no raw-SQL
+# or table-creation API for production code to call).
+rusqlite = { version = "0.34", features = ["bundled"] }

--- a/crates/smugglr/src/watch.rs
+++ b/crates/smugglr/src/watch.rs
@@ -63,13 +63,16 @@ pub async fn run_watch(
                 info!("Watch tick #{}", tick_count);
 
                 let result = match &target {
-                    ResolvedTarget::Sqlite { database } => {
-                        let local = LocalDb::open(config.local_db_path())?;
-                        let target_db = LocalDb::open(database)?;
+                    ResolvedTarget::Sqlite { .. } => {
+                        let local = open_local(config, dry_run)?;
+                        // Mirrors run_sync/run_pull's dry-run-readonly convention: in
+                        // dry-run nothing is written (sync_all bails before
+                        // transfer_rows), so the target does not need write access.
+                        let target_db = crate::TargetSource::open(&target, !dry_run).await?;
                         sync_all(&local, &target_db, config, None, dry_run, &NoProgress).await
                     }
                     ResolvedTarget::Plugin { .. } => {
-                        let local = LocalDb::open(config.local_db_path())?;
+                        let local = open_local(config, dry_run)?;
                         let plugin = plugin.as_ref().expect("plugin initialized before loop");
                         sync_all(&local, plugin, config, None, dry_run, &NoProgress).await
                     }
@@ -132,4 +135,130 @@ pub async fn run_watch(
 
     info!("Watch daemon stopped after {} ticks", tick_count);
     Ok(())
+}
+
+/// Open the local DB in the same dry-run-readonly mode `run_sync`/`run_pull`
+/// use (main.rs): read-only when `dry_run` is true, read-write otherwise.
+///
+/// In dry-run, `sync_all` never reaches a writer -- `push_table`/`pull_table`
+/// both return before `transfer_rows`, the sole caller of `upsert_rows` -- so
+/// a read-write connection is unnecessary: it asks for write access dry-run
+/// never uses, can spuriously fail on a read-only filesystem or a locked DB,
+/// and it diverges from the dry-run-readonly convention `run_sync`/`run_pull`
+/// establish (#217).
+fn open_local(config: &Config, dry_run: bool) -> Result<LocalDb> {
+    if dry_run {
+        LocalDb::open_readonly(config.local_db_path())
+    } else {
+        LocalDb::open(config.local_db_path())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smugglr_core::config::SyncConfig;
+    use smugglr_core::datasource::DataSource;
+    use std::collections::HashMap;
+
+    /// Create a fresh SQLite file at `path` with one table, `t (id, v)`.
+    ///
+    /// `LocalDb`/`TargetSource` intentionally expose no raw-SQL or
+    /// table-creation API (production code never needs one), so the fixture
+    /// is built with a direct `rusqlite` connection instead.
+    fn make_db_with_table(path: &std::path::Path) {
+        let conn = rusqlite::Connection::open(path).expect("create fixture db");
+        conn.execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .expect("create fixture table");
+    }
+
+    fn sample_row() -> HashMap<String, serde_json::Value> {
+        let mut row = HashMap::new();
+        row.insert("id".to_string(), serde_json::json!(1));
+        row.insert("v".to_string(), serde_json::json!("x"));
+        row
+    }
+
+    fn config_for(db_path: &std::path::Path) -> Config {
+        Config {
+            cloudflare_account_id: None,
+            cloudflare_api_token: None,
+            database_id: None,
+            local_db: Some(db_path.to_string_lossy().into_owned()),
+            sync: SyncConfig::default(),
+            stash: None,
+            target: None,
+            broadcast: None,
+        }
+    }
+
+    /// Regression for #217 (local DB): a dry-run watch tick's local
+    /// connection must be genuinely read-only, not merely "unwritten in
+    /// practice." Before the fix, `open_local`'s equivalent (the raw
+    /// `LocalDb::open(...)` call in watch.rs) opened read-write
+    /// unconditionally, ignoring `dry_run`. On that code, a write attempt
+    /// against the dry-run connection succeeds -- the no-writes guarantee
+    /// lived only in caller discipline (`sync_all` bailing before
+    /// `transfer_rows`), not in the connection itself. This test fails
+    /// against that code (the first assertion below) and passes once
+    /// `open_local` opens read-only in dry-run, because SQLite itself then
+    /// rejects the write.
+    #[tokio::test]
+    async fn open_local_dry_run_connection_rejects_writes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("local.db");
+        make_db_with_table(&db_path);
+        let config = config_for(&db_path);
+
+        let db = open_local(&config, true).expect("dry-run open should succeed");
+        let write = db
+            .upsert_rows("t", std::slice::from_ref(&sample_row()))
+            .await;
+        assert!(
+            write.is_err(),
+            "dry-run's local connection must reject writes, but a write succeeded"
+        );
+
+        // Control: the same DB opened non-dry-run accepts the identical
+        // write. This proves the failure above is specifically about the
+        // dry-run open mode, not an unrelated problem with the fixture.
+        let db_rw = open_local(&config, false).expect("non-dry-run open should succeed");
+        let write_rw = db_rw
+            .upsert_rows("t", std::slice::from_ref(&sample_row()))
+            .await;
+        assert!(
+            write_rw.is_ok(),
+            "non-dry-run's local connection should accept writes, got: {:?}",
+            write_rw
+        );
+    }
+
+    /// Regression for #217 (SQLite target): mirrors the local-DB assertion
+    /// above for the SQLite target opened via `TargetSource::open` in the
+    /// watch loop's `ResolvedTarget::Sqlite` arm. Before the fix this arm
+    /// called `LocalDb::open(database)` unconditionally (also ignoring
+    /// `dry_run`), so the same write-succeeds-when-it-shouldn't failure
+    /// applies to the target connection.
+    #[tokio::test]
+    async fn target_source_open_dry_run_connection_rejects_writes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("target.db");
+        make_db_with_table(&db_path);
+
+        let target = ResolvedTarget::Sqlite {
+            database: db_path.to_string_lossy().into_owned(),
+        };
+        let dry_run = true;
+
+        let target_db = crate::TargetSource::open(&target, !dry_run)
+            .await
+            .expect("dry-run target open should succeed");
+        let write = target_db
+            .upsert_rows("t", std::slice::from_ref(&sample_row()))
+            .await;
+        assert!(
+            write.is_err(),
+            "dry-run's target connection must reject writes, but a write succeeded"
+        );
+    }
 }

--- a/crates/smugglr/src/watch.rs
+++ b/crates/smugglr/src/watch.rs
@@ -142,9 +142,8 @@ pub async fn run_watch(
 ///
 /// In dry-run, `sync_all` never reaches a writer -- `push_table`/`pull_table`
 /// both return before `transfer_rows`, the sole caller of `upsert_rows` -- so
-/// a read-write connection is unnecessary: it asks for write access dry-run
-/// never uses, can spuriously fail on a read-only filesystem or a locked DB,
-/// and it diverges from the dry-run-readonly convention `run_sync`/`run_pull`
+/// a read-write connection asks for write access dry-run never uses, and it
+/// diverges from the dry-run-readonly convention `run_sync`/`run_pull`
 /// establish (#217).
 fn open_local(config: &Config, dry_run: bool) -> Result<LocalDb> {
     if dry_run {


### PR DESCRIPTION
## Summary

The watch daemon opened the local DB (and, for the SQLite target arm, the target DB) unconditionally read-write on every tick, regardless of `--dry-run`. `run_sync` and `run_pull` already gate the local DB's open mode on `dry_run` (`LocalDb::open_readonly` vs `LocalDb::open`, main.rs:578-582 and 606-610); watch never did, which diverges from that convention and means a dry-run tick's connections are write-capable even though `sync_all` never actually writes in dry-run (`push_table`/`pull_table` both return before `transfer_rows`, the sole caller of `upsert_rows`).

Fix: extract `open_local(config, dry_run)` in `crates/smugglr/src/watch.rs` (mirrors run_sync/run_pull's `if dry_run { open_readonly } else { open }` shape exactly) and use it in both match arms of the tick handler. Route the SQLite target arm through the existing `TargetSource::open(&target, writable)` helper from main.rs (already used by run_sync/run_pull for their own target opens) instead of a raw `LocalDb::open(database)`, passing `!dry_run` as `writable`.

## Acceptance criteria mapping

### All tests pass (including a regression test that fails before the fix)

Two new tests in `crates/smugglr/src/watch.rs`'s `#[cfg(test)] mod tests`:
  - `open_local_dry_run_connection_rejects_writes` (watch.rs) -- opens the local DB via `open_local(&config, true)` against a real fixture DB with a table, then attempts a write via `DataSource::upsert_rows`. Asserts the write fails. A control assertion in the same test opens the identical DB with `dry_run = false` and asserts the same write *succeeds*, proving the failure is specifically about the dry-run open mode.
  - `target_source_open_dry_run_connection_rejects_writes` -- same assertion for the SQLite target arm's `TargetSource::open(&target, !dry_run)`.
  - **Observed fails-before:** I verified both tests fail against the pre-fix code. I temporarily reverted `open_local` to always call `LocalDb::open` (ignoring `dry_run`, matching the original watch.rs body) and temporarily hardcoded the target test's `TargetSource::open(&target, true)` (matching the original unconditional `LocalDb::open(database)` call), then ran `cargo test -p smugglr --bin smugglr watch::tests`. Both failed:
    ```
    thread 'watch::tests::target_source_open_dry_run_connection_rejects_writes' panicked:
    dry-run's target connection must reject writes, but a write succeeded
    thread 'watch::tests::open_local_dry_run_connection_rejects_writes' panicked:
    dry-run's local connection must reject writes, but a write succeeded
    test result: FAILED. 0 passed; 2 failed
    ```
    I then restored the real fix and reran -- both pass. Full suite: `cargo test -p smugglr -- --skip multicast` (28 unit + 1 integration test, all green) and `cargo test -p smugglr-core -- --skip multicast` (202 tests green). `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` are both clean.
  - Note: an earlier draft of this fix used a black-box integration test that chmod'd the DB files read-only on disk and asserted the process still ran a tick. I discarded that approach after probing it empirically: SQLite/rusqlite silently falls back to a read-only open when a read-write open hits a permission-denied file, so that test passed even on the *pre-fix* code -- it did not discriminate. The `upsert_rows`-based tests above test the actual, deterministic behavior (SQLite unconditionally rejects writes on a connection opened `SQLITE_OPEN_READ_ONLY`) rather than relying on an OS/filesystem permission edge case that turned out not to manifest as an open-time failure in this build.

### Simplify pass completed

Ran via `legion quality-gate check --skill legion-simplify`, gate id `019f6200-820b-7bd3-94da-dd83306da680`, result clean, 3 file entries (watch.rs, Cargo.toml, Cargo.lock). Covered: the intentional non-unification of `open_local` with run_sync/run_pull's inline dry-run-open logic (out of scope per the issue's own "broader structural extraction... tracked as a separate refactor issue" carve-out, and `open_local` needed to be a standalone callable to serve as the test seam); reuse of the existing `TargetSource::open` helper instead of a new one; the new `rusqlite` dev-dependency (test-only, no new package/version in `Cargo.lock`, needed because `LocalDb` deliberately has no raw-SQL/table-creation API for tests to piggyback on).

### Review pass completed and issues fixed

Not yet run at the time of this write-check -- this PR is being opened now per the assigned workflow (`legion pr create` next); the `legion-review` stage runs on the open PR, after this write-check gate, per the plugin's documented pipeline order (simplify -> pr-write -> review -> verify).

Evidence: gate id `019f6200-820b-7bd3-94da-dd83306da680` (the `legion-simplify` gate recorded above) is the completed predecessor stage; `legion-review` will record its own gate id against this same branch/PR once run, satisfying this criterion at that point.

### PR created and linked to this issue

This PR is opened via `legion pr create --repo smugglr --issue 217 --task 019e98dc-b725-72d2-aaf1-eee4172694e4`, which links the PR to issue #217 (via `--issue`) and to kanban card `019e98dc-b725-72d2-aaf1-eee4172694e4` (via `--task`).

Evidence: branch `refactor/217-watch-dryrun-readonly`, commits `876fc8f` ("refactor(#217): open local DB read-only in dry-run watch") and `8f388c6` ("docs(#217): drop unverified spurious-failure claim from open_local doc"), both carrying the `#217` issue reference in the subject line.

## What I deliberately did NOT do

- Did not unify `open_local` with the inline dry-run-open logic already in `run_sync`/`run_pull` (main.rs) into one shared helper across all three call sites. The issue explicitly scopes that out ("Any broader structural extraction this finding may relate to (tracked as a separate refactor issue). Fix only the defect described here.").
- Did not change `run_sync`'s target-open behavior. `run_sync` opens its SQLite target unconditionally writable (`TargetSource::open(&target, true)`, not gated on `dry_run`) -- that's pre-existing, out-of-scope behavior. Watch's target arm is gated on `dry_run` per this issue's explicit requirement ("Mirror run_sync: open local (and the sqlite target) read-only when dry_run"), which is an intentional, narrower guarantee than what `run_sync` itself currently provides for its target.
- Did not add any new production-facing API to `smugglr_core::local::LocalDb` (e.g., a raw-SQL execute or table-creation method) to make testing easier; the regression tests build their fixture DB with a direct `rusqlite::Connection` instead, added as a `smugglr`-crate dev-dependency.
- Did not change non-dry-run behavior. `open_local(_, false)` is exactly `LocalDb::open`, and `TargetSource::open(&target, true)` is unchanged; only the `dry_run = true` path changes open mode.