### PR TITLE
refactor(#222): hoist generate_batch_sql and rows_to_maps into smugglr-core

### DIFF
--- a/crates/smugglr-core/src/batch_sql.rs
+++ b/crates/smugglr-core/src/batch_sql.rs
@@ -1,0 +1,167 @@
+//! The one canonical home for building multi-row `INSERT OR REPLACE` batch
+//! statements and reshaping positional result rows into column->value maps.
+//!
+//! Both `generate_batch_sql` and `rows_to_maps` were byte-identical copies in
+//! the http-sql plugin (`plugins/smugglr-http-sql/src/adapter.rs`) and the
+//! wasm adapter (`crates/smugglr-wasm/src/adapter_common.rs`) -- pure,
+//! self-free functions with no reason to differ. Hoisted here (#222) so the
+//! emitted SQL and row-reshaping logic cannot drift between adapters the way
+//! `rowhash.rs` already prevents for content hashing.
+//!
+//! This module is always compiled (no `native` deps): both the plugin and the
+//! wasm adapter depend on smugglr-core with `default-features = false` and
+//! call straight into here.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+/// Build an `INSERT OR REPLACE` batch statement plus its flattened params.
+pub fn generate_batch_sql(
+    table: &str,
+    columns: &[String],
+    rows: &[HashMap<String, Value>],
+) -> (String, Vec<Value>) {
+    let col_list = columns
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let row_placeholder = format!("({})", vec!["?"; columns.len()].join(", "));
+    let all_placeholders = vec![row_placeholder.as_str(); rows.len()].join(", ");
+
+    let sql = format!(
+        "INSERT OR REPLACE INTO \"{}\" ({}) VALUES {}",
+        table, col_list, all_placeholders
+    );
+
+    let params: Vec<Value> = rows
+        .iter()
+        .flat_map(|row| {
+            columns
+                .iter()
+                .map(|c| row.get(c).cloned().unwrap_or(Value::Null))
+        })
+        .collect();
+
+    (sql, params)
+}
+
+/// Reshape positional result rows into per-row column->value maps.
+pub fn rows_to_maps(columns: &[String], rows: &[Vec<Value>]) -> Vec<HashMap<String, Value>> {
+    rows.iter()
+        .map(|row| {
+            columns
+                .iter()
+                .zip(row.iter())
+                .map(|(col, val)| (col.clone(), val.clone()))
+                .collect()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_row(id: i64, name: &str) -> HashMap<String, Value> {
+        let mut row = HashMap::new();
+        row.insert("id".to_string(), Value::from(id));
+        row.insert("name".to_string(), Value::from(name));
+        row
+    }
+
+    #[test]
+    fn generate_batch_sql_single_row() {
+        let rows = vec![make_row(1, "alice")];
+        let columns = vec!["id".to_string(), "name".to_string()];
+        let (sql, params) = generate_batch_sql("users", &columns, &rows);
+
+        assert!(sql.starts_with("INSERT OR REPLACE INTO \"users\""));
+        assert!(sql.contains("(?, ?)"));
+        assert!(!sql.contains("), ("));
+        assert_eq!(params.len(), 2);
+    }
+
+    #[test]
+    fn generate_batch_sql_multi_row() {
+        let rows = vec![
+            make_row(1, "alice"),
+            make_row(2, "bob"),
+            make_row(3, "charlie"),
+        ];
+        let columns = vec!["id".to_string(), "name".to_string()];
+        let (sql, params) = generate_batch_sql("users", &columns, &rows);
+
+        assert!(sql.contains("(?, ?), (?, ?), (?, ?)"));
+        assert_eq!(params.len(), 6);
+    }
+
+    #[test]
+    fn generate_batch_sql_null_for_missing_column() {
+        let mut row = HashMap::new();
+        row.insert("id".to_string(), Value::from(1));
+        // "name" is missing from this row
+        let columns = vec!["id".to_string(), "name".to_string()];
+        let (_, params) = generate_batch_sql("users", &columns, &[row]);
+
+        assert_eq!(params[0], Value::from(1));
+        assert_eq!(params[1], Value::Null);
+    }
+
+    /// Snapshot test pinning the exact emitted SQL string for issue #222: the
+    /// hoist from the plugin and wasm-adapter duplicates must not change a
+    /// single byte of output. This is the byte-identical string both
+    /// duplicated copies produced before the hoist.
+    #[test]
+    fn generate_batch_sql_snapshot_two_rows_three_columns() {
+        let columns = vec!["id".to_string(), "name".to_string(), "score".to_string()];
+        let mut row1 = HashMap::new();
+        row1.insert("id".to_string(), Value::from(1));
+        row1.insert("name".to_string(), Value::from("alice"));
+        row1.insert("score".to_string(), Value::from(10));
+        let mut row2 = HashMap::new();
+        row2.insert("id".to_string(), Value::from(2));
+        row2.insert("name".to_string(), Value::from("bob"));
+        row2.insert("score".to_string(), Value::from(20));
+
+        let (sql, params) = generate_batch_sql("scores", &columns, &[row1, row2]);
+
+        assert_eq!(
+            sql,
+            "INSERT OR REPLACE INTO \"scores\" (\"id\", \"name\", \"score\") VALUES (?, ?, ?), (?, ?, ?)"
+        );
+        assert_eq!(
+            params,
+            vec![
+                Value::from(1),
+                Value::from("alice"),
+                Value::from(10),
+                Value::from(2),
+                Value::from("bob"),
+                Value::from(20),
+            ]
+        );
+    }
+
+    // Batch-size/param-limit chunking is adapter policy (max_rows_per_batch
+    // lives in each adapter, not here) -- that behavior stays tested in
+    // plugins/smugglr-http-sql/src/adapter.rs::batch_splitting_respects_param_limit
+    // and crates/smugglr-wasm/src/local_adapter.rs. This module only owns SQL
+    // generation for an already-chunked batch, which the snapshot test above
+    // and the tests below cover.
+
+    #[test]
+    fn rows_to_maps_basic() {
+        let columns = vec!["id".to_string(), "name".to_string()];
+        let rows = vec![
+            vec![Value::from(1), Value::from("alice")],
+            vec![Value::from(2), Value::from("bob")],
+        ];
+        let maps = rows_to_maps(&columns, &rows);
+        assert_eq!(maps.len(), 2);
+        assert_eq!(maps[0]["name"], "alice");
+        assert_eq!(maps[1]["id"], 2);
+    }
+}

--- a/crates/smugglr-core/src/lib.rs
+++ b/crates/smugglr-core/src/lib.rs
@@ -9,6 +9,7 @@
 //! reached through `PluginDataSource`. Without `native`, only the diff/sync
 //! engine and trait definitions are available.
 
+pub mod batch_sql;
 pub mod config;
 pub mod datasource;
 pub mod diff;

--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -19,6 +19,12 @@ use serde_json::Value;
 pub(crate) use smugglr_core::rowhash::content_hash;
 pub(crate) use smugglr_core::rowhash::pk_text_expr as build_pk_text_expr;
 
+// Batch-SQL generation and row reshaping -- the one canonical definition
+// lives in smugglr-core::batch_sql so the http-sql plugin and wasm adapters
+// cannot drift (#222). Re-exported under the names this crate already uses.
+pub(crate) use smugglr_core::batch_sql::generate_batch_sql;
+pub(crate) use smugglr_core::batch_sql::rows_to_maps;
+
 /// Parse the rows of a `PRAGMA table_info(...)` result into a [`TableInfo`].
 ///
 /// Shared by both adapters, which differ only in how they obtain the
@@ -64,19 +70,6 @@ pub(crate) fn parse_table_info(table: &str, columns: &[String], rows: &[Vec<Valu
         columns: col_infos,
         primary_key,
     }
-}
-
-/// Reshape positional result rows into per-row column->value maps.
-pub(crate) fn rows_to_maps(columns: &[String], rows: &[Vec<Value>]) -> Vec<HashMap<String, Value>> {
-    rows.iter()
-        .map(|row| {
-            columns
-                .iter()
-                .zip(row.iter())
-                .map(|(col, val)| (col.clone(), val.clone()))
-                .collect()
-        })
-        .collect()
 }
 
 /// Convert result rows (each with a synthetic `__pk` column) into RowMeta
@@ -181,38 +174,6 @@ where
         .unwrap()
         .insert(table.to_string(), info.clone());
     Ok(info)
-}
-
-/// Build an `INSERT OR REPLACE` batch statement plus its flattened params.
-pub(crate) fn generate_batch_sql(
-    table: &str,
-    columns: &[String],
-    rows: &[HashMap<String, Value>],
-) -> (String, Vec<Value>) {
-    let col_list = columns
-        .iter()
-        .map(|c| format!("\"{}\"", c))
-        .collect::<Vec<_>>()
-        .join(", ");
-
-    let row_placeholder = format!("({})", vec!["?"; columns.len()].join(", "));
-    let all_placeholders = vec![row_placeholder.as_str(); rows.len()].join(", ");
-
-    let sql = format!(
-        "INSERT OR REPLACE INTO \"{}\" ({}) VALUES {}",
-        table, col_list, all_placeholders
-    );
-
-    let params: Vec<Value> = rows
-        .iter()
-        .flat_map(|row| {
-            columns
-                .iter()
-                .map(|c| row.get(c).cloned().unwrap_or(Value::Null))
-        })
-        .collect();
-
-    (sql, params)
 }
 
 #[cfg(test)]

--- a/plugins/smugglr-http-sql/src/adapter.rs
+++ b/plugins/smugglr-http-sql/src/adapter.rs
@@ -147,18 +147,6 @@ impl HttpSqlAdapter {
         Err(PluginError::new("columns not found in response"))
     }
 
-    fn rows_to_maps(&self, columns: &[String], rows: &[Vec<Value>]) -> Vec<HashMap<String, Value>> {
-        rows.iter()
-            .map(|row| {
-                columns
-                    .iter()
-                    .zip(row.iter())
-                    .map(|(col, val)| (col.clone(), val.clone()))
-                    .collect()
-            })
-            .collect()
-    }
-
     /// Maximum rows per batch for a given column count and bind param limit.
     /// Returns `None` when there is no limit (max_bind_params == 0).
     fn max_rows_per_batch(num_columns: usize, max_bind_params: usize) -> Option<usize> {
@@ -167,38 +155,6 @@ impl HttpSqlAdapter {
         } else {
             None
         }
-    }
-
-    /// Generate a multi-row INSERT OR REPLACE statement with flattened params.
-    fn generate_batch_sql(
-        table: &str,
-        columns: &[String],
-        rows: &[HashMap<String, Value>],
-    ) -> (String, Vec<Value>) {
-        let col_list = columns
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        let row_placeholder = format!("({})", vec!["?"; columns.len()].join(", "));
-        let all_placeholders = vec![row_placeholder.as_str(); rows.len()].join(", ");
-
-        let sql = format!(
-            "INSERT OR REPLACE INTO \"{}\" ({}) VALUES {}",
-            table, col_list, all_placeholders
-        );
-
-        let params: Vec<Value> = rows
-            .iter()
-            .flat_map(|row| {
-                columns
-                    .iter()
-                    .map(|c| row.get(c).cloned().unwrap_or(Value::Null))
-            })
-            .collect();
-
-        (sql, params)
     }
 }
 
@@ -315,7 +271,7 @@ impl PluginAdapter for HttpSqlAdapter {
         let response = self.execute(&sql, &[]).await?;
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
-        let maps = self.rows_to_maps(&columns, &rows);
+        let maps = smugglr_core::batch_sql::rows_to_maps(&columns, &rows);
         Ok(build_row_metadata(
             &maps,
             &column_order,
@@ -342,7 +298,7 @@ impl PluginAdapter for HttpSqlAdapter {
         let response = self.execute(&sql, &params).await?;
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
-        Ok(self.rows_to_maps(&columns, &rows))
+        Ok(smugglr_core::batch_sql::rows_to_maps(&columns, &rows))
     }
 
     async fn upsert_rows(
@@ -360,7 +316,7 @@ impl PluginAdapter for HttpSqlAdapter {
 
         let mut total = 0;
         for batch in rows.chunks(batch_size) {
-            let (sql, params) = Self::generate_batch_sql(table, &columns, batch);
+            let (sql, params) = smugglr_core::batch_sql::generate_batch_sql(table, &columns, batch);
 
             self.execute(&sql, &params).await.map_err(|e| {
                 PluginError::new(format!(
@@ -532,26 +488,9 @@ mod tests {
         assert_ne!(hash1, hash2);
     }
 
-    #[test]
-    fn test_rows_to_maps() {
-        let adapter = HttpSqlAdapter::new();
-        let columns = vec!["id".into(), "name".into()];
-        let rows = vec![
-            vec![Value::from(1), Value::from("alice")],
-            vec![Value::from(2), Value::from("bob")],
-        ];
-        let maps = adapter.rows_to_maps(&columns, &rows);
-        assert_eq!(maps.len(), 2);
-        assert_eq!(maps[0]["name"], "alice");
-        assert_eq!(maps[1]["id"], 2);
-    }
-
-    fn make_row(id: i64, name: &str) -> HashMap<String, Value> {
-        let mut row = HashMap::new();
-        row.insert("id".to_string(), Value::from(id));
-        row.insert("name".to_string(), Value::from(name));
-        row
-    }
+    // test_rows_to_maps and the generate_batch_sql_* unit tests moved to
+    // smugglr_core::batch_sql (#222) alongside the hoisted implementations --
+    // the plugin no longer owns a private copy of either function to test.
 
     #[test]
     fn batch_size_no_limit() {
@@ -582,44 +521,6 @@ mod tests {
     }
 
     #[test]
-    fn generate_batch_sql_single_row() {
-        let rows = vec![make_row(1, "alice")];
-        let columns = vec!["id".to_string(), "name".to_string()];
-        let (sql, params) = HttpSqlAdapter::generate_batch_sql("users", &columns, &rows);
-
-        assert!(sql.starts_with("INSERT OR REPLACE INTO \"users\""));
-        assert!(sql.contains("(?, ?)"));
-        assert!(!sql.contains("), ("));
-        assert_eq!(params.len(), 2);
-    }
-
-    #[test]
-    fn generate_batch_sql_multi_row() {
-        let rows = vec![
-            make_row(1, "alice"),
-            make_row(2, "bob"),
-            make_row(3, "charlie"),
-        ];
-        let columns = vec!["id".to_string(), "name".to_string()];
-        let (sql, params) = HttpSqlAdapter::generate_batch_sql("users", &columns, &rows);
-
-        assert!(sql.contains("(?, ?), (?, ?), (?, ?)"));
-        assert_eq!(params.len(), 6);
-    }
-
-    #[test]
-    fn generate_batch_sql_null_for_missing_column() {
-        let mut row = HashMap::new();
-        row.insert("id".to_string(), Value::from(1));
-        // "name" is missing from this row
-        let columns = vec!["id".to_string(), "name".to_string()];
-        let (_, params) = HttpSqlAdapter::generate_batch_sql("users", &columns, &[row]);
-
-        assert_eq!(params[0], Value::from(1));
-        assert_eq!(params[1], Value::Null);
-    }
-
-    #[test]
     fn batch_splitting_respects_param_limit() {
         // 10 columns, 100 param limit -> max 10 rows per batch
         let columns: Vec<String> = (0..10).map(|i| format!("col_{}", i)).collect();
@@ -644,7 +545,7 @@ mod tests {
 
         // Verify no batch exceeds param limit
         for batch in &batches {
-            let (_, params) = HttpSqlAdapter::generate_batch_sql("test", &columns, batch);
+            let (_, params) = smugglr_core::batch_sql::generate_batch_sql("test", &columns, batch);
             assert!(params.len() <= 100);
         }
     }


### PR DESCRIPTION
## Summary

Hoists the byte-identical `generate_batch_sql` and `rows_to_maps` pure functions --
previously duplicated in `plugins/smugglr-http-sql/src/adapter.rs` and
`crates/smugglr-wasm/src/adapter_common.rs` -- into a single canonical home,
`crates/smugglr-core/src/batch_sql.rs`, following the same always-compiled-module
pattern already established by `smugglr-core::rowhash`. Both adapters now call the
shared implementation instead of maintaining their own copy; the emitted SQL is pinned
byte-for-byte by a new snapshot test. Fixes #222.

## Acceptance criteria mapping

### 1. All tests pass (including a regression test that fails before the fix)

This is a behavior-preserving refactor, not a bug fix, so there is no failing-before
regression to reproduce -- the equivalent forcing function here is a snapshot test that
pins the exact pre-hoist SQL output, which would fail if the hoist changed a single
byte of behavior. I confirmed the four original function bodies (plugin
`rows_to_maps`/`generate_batch_sql` at the old `adapter.rs:150-160`/`:172-202`, wasm
`adapter_common.rs:70-80`/`:187-216`) were identical apart from receiver/visibility
wrapping before touching anything, then moved the logic verbatim into
`crates/smugglr-core/src/batch_sql.rs`. All call sites were updated to the shared
functions and the full test matrix passes: `cargo test -p smugglr-core` (batch_sql
module: 5/5; the 5 `multicast::tests::*` failures are pre-existing local UDP-port-bind
flakes unrelated to this change, as called out in the task), `cargo test -p
smugglr-http-sql` (11/11), `cargo test --workspace` (same result), `cargo build`,
`cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `cargo check
-p smugglr-wasm --target wasm32-unknown-unknown`, and `cargo clippy -p smugglr-wasm
--target wasm32-unknown-unknown --all-targets -- -D warnings` -- all clean.
Evidence: `crates/smugglr-core/src/batch_sql.rs::tests::generate_batch_sql_snapshot_two_rows_three_columns`
asserts the exact string `INSERT OR REPLACE INTO "scores" ("id", "name", "score")
VALUES (?, ?, ?), (?, ?, ?)`.

### 2. Simplify pass completed

Ran `/legion-simplify` over the diff and validated with `legion quality-gate check
--skill legion-simplify`. Beyond the mechanical hoist, I removed now-redundant tests
from the plugin (`test_rows_to_maps` and the three `generate_batch_sql_*` unit tests,
plus their orphaned `make_row` helper) since that coverage now lives exactly once in
`smugglr-core::batch_sql::tests`, and deliberately did not add a param-limit-chunking
test to the new core module -- that policy (`max_rows_per_batch`) is adapter-specific
and stays tested where it's defined, in the plugin and in
`crates/smugglr-wasm/src/local_adapter.rs`.
Evidence: gate id `019f620d-e746-76d1-9f3b-cd02f17bb64f` (articulation accepted, 0
findings).

### 3. Review pass completed and issues fixed

Not yet run -- this PR is being opened for `/legion-review` per the standard pipeline
(simplify -> pr-write -> review -> fix). This criterion will be satisfied by a
follow-up review pass on this open PR before merge; it is not claimed as complete in
this body.
Evidence: no `legion-review` gate is recorded for this card yet -- `legion
quality-gate list --repo smugglr --card 019e98dc-b724-7092-a93b-445ddae8e625` shows
only the `legion-simplify` gate (id `019f620d-e746-76d1-9f3b-cd02f17bb64f`) at the
time this PR is opened; the review gate will appear there once `/legion-review` runs
against this PR.

### 4. PR created and linked to this issue

This PR is opened via `legion pr create --repo smugglr --issue 222`, referencing #222
in the title and this body, with the card task ID attached.
Evidence: PR title `refactor(#222): hoist generate_batch_sql and rows_to_maps into
smugglr-core`.

## Not done

- Content-hash extraction (`content_hash`, `pk_text_expr` in `smugglr-core::rowhash`)
  is explicitly out of scope per the issue -- untouched here.
- `build_row_metadata` (plugin) / `row_maps_to_metadata` (wasm), the NULL-/duplicate
  primary-key guards, are plugin-local and wasm-local respectively, not the
  cross-crate dedup this issue tracks -- left in place in both files.
- `max_rows_per_batch`, the adapter-specific bind-param-limit policy, is not one of
  the two functions named in the issue -- left in place in both the plugin and
  `local_adapter.rs`.
- The review pass (criterion 3 above) has not yet run; it is the next step after this
  PR opens, not something this PR claims to have completed.