### PR TITLE
refactor(#218): mark watch dry-run text output as a dry run

### DIFF
--- a/crates/smugglr/src/watch.rs
+++ b/crates/smugglr/src/watch.rs
@@ -88,8 +88,9 @@ pub async fn run_watch(
                             println!("{}", serde_json::to_string(&out).expect("WatchTickOutput is always serializable"));
                         } else if total_pushed > 0 || total_pulled > 0 {
                             info!(
-                                "Tick #{}: {} pushed, {} pulled across {} tables",
-                                tick_count, total_pushed, total_pulled, results.len()
+                                "Tick #{}: {}",
+                                tick_count,
+                                format_tick_summary(total_pushed, total_pulled, results.len(), dry_run)
                             );
                         } else {
                             info!("Tick #{}: no changes", tick_count);
@@ -135,6 +136,28 @@ pub async fn run_watch(
 
     info!("Watch daemon stopped after {} ticks", tick_count);
     Ok(())
+}
+
+/// Format the text-mode "N pushed, M pulled" summary for a watch tick.
+///
+/// When `dry_run` is true, appends the same `(dry run - no actual changes
+/// made)` marker `print_summary` and `run_sync` print in main.rs, so a user
+/// watching with `--dry-run` doesn't mistake would-push/would-pull counts
+/// for an applied sync (#218). The leading space (rather than main.rs's
+/// leading `\n  `) matches this being a single-line `info!` log record, not
+/// a multi-line `println!` block. Like `print_summary`, the marker only
+/// applies to this counts branch -- the separate "no changes" tick log
+/// (below) carries no counts to be mistaken for an applied sync, so it is
+/// left unmarked in both modes.
+fn format_tick_summary(pushed: usize, pulled: usize, tables: usize, dry_run: bool) -> String {
+    let mut summary = format!(
+        "{} pushed, {} pulled across {} tables",
+        pushed, pulled, tables
+    );
+    if dry_run {
+        summary.push_str(" (dry run - no actual changes made)");
+    }
+    summary
 }
 
 /// Open the local DB in the same dry-run-readonly mode `run_sync`/`run_pull`
@@ -258,6 +281,39 @@ mod tests {
         assert!(
             write.is_err(),
             "dry-run's target connection must reject writes, but a write succeeded"
+        );
+    }
+
+    /// Regression for #218: the text-mode tick summary must tell the user
+    /// when a tick was a dry run, matching the `(dry run - no actual
+    /// changes made)` wording `print_summary`/`run_sync` use in main.rs.
+    /// Before the fix, `format_tick_summary` did not exist and the tick log
+    /// line never varied on `dry_run` -- a real sync and a dry run produced
+    /// identical text. This asserts the marker is present iff `dry_run` is
+    /// true, and that non-dry-run text is unchanged (no marker, same
+    /// counts/wording).
+    #[test]
+    fn format_tick_summary_marks_dry_run() {
+        let dry = format_tick_summary(3, 5, 2, true);
+        assert!(
+            dry.contains("(dry run - no actual changes made)"),
+            "dry-run tick summary must contain the dry-run marker, got: {:?}",
+            dry
+        );
+        assert_eq!(
+            dry, "3 pushed, 5 pulled across 2 tables (dry run - no actual changes made)",
+            "dry-run tick summary text changed unexpectedly"
+        );
+
+        let real = format_tick_summary(3, 5, 2, false);
+        assert!(
+            !real.contains("dry run"),
+            "non-dry-run tick summary must not mention dry run, got: {:?}",
+            real
+        );
+        assert_eq!(
+            real, "3 pushed, 5 pulled across 2 tables",
+            "non-dry-run tick summary text must stay exactly as before"
         );
     }
 }


### PR DESCRIPTION
## Summary

Text-mode watch ticks logged `Tick #{}: {} pushed, {} pulled across {} tables`
using the would-push/would-pull counts from a `dry_run` `sync_all`, but never
indicated the run was a dry run -- unlike every other command's dry-run text
path (`print_summary` and `run_sync` in main.rs both append `(dry run - no
actual changes made)`). A user running `watch --dry-run` in text mode saw
counts that looked identical to a real applied sync. This change extracts a
pure `format_tick_summary` helper in `crates/smugglr/src/watch.rs` that
appends the same marker wording when `dry_run` is true, leaving non-dry-run
text byte-for-byte unchanged.

## Acceptance criteria mapping

### 1. All tests pass (including a regression test that fails before the fix)

Added `format_tick_summary_marks_dry_run` in `crates/smugglr/src/watch.rs`
(`#[cfg(test)] mod tests`). It asserts `format_tick_summary(3, 5, 2, true)`
contains, and exactly equals, `"3 pushed, 5 pulled across 2 tables (dry run
- no actual changes made)"`, and that `format_tick_summary(3, 5, 2, false)`
contains no "dry run" text and equals the pre-fix string `"3 pushed, 5
pulled across 2 tables"` exactly -- pinning both the new behavior and the
no-regression case in one test.

Fails-before, observed directly: I temporarily reverted `format_tick_summary`'s
body to the pre-fix behavior (ignore `dry_run`, always return the bare
counts string) and ran `cargo test -p smugglr format_tick_summary_marks_dry_run`.
Observed failure:
```
test watch::tests::format_tick_summary_marks_dry_run ... FAILED
thread '...' panicked at crates/smugglr/src/watch.rs:290:9:
dry-run tick summary must contain the dry-run marker, got: "3 pushed, 5 pulled across 2 tables"
```
I then restored the fix, diffed the file against a saved copy of the
intended version (exit 0, byte-identical), and re-ran the full suite green.

Evidence: test `watch::tests::format_tick_summary_marks_dry_run` in
`crates/smugglr/src/watch.rs`, observed pre-fix failure quoted above; full
suite `cargo test -p smugglr -- --skip multicast` -- 29 unit tests + 1
integration test pass, including pre-existing
`open_local_dry_run_connection_rejects_writes`,
`target_source_open_dry_run_connection_rejects_writes`, and JSON-mode golden
`output::tests::golden_watch_tick_dry_run_output`; `cargo clippy -p smugglr
--all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.

### 2. Simplify pass completed

Ran `/legion-simplify` against the diff and articulated per-file findings
for `crates/smugglr/src/watch.rs` (the only changed file -- `output.rs` was
deliberately not touched; see "Not done" below). The articulation covers why
the helper extraction is the minimal seam the issue asked for, why the
marker literal is duplicated rather than shared with main.rs's copies, and
why the "no changes" tick branch is left unmarked. Evidence: quality-gate
id `019f6219-5464-7a01-928d-ae0d664ff6c3`, result clean, 0 findings, 1 file
entry.

### 3. Review pass completed and issues fixed

Will run `/legion-review` against this PR once opened, per the pipeline
(simplify -> pr-write -> review -> verify), and address any findings before
this criterion is closed out.

Evidence: pipeline step tracked as a follow-up on this PR; not yet run as
of this PR-write gate (review runs after PR creation per the doctrine
sequence). This entry will be updated with the review gate id after that
pass completes.

### 4. PR created and linked to this issue

This PR is opened from branch `refactor/218-watch-dryrun-text` against
`main`, created via `legion pr create --repo smugglr --title
"refactor(#218): mark watch dry-run text output as a dry run" --body
"$(cat /tmp/pr-218.md)" --task 019e98dc-b725-72d2-aaf1-eed8cfd30e1c`, which
links the PR to card `019e98dc-b725-72d2-aaf1-eed8cfd30e1c` (issue #218).

Evidence: PR URL/number returned by the `legion pr create` invocation
above, and the `--task` flag binding the PR to card
`019e98dc-b725-72d2-aaf1-eed8cfd30e1c`.

## Not done

Did not touch `output.rs`. The dry-run marker literal (`"(dry run - no
actual changes made)"`) already exists twice in main.rs (`print_summary`,
`run_sync`); I did not extract a third, shared constant or formatting
function for it. main.rs's two call sites use it inside a `println!` block
with a leading `"\n  "` (paragraph spacing), while watch.rs's call site is a
single-line `tracing::info!` record with a leading `" "` -- different
formatting conventions for the same wording, so sharing a formatter would
need a parameter just to toggle line-break style. Three call sites didn't
justify that; the wording the issue asked to match is identical, the
surrounding punctuation is not, by design.

Did not add a marker to the "no changes" tick log line (`"Tick #{}: no
changes"`), matching `print_summary`'s existing convention of only marking
the has-changes branch, not the "No changes to sync" branch.

Did not change the JSON output path (`WatchTickOutput::from_results` in
`output.rs`) or its golden test -- it already carries a `dry_run` field
end-to-end and was already correct.

Did not touch `open_local` or the dry-run-readonly connection logic below
it in the same file -- that is issue #217, already merged in this branch's
history, out of scope here.

No broader structural extraction of the tick log/summary logic beyond this
defect, per the issue's explicit "Out of Scope" note.