### PR TITLE
refactor(#227): extract a shared createPersistBinding for the zustand and nanostores plugins

### DIFF
--- a/packages/nanostores-plugin/src/index.test.ts
+++ b/packages/nanostores-plugin/src/index.test.ts
@@ -178,4 +178,24 @@ describe("@smugglr/nanostores", () => {
       expect(JSON.parse(stored.value)).toBe(0);
     }
   });
+
+  it("rejects an unsafe table identifier synchronously", () => {
+    const { executor } = fixtureExecutor();
+    const smugglr = fixtureSmugglr();
+    const $count = atom(0);
+
+    // The shared createPersistBinding core validates `table` with the same
+    // identifier guard autoSync uses (packages/smugglr/src/autoSync.ts
+    // quoteIdent) before building any SQL. A crafted table name that would
+    // break out of the quoted identifier must throw at construction time
+    // rather than being interpolated into HYDRATE_SQL/UPSERT_SQL.
+    expect(() =>
+      smuggl($count, {
+        smugglr,
+        executor,
+        table: 'app_state"; DROP TABLE app_state; --',
+        key: "count",
+      }),
+    ).toThrow();
+  });
 });

--- a/packages/nanostores-plugin/src/index.ts
+++ b/packages/nanostores-plugin/src/index.ts
@@ -10,7 +10,8 @@
 //     updated_at TEXT
 //   );
 
-import type { Smugglr, SqlExecutor, TableChangedEvent } from "smugglr";
+import type { Smugglr, SqlExecutor } from "smugglr";
+import { createPersistBinding } from "smugglr";
 import type { Atom, MapStore, ReadableAtom } from "nanostores";
 
 export interface SmugglOptions<T> {
@@ -32,13 +33,6 @@ export interface SmugglOptions<T> {
   /** Called once after the initial hydration query completes. */
   onHydrate?: (hydrated: T | null) => void;
 }
-
-const HYDRATE_SQL = (table: string) =>
-  `SELECT value FROM "${table}" WHERE key = ? LIMIT 1`;
-
-const UPSERT_SQL = (table: string) =>
-  `INSERT INTO "${table}" (key, value, updated_at) VALUES (?, ?, ?)
-   ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`;
 
 /** A nanostore that supports `.get()` and `.set()` -- atom or map. */
 type WritableStore<T> = ReadableAtom<T> & { set(value: T): void };
@@ -70,75 +64,34 @@ export function smuggl<T>(
   const writable = store as WritableStore<T>;
   const serialize = options.serialize ?? JSON.stringify;
   const deserialize = options.deserialize ?? JSON.parse;
-  const upsertSql = UPSERT_SQL(options.table);
-  const hydrateSql = HYDRATE_SQL(options.table);
 
-  let suppressNextWrite = false;
-  // nanostores' subscribe() fires synchronously with the current value at
-  // attach time. That's not a "change" -- we don't want to persist the
-  // pre-hydration default and stomp the row before hydrate() can read it.
-  let seenInitialFire = false;
-  let lastSerialized: string | null = null;
-
-  const persist = async (value: T) => {
-    const next = serialize(value);
-    if (next === lastSerialized) return;
-    lastSerialized = next;
-    try {
-      await options.executor.run(upsertSql, [options.key, next, new Date().toISOString()]);
-    } catch (err) {
-      console.warn("[@smugglr/nanostores] persist failed:", err);
-    }
-  };
-
-  const hydrate = async () => {
-    try {
-      const result = await options.executor.run(hydrateSql, [options.key]);
-      if (result.rows.length === 0) {
-        options.onHydrate?.(null);
-        return;
-      }
-      const raw = result.rows[0][0];
-      if (typeof raw !== "string") {
-        options.onHydrate?.(null);
-        return;
-      }
-      const parsed = deserialize(raw) as T;
-      lastSerialized = raw;
-      suppressNextWrite = true;
-      writable.set(parsed);
-      options.onHydrate?.(parsed);
-    } catch (err) {
-      console.warn("[@smugglr/nanostores] hydrate failed:", err);
-      options.onHydrate?.(null);
-    }
-  };
-
-  const unsubStore = writable.subscribe((value) => {
-    if (!seenInitialFire) {
-      seenInitialFire = true;
-      return;
-    }
-    if (suppressNextWrite) {
-      suppressNextWrite = false;
-      return;
-    }
-    void persist(value);
+  const binding = createPersistBinding<T>({
+    smugglr: options.smugglr,
+    executor: options.executor,
+    table: options.table,
+    key: options.key,
+    serialize,
+    deserialize,
+    applyHydrated: (parsed) => writable.set(parsed),
+    onHydrate: options.onHydrate,
+    subscribe: (notify) => {
+      // nanostores' subscribe() fires synchronously with the current value
+      // at attach time. That's not a "change" -- we don't want to persist
+      // the pre-hydration default and stomp the row before hydrate() can
+      // read it.
+      let seenInitialFire = false;
+      return writable.subscribe((value) => {
+        if (!seenInitialFire) {
+          seenInitialFire = true;
+          return;
+        }
+        notify(value);
+      });
+    },
+    logPrefix: "[@smugglr/nanostores]",
   });
 
-  const unsubSmugglr = options.smugglr.on(
-    "table-changed",
-    (event: TableChangedEvent) => {
-      if (event.table !== options.table) return;
-      if (!event.changedPks.includes(options.key)) return;
-      void hydrate();
-    },
-  );
-
-  void hydrate();
-
   return () => {
-    unsubStore();
-    unsubSmugglr();
+    binding.dispose();
   };
 }

--- a/packages/smugglr/src/autoSync.ts
+++ b/packages/smugglr/src/autoSync.ts
@@ -160,7 +160,14 @@ async function isLocalEmpty(
   return true;
 }
 
-function quoteIdent(name: string): string {
+/**
+ * Quote a SQL identifier, refusing anything that is not a plain
+ * `[A-Za-z_][A-Za-z0-9_]*` name. Shared by autoSync's empty-table probe and
+ * the persist-binding core (`persistBinding.ts`) -- both build table-name
+ * SQL from caller-supplied strings and need the same guard against
+ * injection via a crafted `table` option.
+ */
+export function quoteIdent(name: string): string {
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
     throw new Error(`autoSync: refusing unsafe table identifier "${name}"`);
   }

--- a/packages/smugglr/src/index.ts
+++ b/packages/smugglr/src/index.ts
@@ -41,6 +41,12 @@ export type {
 export { SmugglrError };
 export { createWaSqliteExecutor } from "./opfs.js";
 export type { WaSqlite3 } from "./opfs.js";
+export { createPersistBinding } from "./persistBinding.js";
+export type {
+  CreatePersistBindingOptions,
+  PersistBinding,
+  PersistBindingSource,
+} from "./persistBinding.js";
 
 // WASM module state -- loaded lazily or set explicitly via setWasm().
 let wasmModule: WasmModule | null = null;

--- a/packages/smugglr/src/persistBinding.ts
+++ b/packages/smugglr/src/persistBinding.ts
@@ -1,0 +1,162 @@
+// Shared persistence core for smugglr's state-library plugins (zustand,
+// nanostores, and any future adapter). Owns the SQL constants, the
+// persist/hydrate round trip, the dedup-by-lastSerialized + suppress-loop
+// guard, and the `table-changed` event matcher. Each plugin keeps its own
+// store-specific glue (zustand's `include()` projection, nanostores'
+// `seenInitialFire` skip) and wires it in through `subscribe` /
+// `applyHydrated` rather than having it flattened into this module.
+//
+// Persistence shape (one row per key, multiple keys can share a table):
+//   CREATE TABLE <table> (
+//     key TEXT PRIMARY KEY,
+//     value TEXT NOT NULL,
+//     updated_at TEXT
+//   );
+
+import type { SqlExecutor, TableChangedEvent, Unsubscribe } from "./types.js";
+import { quoteIdent } from "./autoSync.js";
+
+/** Minimal event source contract -- satisfied by `Pick<Smugglr, "on">`. */
+export interface PersistBindingSource {
+  on(
+    event: "table-changed",
+    handler: (event: TableChangedEvent) => void,
+  ): Unsubscribe;
+}
+
+export interface CreatePersistBindingOptions<T> {
+  /** Smugglr instance (or a stub) used for change-event subscription. */
+  smugglr: PersistBindingSource;
+  /** Local SQL executor used for direct read/write of the persistence row. */
+  executor: SqlExecutor;
+  /**
+   * Table that stores the persisted row. Caller owns the DDL:
+   * `CREATE TABLE <table> (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT)`.
+   * Validated with the same identifier guard autoSync uses (`quoteIdent`);
+   * an unsafe table name throws at construction time.
+   */
+  table: string;
+  /** Primary key for this binding's row. Use distinct keys when multiple bindings share a table. */
+  key: string;
+  /** Serializer for the persisted value. */
+  serialize: (value: T) => string;
+  /** Parser for the persisted value. */
+  deserialize: (raw: string) => T;
+  /**
+   * Applies a hydrated value to the underlying store/atom. Called with the
+   * suppress-next-write guard already armed, so if this triggers a
+   * synchronous write back through `subscribe`, that write is swallowed
+   * instead of looping into a redundant persist.
+   */
+  applyHydrated: (value: T) => void;
+  /** Called once after every hydrate attempt, whether or not a row existed. */
+  onHydrate?: (hydrated: T | null) => void;
+  /**
+   * Attaches a listener for local writes that are candidates for
+   * persistence. Callers apply their own store-specific pre-filtering here
+   * (zustand's `include()` projection, nanostores' `seenInitialFire` skip
+   * on the synchronous first fire) before invoking `notify`. Must return an
+   * unsubscribe function.
+   */
+  subscribe: (notify: (value: T) => void) => Unsubscribe;
+  /** Prefix used on `console.warn` messages, e.g. "[@smugglr/zustand]". */
+  logPrefix: string;
+}
+
+export interface PersistBinding {
+  /**
+   * Detaches the store listener and the `table-changed` listener. Does not
+   * roll back the persisted row -- the data stays put.
+   */
+  dispose(): void;
+}
+
+/**
+ * Shared persist/hydrate core for smugglr's state-library plugins.
+ *
+ * Runs an initial hydrate on construction (fire-and-forget, matching the
+ * plugins' prior behavior).
+ *
+ * @example
+ * ```ts
+ * const binding = createPersistBinding<State>({
+ *   smugglr,
+ *   executor,
+ *   table: "app_state",
+ *   key: "todos",
+ *   serialize: JSON.stringify,
+ *   deserialize: JSON.parse,
+ *   applyHydrated: (v) => store.set(v),
+ *   subscribe: (notify) => store.subscribe(notify),
+ *   logPrefix: "[@smugglr/example]",
+ * });
+ * ```
+ */
+export function createPersistBinding<T>(
+  options: CreatePersistBindingOptions<T>,
+): PersistBinding {
+  const safeTable = quoteIdent(options.table);
+  const upsertSql = `INSERT INTO ${safeTable} (key, value, updated_at) VALUES (?, ?, ?)
+   ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`;
+  const hydrateSql = `SELECT value FROM ${safeTable} WHERE key = ? LIMIT 1`;
+
+  let suppressNextWrite = false;
+  let lastSerialized: string | null = null;
+
+  const persist = async (value: T): Promise<void> => {
+    const next = options.serialize(value);
+    if (next === lastSerialized) return;
+    lastSerialized = next;
+    try {
+      await options.executor.run(upsertSql, [options.key, next, new Date().toISOString()]);
+    } catch (err) {
+      console.warn(`${options.logPrefix} persist failed:`, err);
+    }
+  };
+
+  const hydrate = async (): Promise<void> => {
+    try {
+      const result = await options.executor.run(hydrateSql, [options.key]);
+      if (result.rows.length === 0) {
+        options.onHydrate?.(null);
+        return;
+      }
+      const raw = result.rows[0][0];
+      if (typeof raw !== "string") {
+        options.onHydrate?.(null);
+        return;
+      }
+      const parsed = options.deserialize(raw);
+      lastSerialized = raw;
+      suppressNextWrite = true;
+      options.applyHydrated(parsed);
+      options.onHydrate?.(parsed);
+    } catch (err) {
+      console.warn(`${options.logPrefix} hydrate failed:`, err);
+      options.onHydrate?.(null);
+    }
+  };
+
+  const unsubStore = options.subscribe((value) => {
+    if (suppressNextWrite) {
+      suppressNextWrite = false;
+      return;
+    }
+    void persist(value);
+  });
+
+  const unsubSmugglr = options.smugglr.on("table-changed", (event: TableChangedEvent) => {
+    if (event.table !== options.table) return;
+    if (!event.changedPks.includes(options.key)) return;
+    void hydrate();
+  });
+
+  void hydrate();
+
+  return {
+    dispose() {
+      unsubStore();
+      unsubSmugglr();
+    },
+  };
+}

--- a/packages/zustand-plugin/src/index.test.ts
+++ b/packages/zustand-plugin/src/index.test.ts
@@ -176,4 +176,28 @@ describe("@smugglr/zustand", () => {
     await flushMicrotasks();
     expect(onHydrate).toHaveBeenCalledTimes(1);
   });
+
+  it("rejects an unsafe table identifier synchronously", () => {
+    const { executor } = fixtureExecutor();
+    const smugglr = fixtureSmugglr();
+
+    // The shared createPersistBinding core validates `table` with the same
+    // identifier guard autoSync uses (packages/smugglr/src/autoSync.ts
+    // quoteIdent) before building any SQL. A crafted table name that would
+    // break out of the quoted identifier must throw at store-creation time
+    // rather than being interpolated into HYDRATE_SQL/UPSERT_SQL.
+    expect(() =>
+      createStore(
+        smuggl(
+          () => ({ items: [] as string[] }),
+          {
+            smugglr,
+            executor,
+            table: 'app_state"; DROP TABLE app_state; --',
+            key: "todos",
+          },
+        ),
+      ),
+    ).toThrow();
+  });
 });

--- a/packages/zustand-plugin/src/index.ts
+++ b/packages/zustand-plugin/src/index.ts
@@ -8,7 +8,8 @@
 //     updated_at TEXT
 //   );
 
-import type { Smugglr, SqlExecutor, TableChangedEvent } from "smugglr";
+import type { Smugglr, SqlExecutor } from "smugglr";
+import { createPersistBinding } from "smugglr";
 import type { StateCreator, StoreMutatorIdentifier } from "zustand";
 
 export interface SmugglOptions<T, U = T> {
@@ -49,13 +50,6 @@ export type Smuggl = <
   options: SmugglOptions<T, U>,
 ) => StateCreator<T, Mps, Mcs>;
 
-const HYDRATE_SQL = (table: string) =>
-  `SELECT value FROM "${table}" WHERE key = ? LIMIT 1`;
-
-const UPSERT_SQL = (table: string) =>
-  `INSERT INTO "${table}" (key, value, updated_at) VALUES (?, ?, ?)
-   ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`;
-
 /**
  * Zustand middleware that persists a store slice to a smugglr-managed table
  * and rehydrates whenever a sync event touches the same row.
@@ -83,66 +77,25 @@ export const smuggl: Smuggl = (initializer, options) => (set, get, api) => {
   const include = options.include ?? ((s: unknown) => s as never);
   const serialize = options.serialize ?? JSON.stringify;
   const deserialize = options.deserialize ?? JSON.parse;
-  const upsertSql = UPSERT_SQL(options.table);
-  const hydrateSql = HYDRATE_SQL(options.table);
-
-  let suppressNextWrite = false;
-  let lastSerialized: string | null = null;
 
   // Build the underlying store first; subscribe + hydrate after.
   const state = initializer(set, get, api);
 
-  const persist = async (raw: unknown) => {
-    const slice = include(raw as never);
-    const next = serialize(slice);
-    if (next === lastSerialized) return;
-    lastSerialized = next;
-    try {
-      await options.executor.run(upsertSql, [options.key, next, new Date().toISOString()]);
-    } catch (err) {
-      console.warn("[@smugglr/zustand] persist failed:", err);
-    }
-  };
-
-  const hydrate = async () => {
-    try {
-      const result = await options.executor.run(hydrateSql, [options.key]);
-      if (result.rows.length === 0) {
-        options.onHydrate?.(null);
-        return;
-      }
-      const raw = result.rows[0][0];
-      if (typeof raw !== "string") {
-        options.onHydrate?.(null);
-        return;
-      }
-      const parsed = deserialize(raw);
-      lastSerialized = raw;
-      suppressNextWrite = true;
-      // Merge the hydrated slice into the live store.
-      set(parsed as never, false);
-      options.onHydrate?.(parsed);
-    } catch (err) {
-      console.warn("[@smugglr/zustand] hydrate failed:", err);
-      options.onHydrate?.(null);
-    }
-  };
-
-  api.subscribe((next) => {
-    if (suppressNextWrite) {
-      suppressNextWrite = false;
-      return;
-    }
-    void persist(next);
+  createPersistBinding({
+    smugglr: options.smugglr,
+    executor: options.executor,
+    table: options.table,
+    key: options.key,
+    serialize,
+    deserialize,
+    // Merge the hydrated slice into the live store.
+    applyHydrated: (parsed) => set(parsed as never, false),
+    onHydrate: options.onHydrate,
+    // include() is zustand's projection: persist include(state), not the
+    // full state.
+    subscribe: (notify) => api.subscribe((next) => notify(include(next as never))),
+    logPrefix: "[@smugglr/zustand]",
   });
-
-  options.smugglr.on("table-changed", (event: TableChangedEvent) => {
-    if (event.table !== options.table) return;
-    if (!event.changedPks.includes(options.key)) return;
-    void hydrate();
-  });
-
-  void hydrate();
 
   return state;
 };


### PR DESCRIPTION
## Summary

`@smugglr/zustand` and `@smugglr/nanostores` each carried a near-identical
persist/hydrate/event-matcher/suppress-loop implementation, plus
byte-identical `HYDRATE_SQL`/`UPSERT_SQL` string builders. This hoists that
shared core into `createPersistBinding(...)` in the `smugglr` package
(`packages/smugglr/src/persistBinding.ts`), exported from
`packages/smugglr/src/index.ts`, and rewrites both plugins to call it.

## Acceptance criteria mapping

### 1. All tests pass (including a regression test that fails before the fix)

The issue's Requirements section mandated folding the `quoteIdent` guard
(`packages/smugglr/src/autoSync.ts:170`, "the canonical guard... BOTH
plugins currently omit") into the SQL builders. That guard is the one
genuine behavior delta in this refactor -- everything else is pure
extraction of existing logic. It has a real fails-before/passes-after
regression test: `packages/zustand-plugin/src/index.test.ts:180-202` and
`packages/nanostores-plugin/src/index.test.ts:182-200` each assert that
constructing the binding with `table: 'app_state"; DROP TABLE app_state;
--'` throws synchronously.

Fails before: verified by reading the pre-refactor `smuggl` bodies (this
branch's own `git diff`). Both built `` `SELECT value FROM "${table}" WHERE
key = ? LIMIT 1` `` / `` `INSERT INTO "${table}" ...` `` via plain template
interpolation, with no identifier validation anywhere in the call path --
constructing the store/binding with this `table` value could not throw
synchronously before this change. (The crafted string is itself a
syntactically valid double-quoted SQLite identifier containing `"` and `;`,
so it wasn't rejected by SQL syntax either -- only the new guard catches
it.)

Passes after: `createPersistBinding` calls `quoteIdent(options.table)`
(`persistBinding.ts:98`) before building either SQL string, and
`quoteIdent` throws for anything that doesn't match
`^[A-Za-z_][A-Za-z0-9_]*$` (`autoSync.ts:171-173`).

Every other behavior in the extraction is preservation, not new coverage,
because it was already covered before this change: both plugins had
pre-existing hydrate/persist/re-hydrate/suppress-loop/dispose tests
(`zustand-plugin/src/index.test.ts`, `nanostores-plugin/src/index.test.ts`)
exercising exactly the logic now living in `persistBinding.ts`. Those
suites are unchanged apart from the one new test each, and all pass against
the refactored implementation -- that is the preservation proof for the
extraction.

Evidence: `packages/zustand-plugin/src/index.test.ts:180-202` (new test),
5/5 tests green; `packages/nanostores-plugin/src/index.test.ts:182-200`
(new test), 7/7 tests green; `persistBinding.ts:98` (`quoteIdent` call
site); `autoSync.ts:171-173` (`quoteIdent` implementation). Commands and
output in "Test plan" below.

### 2. Simplify pass completed

Ran `/legion-simplify` equivalent over every changed file (5 source/export
files plus the 2 test files that gained the new regression test) and
recorded the gate.

Evidence: `legion quality-gate check --skill legion-simplify --result clean
--findings-count 0 --articulation-file /tmp/simplify-227.md` accepted, gate
id `019f6211-dacd-7b60-9ed5-56686fe6f145`, 7 file entries, 0 findings.

### 3. Review pass completed and issues fixed

Not run in this pass. `legion review` runs after this PR is opened, per the
pipeline this task is scoped to (build -> simplify -> pr-write -> review ->
verify). This PR does not claim review is done -- that is the next stage,
and this criterion will not be satisfied until that stage runs and any
findings are fixed.

Evidence: none yet -- intentionally deferred, not skipped.

### 4. PR created and linked to this issue

This criterion is satisfied by the act of opening this PR through
`legion pr create --repo smugglr --issue 227 --task
019e98dc-b71f-78b3-a453-ca42423b9399` from branch
`refactor/227-shared-persist-binding`, after both the simplify gate (item 2
above) and this pr-write gate passed on the current HEAD. The `--task` flag
ties the PR back to kanban card `019e98dc-b71f-78b3-a453-ca42423b9399`,
which is issue #227's card, and the title is prefixed `refactor(#227):` so
GitHub's issue-linking picks it up automatically -- the same mechanism used
by every other PR in this repo's recent history (e.g. `fix(#190): ...`,
`fix(#196): ...` in the current commit log). There is no code artifact to
cite for this criterion; the observable behavior is the PR's existence,
its base branch, and its title/task linkage, all of which are visible on
the PR itself once created.

Evidence: PR title `refactor(#227): extract a shared createPersistBinding
for the zustand and nanostores plugins`, branch
`refactor/227-shared-persist-binding`, `--task
019e98dc-b71f-78b3-a453-ca42423b9399`.

## Not done

- The autoSync shared-counter bug -- explicitly out of scope per the issue,
  not touched.
- No package version bump (`smugglr`, `@smugglr/zustand`,
  `@smugglr/nanostores` all stay at `0.4.2`) -- release is a separate step,
  not part of this task.
- `peerDependencies.smugglr` on both plugins is still `^0.4.0`, which
  permits pre-refactor `0.4.0`/`0.4.1` that lack the `createPersistBinding`
  export. Left as-is because tightening it is a version/release concern,
  not a refactor concern; flagged here so it isn't lost before the next
  release.
- `legion review` and `legion verify` -- not run in this pass; they are the
  pipeline stages after PR creation, out of scope for this task. This PR is
  not merged.

## What changed

- `packages/smugglr/src/persistBinding.ts` (new): `createPersistBinding<T>`
  owns the `HYDRATE_SQL`/`UPSERT_SQL` builders (now built from
  `quoteIdent(options.table)`), the `persist()` dedup-by-`lastSerialized`
  closure, the `hydrate()` closure (including the `typeof raw !== "string"`
  guard), the suppress-next-write flag, and the `table-changed` event
  matcher (`event.table !== options.table` /
  `!event.changedPks.includes(options.key)`). Returns `{ dispose(): void }`.
  Each plugin's own glue is injected rather than flattened in: a
  `subscribe(notify)` option lets the caller pre-filter writes (zustand's
  `include()` projection, nanostores' `seenInitialFire` skip on the
  synchronous first fire) before calling `notify`, and an `applyHydrated`
  callback lets the caller decide how a hydrated value reaches the store
  (`set(parsed as never, false)` for zustand, `writable.set(parsed)` for
  nanostores).
- `packages/smugglr/src/autoSync.ts`: `quoteIdent` changed from file-local
  to `export`ed, so `persistBinding.ts` reuses the exact same guard
  `isLocalEmpty` already used instead of re-implementing the regex.
- `packages/smugglr/src/index.ts`: exports `createPersistBinding` and its
  three supporting types. Purely additive -- no existing export changed.
- `packages/zustand-plugin/src/index.ts`: removed the duplicated SQL
  constants and the persist/hydrate/subscribe/event-matcher block (149
  lines -> 102 lines), replaced with one `createPersistBinding({...})` call.
  `SmugglOptions<T, U>` and the `Smuggl` type/`smuggl` runtime signature are
  unchanged.
- `packages/nanostores-plugin/src/index.ts`: same shape of change (145
  lines -> 98 lines). `SmugglOptions<T>` and `smuggl<T>()`'s signature are
  unchanged; the returned dispose function now delegates to
  `binding.dispose()`, functionally identical to the prior
  `() => { unsubStore(); unsubSmugglr(); }`.
- `packages/zustand-plugin/src/index.test.ts`,
  `packages/nanostores-plugin/src/index.test.ts`: one new test each for the
  `quoteIdent` fold-in (see above).

## Test plan

Ran from each package directory (pnpm only, no npm/yarn/npx):

- `packages/smugglr`: `pnpm build:ts` (tsc) -- passed, no errors.
- `packages/zustand-plugin`: `pnpm install` (already up to date after first
  run), then `tsc` and `vitest run` invoked directly via
  `./node_modules/.bin/tsc` / `./node_modules/.bin/vitest run` (pnpm's
  wrapped `build`/`test` scripts were blocked in this sandbox by an
  unrelated `ERR_PNPM_IGNORED_BUILDS` supply-chain approval prompt for
  `esbuild`, not caused by this change) -- both passed: `tsc` clean, 5/5
  tests green (4 pre-existing + 1 new).
- `packages/nanostores-plugin`: same pattern -- `tsc` clean, 7/7 tests green
  (6 pre-existing + 1 new).