### PR TITLE
refactor(#229): route stash sync onto the generic pipeline

### DIFF
--- a/crates/smugglr-core/src/stash.rs
+++ b/crates/smugglr-core/src/stash.rs
@@ -220,9 +220,6 @@ async fn upload_relay(
 
 /// Sync rows from source DataSource to destination DataSource for a single table.
 ///
-/// This is a generic version that works with any two DataSource implementations,
-/// unlike the D1-specific push_table/pull_table in sync.rs.
-///
 /// `label` is used for logging (e.g. "stash" or "retrieve").
 /// `set_count` receives the number of synced rows and records it in the result.
 #[allow(clippy::too_many_arguments)]
@@ -255,42 +252,34 @@ async fn sync_table<S: DataSource, D: DataSource>(
         return Ok(crate::sync::finalize_in_sync(table, stats, detail));
     }
 
+    info!("{}: syncing table {} (dry_run={})", label, table, dry_run);
+
+    // Both stash and retrieve use "push" semantics: source-only + source-newer
+    // rows go to dest. Route through the generic engine's push_table so stash
+    // shares the transfer/batch/retry logic with every other DataSource pair
+    // instead of re-fetching and re-upserting rows by hand.
+    let push_result = crate::sync::push_table(
+        source,
+        dest,
+        table,
+        &diff,
+        conflict_resolution,
+        &crate::config::BatchConfig::default(),
+        &[],
+        dry_run,
+        &crate::sync::NoProgress,
+    )
+    .await?;
+
     let mut result = SyncResult::new(table);
     result.diff_stats = stats;
     result.diff_detail = detail;
-
-    // Both stash and retrieve use "push" semantics: source-only + source-newer rows go to dest.
-    let rows_to_sync = diff.rows_to_push(conflict_resolution);
-
-    if rows_to_sync.is_empty() {
-        info!("No changes to sync for table: {}", table);
-        return Ok(result);
-    }
+    set_count(&mut result, push_result.rows_pushed);
 
     info!(
-        "{}: {} rows for table {} (dry_run={})",
-        label,
-        rows_to_sync.len(),
-        table,
-        dry_run
+        "{}: synced {} rows for table {}",
+        label, push_result.rows_pushed, table
     );
-
-    if dry_run {
-        set_count(&mut result, rows_to_sync.len());
-        return Ok(result);
-    }
-
-    let rows = source.get_rows(table, &rows_to_sync).await?;
-
-    if rows.is_empty() {
-        warn!("No rows found in source for sync");
-        return Ok(result);
-    }
-
-    let count = dest.upsert_rows(table, &rows).await?;
-    set_count(&mut result, count);
-
-    info!("{}: synced {} rows for table {}", label, count, table);
     Ok(result)
 }
 


### PR DESCRIPTION
## Summary

Issue #229 (refactor, tagged "consider"): stash's local<->local sync hand-rolled the
"push" half of the generic sync pipeline -- compute a diff, derive rows-to-push, fetch from
source, upsert into dest -- duplicating `sync::transfer_rows` (sync.rs:172) and the row
transfer body of `sync::push_table` (sync.rs:210). `stash::sync_table` now computes the
`TableDiff` as before (still needed for dry-run stats/detail and the shared
`finalize_in_sync` no-changes path) but hands that diff to `sync::push_table` instead of
re-deriving `rows_to_push` and re-implementing the fetch/upsert loop by hand. `LocalDb`
already implements `DataSource` (local.rs:58-92), so no new trait impl was required --
this was a case of routing an existing generic function through an existing trait impl,
not adding capability.

## Acceptance criteria mapping

### 1. All tests pass (including a regression test that fails before the fix)
This is a behavior-preserving refactor, per the issue's own framing -- not a bug fix --
so there is no failing-before-fix behavior to write a regression test for; N/A is the
correct answer for that half of the criterion. The proof of preservation is the existing
stash integration suite staying green *unmodified*: I did not add, remove, or edit a
single stash test. These tests exercise exactly the surface this refactor touches -- rows
synced, dry-run stats, conflict resolution outcomes, table filtering -- so their being
green with an unmodified assertion set is the evidence that swapping the implementation
under `stash::sync_table` did not change observable behavior.
Evidence: `cargo test -p smugglr-core -- --skip multicast` passes 211/211, including
`test_stash_new_relay`, `test_stash_dry_run`, `test_stash_table_filter`,
`test_stash_no_changes`, `test_stash_updates_existing_rows`,
`test_stash_then_retrieve_roundtrip`, `test_retrieve_from_relay`, `test_retrieve_dry_run`,
`test_retrieve_conflict_resolution_newer_wins`, `test_retrieve_conflict_resolution_remote_wins`,
`test_retrieve_missing_relay`, `test_retrieve_source_only_table_skipped`; `cargo clippy
--all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean; `cargo check -p
smugglr-core --no-default-features --target wasm32-unknown-unknown` clean (stash.rs is
`cfg(feature = "native")`-gated so it is not compiled into the wasm target at all; the
plain `--target wasm32-unknown-unknown` invocation without `--no-default-features` fails
on unmodified `main` too, for an unrelated getrandom/wasm_js backend reason, confirmed by
stashing this diff and re-running the same command against main).

### 2. Simplify pass completed
The articulation (`/tmp/simplify-229.md`) walks the one changed file, citing the deleted
duplication (the manual `rows_to_push` + `get_rows`/`upsert_rows` loop that duplicated
`sync::transfer_rows`/`sync::push_table`) and the now-deleted stale doc comment that
claimed the generic `sync.rs` functions were D1-specific -- they were always generic over
`<Src: DataSource, Dst: DataSource>`, so the comment's premise was false the whole time.
Evidence: `legion quality-gate check --skill legion-simplify --result clean
--findings-count 0 --articulation-file /tmp/simplify-229.md` accepted, gate id
`019f6236-6a86-7011-a44d-38e25cebdf4f`.

### 3. Review pass completed and issues fixed
Pending -- runs after this PR is opened, per the pipeline order (simplify -> pr-write ->
review -> verify); not yet applicable at this stage of the pipeline.
Evidence: N/A until the review agent runs against this open PR; tracked by the
`legion-review` quality gate this repo's pipeline records post-open.

### 4. PR created and linked to this issue
This PR is opened against issue #229 and card `019e98dc-b71c-7663-a798-6d5eaa7f43ab`.
Evidence: `legion pr create --repo smugglr --title "refactor(#229): route stash sync onto
the generic pipeline" --body "$(cat /tmp/pr-229.md)" --task
019e98dc-b71c-7663-a798-6d5eaa7f43ab`, run immediately after this gate passes.

## Not done

The issue named a second piece of duplication: `stash::get_stash_tables` (stash.rs:301)
vs. `sync::get_tables_to_sync` (sync.rs:381). I did not merge these, and stopped per the
issue's own guardrail ("if accomplishing it cleanly requires... any behavior/wire change,
STOP and report the blocker instead of forcing it").

The two functions diverged in error handling as part of #224:
`get_tables_to_sync`'s primary-key-inspection loop (sync.rs:399-412) treats *any*
`table_info` error as warn-and-skip and continues syncing other tables.
`get_stash_tables`'s loop (stash.rs:332-353) deliberately hard-aborts (`return
Err(SyncError::Stash(...))`) on any `table_info` error that is not
`SyncError::NoPrimaryKey` -- the comment at stash.rs:336-340 explains the two "no PK"
encodings are intentionally the *only* case folded into a shared warn+skip; every other
error is meant to stop the whole stash/retrieve operation rather than silently sync a
partial table set.

Reusing `get_tables_to_sync` would silently convert stash's hard-abort-on-real-error
behavior into warn-and-skip -- a real behavior change -- and no stash test exercises a
non-NoPrimaryKey `table_info` failure, so nothing would catch that regression (exactly the
guardrail's stop condition). `get_tables_to_sync` also takes `&Config` (the whole app
config: target, stash, broadcast sections) rather than the explicit
`tables_filter`/`exclude_tables` slices stash already has, so reusing it as-is would mean
synthesizing a throwaway `Config` for two filter fields. Left as a clean, separately-scoped
deferral: it needs either a deliberate decision to drop stash's hard-abort semantics (a
real behavior change requiring its own test and sign-off) or a `get_tables_to_sync`
signature change to accept explicit filters, neither of which belongs inside a refactor
that is supposed to be behavior-preserving end to end.

Also not done, and worth flagging for reviewers: the issue's background text says the
generic pipeline "after #224 ... centers on `run_directional`." That symbol does not exist
on current main -- the pipeline centers on `push_table`/`pull_table`/`sync_table` (verified
via `legion sym list --file crates/smugglr-core/src/sync.rs`). This is a stale premise in
the issue text, not a gap in this PR's work, and required no code change of its own.

I additionally did not thread a caller-supplied `BatchConfig` or progress reporter through
stash -- `BatchConfig::default()` and `sync::NoProgress` are used at the `push_table` call
site since stash never had a caller-supplied value for either before this change and
plumbing one through `StashConfig` is a separate feature, not part of this refactor's scope.