### PR TITLE
refactor(#228): unify wire types into a no-tokio smugglr-wire crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,11 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
+      - name: Publish smugglr-wire
+        run: cargo publish -p smugglr-wire
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
       - name: Publish smugglr-plugin-sdk
         run: cargo publish -p smugglr-plugin-sdk
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "smugglr-wire",
  "socket2 0.5.10",
  "tempfile",
  "thiserror",
@@ -1815,6 +1816,7 @@ version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",
+ "smugglr-wire",
  "tokio",
 ]
 
@@ -1833,6 +1835,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+]
+
+[[package]]
+name = "smugglr-wire"
+version = "0.4.2"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,14 @@ members = [
     "crates/smugglr",
     "crates/smugglr-plugin-sdk",
     "crates/smugglr-wasm",
+    "crates/smugglr-wire",
     "plugins/smugglr-http-sql",
 ]
 default-members = [
     "crates/smugglr-core",
     "crates/smugglr",
     "crates/smugglr-plugin-sdk",
+    "crates/smugglr-wire",
     "plugins/smugglr-http-sql",
 ]
 resolver = "2"

--- a/crates/smugglr-core/Cargo.toml
+++ b/crates/smugglr-core/Cargo.toml
@@ -29,6 +29,10 @@ native = [
 ]
 
 [dependencies]
+# Canonical wire types (TableInfo/ColumnInfo/RowMeta), shared with
+# smugglr-plugin-sdk. serde-only, no tokio -- safe on the wasm32 path. See #228.
+smugglr-wire = { path = "../smugglr-wire", version = "0.4.2" }
+
 # Serialization (always needed)
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/smugglr-core/src/datasource.rs
+++ b/crates/smugglr-core/src/datasource.rs
@@ -9,33 +9,14 @@ use crate::error::Result;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 
-/// Table schema information
-#[derive(Debug, Clone)]
-pub struct TableInfo {
-    /// Exists for wire/serialization parity with the plugin's `WireTableInfo`.
-    pub name: String,
-    pub columns: Vec<ColumnInfo>,
-    pub primary_key: Vec<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ColumnInfo {
-    pub name: String,
-    #[allow(dead_code)]
-    pub col_type: String,
-    #[allow(dead_code)]
-    pub notnull: bool,
-    pub pk: bool,
-}
-
-/// A row with its primary key and optional timestamp
-#[derive(Debug, Clone)]
-pub struct RowMeta {
-    /// Exists for wire/serialization parity with the plugin's `WireRowMeta`.
-    pub pk_value: String,
-    pub updated_at: Option<String>,
-    pub content_hash: String,
-}
+/// Table schema information, row metadata, and column info.
+///
+/// Re-exported from `smugglr-wire`, the canonical definition shared with
+/// `smugglr-plugin-sdk` and the plugin JSON-RPC wire protocol -- see #228.
+/// This module keeps re-exporting them under their original names so
+/// `smugglr_core::datasource::{TableInfo, ColumnInfo, RowMeta}` importers
+/// (local.rs, plugin.rs, the wasm crate, the CLI) are unaffected.
+pub use smugglr_wire::{ColumnInfo, RowMeta, TableInfo};
 
 /// Normalize a row's timestamp-column value to the `RowMeta.updated_at` string.
 ///

--- a/crates/smugglr-core/src/plugin.rs
+++ b/crates/smugglr-core/src/plugin.rs
@@ -26,7 +26,7 @@
 //! - `upsert_rows` - params: `{table, rows}`
 //! - `row_count` - params: `{table}`
 
-use crate::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
+use crate::datasource::{DataSource, RowMeta, TableInfo};
 use crate::error::{Result, SyncError};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -100,31 +100,6 @@ fn rpc_error_to_sync_error(plugin_name: &str, err: &RpcError) -> SyncError {
             plugin_name, err.code, err.message
         ))
     }
-}
-
-#[derive(Deserialize)]
-struct WireTableInfo {
-    name: String,
-    columns: Vec<WireColumnInfo>,
-    primary_key: Vec<String>,
-}
-
-#[derive(Deserialize)]
-struct WireColumnInfo {
-    name: String,
-    #[serde(default)]
-    col_type: String,
-    #[serde(default)]
-    notnull: bool,
-    #[serde(default)]
-    pk: bool,
-}
-
-#[derive(Deserialize)]
-struct WireRowMeta {
-    pk_value: String,
-    updated_at: Option<String>,
-    content_hash: String,
 }
 
 impl PluginDataSource {
@@ -268,23 +243,8 @@ impl DataSource for PluginDataSource {
     }
 
     async fn table_info(&self, table: &str) -> Result<TableInfo> {
-        let wire: WireTableInfo = self
-            .call("table_info", serde_json::json!({ "table": table }))
-            .await?;
-        Ok(TableInfo {
-            name: wire.name,
-            columns: wire
-                .columns
-                .into_iter()
-                .map(|c| ColumnInfo {
-                    name: c.name,
-                    col_type: c.col_type,
-                    notnull: c.notnull,
-                    pk: c.pk,
-                })
-                .collect(),
-            primary_key: wire.primary_key,
-        })
+        self.call("table_info", serde_json::json!({ "table": table }))
+            .await
     }
 
     async fn get_row_metadata(
@@ -293,29 +253,15 @@ impl DataSource for PluginDataSource {
         timestamp_column: &str,
         exclude_columns: &[String],
     ) -> Result<HashMap<String, RowMeta>> {
-        let wire: HashMap<String, WireRowMeta> = self
-            .call(
-                "get_row_metadata",
-                serde_json::json!({
-                    "table": table,
-                    "timestamp_column": timestamp_column,
-                    "exclude_columns": exclude_columns,
-                }),
-            )
-            .await?;
-        Ok(wire
-            .into_iter()
-            .map(|(k, v)| {
-                (
-                    k,
-                    RowMeta {
-                        pk_value: v.pk_value,
-                        updated_at: v.updated_at,
-                        content_hash: v.content_hash,
-                    },
-                )
-            })
-            .collect())
+        self.call(
+            "get_row_metadata",
+            serde_json::json!({
+                "table": table,
+                "timestamp_column": timestamp_column,
+                "exclude_columns": exclude_columns,
+            }),
+        )
+        .await
     }
 
     async fn get_rows(
@@ -453,6 +399,11 @@ mod tests {
         assert_eq!(err.message, "table not found");
     }
 
+    // These two deserialize into the canonical `smugglr_wire::{TableInfo,
+    // RowMeta}` (re-exported here as `TableInfo`/`RowMeta`) rather than a
+    // host-local `Wire*` shim -- see #228. `smugglr-wire` itself carries the
+    // byte-level JSON snapshot tests; these confirm the host's `call()` path
+    // deserializes plugin responses into the same canonical types unchanged.
     #[test]
     fn test_wire_table_info_deserialization() {
         let json = r#"{
@@ -463,7 +414,7 @@ mod tests {
             ],
             "primary_key": ["id"]
         }"#;
-        let info: WireTableInfo = serde_json::from_str(json).unwrap();
+        let info: TableInfo = serde_json::from_str(json).unwrap();
         assert_eq!(info.name, "users");
         assert_eq!(info.columns.len(), 2);
         assert!(info.columns[0].pk);
@@ -478,7 +429,7 @@ mod tests {
             "updated_at": "2026-04-03T12:00:00Z",
             "content_hash": "abc123"
         }"#;
-        let meta: WireRowMeta = serde_json::from_str(json).unwrap();
+        let meta: RowMeta = serde_json::from_str(json).unwrap();
         assert_eq!(meta.pk_value, "42");
         assert_eq!(meta.updated_at.unwrap(), "2026-04-03T12:00:00Z");
         assert_eq!(meta.content_hash, "abc123");

--- a/crates/smugglr-plugin-sdk/Cargo.toml
+++ b/crates/smugglr-plugin-sdk/Cargo.toml
@@ -14,6 +14,10 @@ keywords = ["smugglr", "plugin", "sqlite", "sync", "sdk"]
 categories = ["database", "development-tools"]
 
 [dependencies]
+# Canonical wire types (TableInfo/ColumnInfo/RowMeta), shared with
+# smugglr-core. See #228.
+smugglr-wire = { path = "../smugglr-wire", version = "0.4.2" }
+
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["io-std", "io-util", "macros", "rt-multi-thread"] }

--- a/crates/smugglr-plugin-sdk/src/lib.rs
+++ b/crates/smugglr-plugin-sdk/src/lib.rs
@@ -38,30 +38,12 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 
 // -- Public types --
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TableInfo {
-    pub name: String,
-    pub columns: Vec<ColumnInfo>,
-    pub primary_key: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ColumnInfo {
-    pub name: String,
-    #[serde(default)]
-    pub col_type: String,
-    #[serde(default)]
-    pub notnull: bool,
-    #[serde(default)]
-    pub pk: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RowMeta {
-    pub pk_value: String,
-    pub updated_at: Option<String>,
-    pub content_hash: String,
-}
+/// Table schema information, row metadata, and column info.
+///
+/// Re-exported from `smugglr-wire`, the canonical definition shared with
+/// `smugglr-core`'s host-side plugin adapter -- see #228. Plugin authors keep
+/// importing these from `smugglr_plugin_sdk` as before.
+pub use smugglr_wire::{ColumnInfo, RowMeta, TableInfo};
 
 /// Well-known JSON-RPC error code that a plugin uses to signal a *transient*
 /// failure (rate limit, 5xx, timeout against a remote backend) that smugglr

--- a/crates/smugglr-wire/Cargo.toml
+++ b/crates/smugglr-wire/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "smugglr-wire"
+description = "Canonical wire types shared by smugglr-core and smugglr-plugin-sdk (serde-only, no tokio, wasm32-safe)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+authors.workspace = true
+readme = "../../README.md"
+keywords = ["smugglr", "wire", "sqlite", "sync", "serde"]
+categories = ["database", "wasm"]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/smugglr-wire/src/lib.rs
+++ b/crates/smugglr-wire/src/lib.rs
@@ -1,0 +1,124 @@
+//! Canonical wire types for the smugglr plugin protocol.
+//!
+//! [`TableInfo`], [`ColumnInfo`], and [`RowMeta`] are the JSON-RPC payloads
+//! exchanged between the smugglr host and adapter plugins over stdin/stdout
+//! (see `smugglr-core::plugin` and `smugglr-plugin-sdk::run`). Both sides used
+//! to define their own copy of these structs -- the host additionally kept a
+//! third, `Wire`-prefixed copy purely to `#[derive(Deserialize)]` without
+//! pulling in the SDK crate (which drags in tokio + stdin/stdout at module
+//! scope, breaking the host's wasm32-compiled `smugglr-core::datasource` path).
+//!
+//! This crate holds one definition. It depends on nothing but `serde`, so it
+//! compiles on wasm32 and can sit underneath both `smugglr-core` (host side)
+//! and `smugglr-plugin-sdk` (plugin side) without creating a core <-> sdk
+//! dependency cycle. See issue #228.
+//!
+//! The serde representation (field names, attributes, order) is the wire
+//! contract -- changing it is a breaking protocol change. The snapshot tests
+//! below pin the exact JSON shape.
+
+use serde::{Deserialize, Serialize};
+
+/// Table schema information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableInfo {
+    pub name: String,
+    pub columns: Vec<ColumnInfo>,
+    pub primary_key: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnInfo {
+    pub name: String,
+    #[serde(default)]
+    pub col_type: String,
+    #[serde(default)]
+    pub notnull: bool,
+    #[serde(default)]
+    pub pk: bool,
+}
+
+/// A row's primary key, change-detection hash, and optional timestamp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RowMeta {
+    pub pk_value: String,
+    pub updated_at: Option<String>,
+    pub content_hash: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the exact JSON shape of `TableInfo` -- field names and order are
+    /// the wire contract between host and plugin. Any accidental rename,
+    /// reorder, or added/removed field must fail this test.
+    #[test]
+    fn table_info_snapshot() {
+        let info = TableInfo {
+            name: "users".to_string(),
+            columns: vec![
+                ColumnInfo {
+                    name: "id".to_string(),
+                    col_type: "INTEGER".to_string(),
+                    notnull: true,
+                    pk: true,
+                },
+                ColumnInfo {
+                    name: "email".to_string(),
+                    col_type: "TEXT".to_string(),
+                    notnull: false,
+                    pk: false,
+                },
+            ],
+            primary_key: vec!["id".to_string()],
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert_eq!(
+            json,
+            r#"{"name":"users","columns":[{"name":"id","col_type":"INTEGER","notnull":true,"pk":true},{"name":"email","col_type":"TEXT","notnull":false,"pk":false}],"primary_key":["id"]}"#
+        );
+    }
+
+    /// `col_type`, `notnull`, and `pk` are `#[serde(default)]` -- a plugin may
+    /// omit them and still deserialize, defaulting to `""`, `false`, `false`.
+    #[test]
+    fn column_info_defaults_on_missing_fields() {
+        let json = r#"{"name":"email"}"#;
+        let col: ColumnInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(col.name, "email");
+        assert_eq!(col.col_type, "");
+        assert!(!col.notnull);
+        assert!(!col.pk);
+    }
+
+    /// `RowMeta.updated_at` has no `skip_serializing_if` -- `None` must still
+    /// emit an explicit `"updated_at":null`, not omit the key.
+    #[test]
+    fn row_meta_snapshot_with_updated_at() {
+        let meta = RowMeta {
+            pk_value: "42".to_string(),
+            updated_at: Some("2026-04-03T12:00:00Z".to_string()),
+            content_hash: "abc123".to_string(),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert_eq!(
+            json,
+            r#"{"pk_value":"42","updated_at":"2026-04-03T12:00:00Z","content_hash":"abc123"}"#
+        );
+    }
+
+    #[test]
+    fn row_meta_snapshot_without_updated_at() {
+        let meta = RowMeta {
+            pk_value: "42".to_string(),
+            updated_at: None,
+            content_hash: "abc123".to_string(),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert_eq!(
+            json,
+            r#"{"pk_value":"42","updated_at":null,"content_hash":"abc123"}"#
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Collapses three serde-identical carrier struct families -- `TableInfo`,
`ColumnInfo`, `RowMeta` -- into one canonical definition in a new
`smugglr-wire` crate, deleting the host's hand-written `Wire*` shim structs
and their field-by-field conversions. Wire format is byte-identical; this is
a pure architectural refactor.

## Background

Before this PR the same three structs existed in three places:

- `smugglr_core::datasource::{TableInfo, ColumnInfo, RowMeta}` -- no serde
  derives, used natively by `LocalDb` and consumed by the diff/sync engine.
- `smugglr_plugin_sdk::{TableInfo, ColumnInfo, RowMeta}` -- `Serialize +
  Deserialize`, the type a plugin actually serializes onto the wire.
- `smugglr_core::plugin::{WireTableInfo, WireColumnInfo, WireRowMeta}` --
  `Deserialize`-only shims the host used to parse a plugin's JSON-RPC
  response, immediately converted field-by-field into the `datasource`
  structs.

The naive fix -- have core depend on the SDK crate and re-export its types --
doesn't work: `smugglr-plugin-sdk` pulls in `tokio` (`rt-multi-thread`) and
touches `stdin`/`stdout` at module scope (`crates/smugglr-plugin-sdk/src/lib.rs`
`pub async fn run(...)`), and `smugglr_core::datasource` compiles
unconditionally for `wasm32` (the wasm crate depends on core with
`default-features = false`, excluding the `native` feature that gates
`tokio`). A core -> sdk dependency would drag tokio's `mio`/`getrandom`
machinery into the wasm32 build and break it.

## Design: no cycle

```
        smugglr-wire  (serde only, no tokio, no platform deps)
           ^        ^
           |        |
   smugglr-core   smugglr-plugin-sdk
```

`smugglr-wire` depends on nothing but `serde` (`crates/smugglr-wire/Cargo.toml`).
Both `smugglr-core` and `smugglr-plugin-sdk` depend on it as an ordinary path
dependency. There is no edge from core to sdk or sdk to core -- the two only
share a leaf. In core's `Cargo.toml` the dependency sits in the
always-compiled `[dependencies]` block, not behind the `native` feature flag
(`crates/smugglr-core/Cargo.toml:34`), because `datasource.rs` (which now
`pub use`s the wire types) compiles for wasm32 regardless of feature
selection.

`smugglr_core::datasource` and `smugglr_plugin_sdk` both keep exposing
`TableInfo`/`ColumnInfo`/`RowMeta` under their original names via `pub use
smugglr_wire::{...}` (not a type alias -- `pub use` preserves type identity),
so every existing import site needed zero changes: `local.rs:3`,
`plugin.rs:29`, `smugglr-wasm/src/lib.rs:26`, `smugglr/src/main.rs:18`, and
`plugins/smugglr-http-sql/src/adapter.rs:6` (which imports
`smugglr_plugin_sdk::{ColumnInfo, PluginAdapter, PluginError, RowMeta,
TableInfo}`) all compile unchanged.

The host's `PluginDataSource::table_info()` and `get_row_metadata()`
(`crates/smugglr-core/src/plugin.rs`) used to deserialize into `WireTableInfo`/
`WireRowMeta` and then hand-convert into `TableInfo`/`RowMeta` field by field.
Those shim structs and conversions are deleted; the JSON-RPC response now
deserializes directly into the canonical type via the existing generic
`call::<T: DeserializeOwned>()`.

## Wire format: unchanged

This is behavior-preserving -- the acceptance criterion "a regression test
that fails before the fix" is **N/A**: there is no behavior change to write a
failing-before test against. What actually needed guarding is the wire
*format* not drifting during the collapse, so `crates/smugglr-wire/src/lib.rs`
carries four serde snapshot tests that assert the literal JSON string (not
just field equality, so a rename/reorder/added field fails even without a
corresponding assertion):

- `table_info_snapshot` -- pins `TableInfo`'s full JSON shape including
  nested `ColumnInfo`.
- `column_info_defaults_on_missing_fields` -- confirms `#[serde(default)]`
  on `col_type`/`notnull`/`pk` still lets a plugin omit them (mirrors a real
  plugin response shape covered by the pre-existing
  `test_wire_table_info_deserialization` fixture, which omits `notnull`/`pk`
  on its second column).
- `row_meta_snapshot_with_updated_at` / `row_meta_snapshot_without_updated_at`
  -- confirms `updated_at: Option<String>` has no `skip_serializing_if`, so
  `None` still serializes to an explicit `"updated_at":null` rather than
  omitting the key.

The two pre-existing wire tests in `plugin.rs`
(`test_wire_table_info_deserialization`, `test_wire_row_meta_deserialization`)
were retargeted from the deleted `WireTableInfo`/`WireRowMeta` onto the
canonical `TableInfo`/`RowMeta` with the same JSON fixtures and assertions --
coverage of "the host correctly deserializes a plugin's response" carries
forward unchanged.

## What I deliberately did not do

- Did not move `PLUGIN_TRANSIENT_ERROR_CODE` (`crates/smugglr-core/src/plugin.rs`)
  into `smugglr-wire`, even though its doc comment referenced #228. It's a
  scalar JSON-RPC error code, not one of the three carrier struct families
  named in the issue -- out of scope here, left as a smaller follow-up.
- Did not touch `plugins/smugglr-http-sql/src/adapter.rs` or any other plugin
  consumer -- their imports resolve unchanged through the `pub use` chain.
- Did not add a wrapper type or extra methods on the wire types -- neither
  `TableInfo`, `ColumnInfo`, nor `RowMeta` carried any inherent methods
  before this change, so there was nothing to preserve beyond the fields.

## Verification

- `cargo build --workspace` -- clean.
- `cargo test --workspace -- --skip multicast` -- all green, including the 4
  new `smugglr-wire` snapshot tests and the retargeted `plugin.rs` wire tests.
- `cargo clippy --all-targets -- -D warnings` -- clean.
- `cargo fmt --all -- --check` -- clean.
- `cargo clippy -p smugglr-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`
  -- clean. This is the load-bearing check: it compiles `smugglr-wasm` ->
  `smugglr-core` (default-features off) -> `smugglr-wire` for wasm32 with zero
  tokio/mio/getrandom anywhere in the dependency graph, proving `smugglr-wire`
  is genuinely wasm32-safe and that no tokio leaked in through the new
  dependency.
- `cargo check -p smugglr-core --target wasm32-unknown-unknown` (the exact
  command named in the issue, with default features): **fails**, but this is
  pre-existing on `main` and unrelated to this change -- confirmed by running
  the identical command against `main` before this PR's changes, which fails
  identically (`tokio`'s `full` feature, enabled by core's default `native`
  feature, pulls in `mio`/`getrandom`, neither of which supports
  `wasm32-unknown-unknown` without extra target configuration). The correct
  check is `cargo check -p smugglr-core --no-default-features --target
  wasm32-unknown-unknown`, matching exactly how `smugglr-wasm/Cargo.toml`
  actually depends on core (`default-features = false`) -- that passes clean.

## Release wiring

`.github/workflows/release.yml` gets a new `Publish smugglr-wire` step
immediately before the (previously first) `Publish smugglr-plugin-sdk` step.
Both `smugglr-core` and `smugglr-plugin-sdk` now declare `smugglr-wire` as a
`path + version` dependency, and crates.io requires a dependency to already
be published before a dependent crate can publish -- so `smugglr-wire` must
ship first. The existing order among the other four crates
(`smugglr-plugin-sdk` -> `smugglr-core` -> `smugglr-http-sql` -> `smugglr`) is
unchanged. Nothing was published as part of this PR -- only the workflow was
wired.

## Acceptance criteria mapping

### All tests pass (including a regression test that fails before the fix)

All tests pass: `cargo test --workspace -- --skip multicast` is green across every crate (210 tests in `smugglr-core`, 23 in `smugglr-plugin-sdk`, 11 in `smugglr-http-sql`, 29+1 in `smugglr`, 4 new in `smugglr-wire`). A "fails before the fix" regression test is N/A for this criterion as literally stated: the issue is explicit that this refactor is behavior-preserving ("the plugin WIRE FORMAT must stay byte-identical"), so there is no behavior change to regress against and no bug to reproduce with a failing test. The applicable invariant guard instead is the wire-format snapshot suite in `crates/smugglr-wire/src/lib.rs` (`table_info_snapshot`, `column_info_defaults_on_missing_fields`, `row_meta_snapshot_with_updated_at`, `row_meta_snapshot_without_updated_at`) plus the retargeted `crates/smugglr-core/src/plugin.rs` `test_wire_table_info_deserialization` / `test_wire_row_meta_deserialization` -- these assert the literal JSON string and would fail on any accidental field rename, reorder, or default-attribute change, which is the actual risk this refactor carries.

### Simplify pass completed

Ran the simplify gate via `legion quality-gate check --skill legion-simplify --result clean --findings-count 0 --articulation-file /tmp/simplify-228.md`, one `###` entry per changed file (9 entries: the two new `smugglr-wire` files, the four edited Cargo.toml files, `datasource.rs`, `plugin.rs`, `smugglr-plugin-sdk/src/lib.rs`, `release.yml`), each with file:line evidence. Gate accepted (gate id `019f6235-534a-7ab2-b7aa-473ef5c3a960`).

### Review pass completed and issues fixed

Not yet run -- this PR is being opened for the review stage; `legion-review` runs against the open PR next, per the plugin's simplify -> pr-write -> review -> verify pipeline. This criterion completes after review runs and any findings are fixed.

Evidence: no `legion-review` gate id exists yet for this branch HEAD (only the `legion-simplify` gate `019f6235-534a-7ab2-b7aa-473ef5c3a960` and this in-progress `legion-pr-write` gate exist so far); this section will be updated with the review gate id once `legion-review` runs against the opened PR.

### PR created and linked to this issue

This PR, created via `legion pr create --repo smugglr --issue 228 --task 019e98dc-b71f-78b3-a453-ca37de459830`.

Evidence: the `--issue 228` and `--task 019e98dc-b71f-78b3-a453-ca37de459830` flags on the `legion pr create` invocation link the PR to both the GitHub issue and the kanban card; the resulting PR number and URL are reported in this PR's own metadata once opened.

## Not done

- `legion review` (the review-stage gate) has not been run yet -- it runs
  after this PR opens, not before.
- `legion verify` was explicitly withheld per the task instructions for this
  work (do not mark done, do not run verify).
- The branch was not merged -- explicitly withheld per instructions.
- `PLUGIN_TRANSIENT_ERROR_CODE`'s duplication between
  `smugglr-core::plugin` and `smugglr-plugin-sdk` was left untouched (see
  "What I deliberately did not do" above) -- it is a separate, smaller
  follow-up outside this issue's three named struct families.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace -- --skip multicast`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p smugglr-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [x] `cargo check -p smugglr-core --no-default-features --target wasm32-unknown-unknown`