### PR TITLE
docs(#266): surface exit codes in smugglr --help

### DIFF
--- a/crates/smugglr/src/main.rs
+++ b/crates/smugglr/src/main.rs
@@ -219,6 +219,17 @@ fn emit_command_output(
 #[derive(Parser)]
 #[command(name = "smugglr")]
 #[command(author, version, about = "Smuggle data between SQLite-shaped things")]
+#[command(after_help = "\
+EXIT CODES:
+  0  success
+  1  general error
+  2  configuration error (fix the config, do not retry)
+  3  connection/network error (transient, safe to retry)
+  4  conflict (needs a human decision -- pick a conflict_resolution)
+  5  target not found (database missing or API unreachable)
+
+Config is read from config.toml (override with --config). Use --output json \
+for machine-readable output; the exit code is the scripting contract.")]
 struct Cli {
     /// Path to config file
     #[arg(short, long, default_value = "config.toml")]


### PR DESCRIPTION
## Summary

Surfaces the exit-code contract in `smugglr --help`. The codes (0-5) were documented in `error.rs` and on smugglr.dev, but never in `--help` itself -- so an agent or script reading `--help` didn't see the contract it scripts against. Adds a clap `after_help` block: an EXIT CODES table plus a one-line config/`--output json` note. No logic change; static help text only.

## Acceptance criteria mapping

### 1. `smugglr --help` shows the exit codes matching error.rs::exit_code (0-5)
The `after_help` string lists 0 success / 1 general / 2 configuration / 3 connection-network (transient, retryable) / 4 conflict / 5 target-not-found. Verified against `SyncError::exit_code` (error.rs:148-174, located via `sym def exit_code`): Config/InvalidTableName/NoPrimaryKey/ParamLimit -> 2, Http/RateLimited/ServerError/ConnectionTimeout/RetryExhausted -> 3, ConcurrentWrite -> 4, TableNotFound/RelayNotFound/InvalidUrl/D1Api/BadRequest -> 5.
Evidence: `cargo run -q --bin smugglr -- --help` prints the EXIT CODES section; codes match error.rs::exit_code.

### 2. No logic change; build/clippy/fmt pass and existing --help content unchanged
The change is a single `#[command(after_help = ...)]` attribute on `Cli`; no function bodies touched. `cargo clippy -p smugglr --bin smugglr` clean, `cargo fmt -p smugglr -- --check` clean, and the command/flag portion of `--help` is unchanged (the exit-codes block is appended after it).
Evidence: clippy + fmt output clean; `--help` still shows the same 13 commands + global flags, with the new section appended.

### 3. simplify + review; PR linked
Simplify gate recorded clean (one file, main.rs, with located evidence). This body is the pr-write gate. Review runs after the PR opens. Linked to card 019f683e and issue #266.
Evidence: simplify gate id recorded on this HEAD.

## Not done

No enrichment beyond the exit codes -- the rest of the CLI help was audited (all 13 commands) and found already truthful and appropriately terse (smugglr's "terminal reference card" register), so nothing else needed changing. No examples/long descriptions added, deliberately, to keep the reference-card form.