### PR TITLE
fix(core): escape composite-PK delimiter in pk_text_expr (silent row-loss)

### DIFF
--- a/crates/smugglr-core/src/rowhash.rs
+++ b/crates/smugglr-core/src/rowhash.rs
@@ -132,9 +132,24 @@ pub fn content_hash(
 /// type-agnostically, so the cast is harmless there -- making this the one form
 /// that is correct everywhere.
 pub fn pk_text_expr(primary_key: &[String]) -> String {
+    // Single-column PK: no delimiter, so no collision is possible -- render it
+    // unchanged. This preserves the `__pk` wire contract for the overwhelmingly
+    // common single-PK case; only composite-PK tables re-render (and re-sync once).
+    if primary_key.len() == 1 {
+        return format!("CAST(\"{}\" AS TEXT)", primary_key[0]);
+    }
+    // Composite PK: a bare `|` join is NOT injective. `{a:'x|', b:'y'}` and
+    // `{a:'x', b:'|y'}` both render `x||y`, collapsing two distinct rows onto one
+    // `__pk` -- silent row loss in the pk-keyed metadata map. Escape the escape
+    // char first, then the delimiter, in each part so the join is unambiguous.
     primary_key
         .iter()
-        .map(|k| format!("CAST(\"{}\" AS TEXT)", k))
+        .map(|k| {
+            format!(
+                "REPLACE(REPLACE(CAST(\"{}\" AS TEXT), '\\', '\\\\'), '|', '\\|')",
+                k
+            )
+        })
         .collect::<Vec<_>>()
         .join(" || '|' || ")
 }
@@ -306,11 +321,34 @@ mod tests {
 
     #[test]
     fn pk_text_expr_single_and_composite() {
+        // Single PK renders unchanged (no delimiter, no collision possible).
         assert_eq!(pk_text_expr(&["id".to_string()]), "CAST(\"id\" AS TEXT)");
+        // Composite PK escapes '\' then '|' in each part before the '|' join.
         assert_eq!(
             pk_text_expr(&["a".to_string(), "b".to_string()]),
-            "CAST(\"a\" AS TEXT) || '|' || CAST(\"b\" AS TEXT)"
+            "REPLACE(REPLACE(CAST(\"a\" AS TEXT), '\\', '\\\\'), '|', '\\|') \
+             || '|' || \
+             REPLACE(REPLACE(CAST(\"b\" AS TEXT), '\\', '\\\\'), '|', '\\|')"
         );
+    }
+
+    #[test]
+    fn pk_text_expr_composite_is_injective() {
+        // Regression for the delimiter-collision bug: `{a:'x|', b:'y'}` and
+        // `{a:'x', b:'|y'}` both rendered `x||y` under a bare `|` join, collapsing
+        // two rows onto one `__pk`. This helper mirrors the SQL escaping (REPLACE
+        // '\' -> '\\' then '|' -> '\|', join with '|') so we can assert the two
+        // distinct composite keys now render distinctly without a database.
+        fn render(parts: &[&str]) -> String {
+            parts
+                .iter()
+                .map(|p| p.replace('\\', "\\\\").replace('|', "\\|"))
+                .collect::<Vec<_>>()
+                .join("|")
+        }
+        assert_ne!(render(&["x|", "y"]), render(&["x", "|y"]));
+        assert_eq!(render(&["x|", "y"]), "x\\||y");
+        assert_eq!(render(&["x", "|y"]), "x|\\|y");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a silent row-loss bug in the shipped content-hash sync path. `pk_text_expr` joined composite primary-key parts with a bare `|`, so two distinct composite PKs could render to the same `__pk` (e.g. `{a:'x|', b:'y'}` and `{a:'x', b:'|y'}` both -> `x||y`) and collapse in the pk-keyed metadata map. The fix escapes `\` then `|` in each composite part before the `|` join, so the rendering is injective. Single-column PKs render unchanged, preserving the `__pk` wire contract for the common case.

## Acceptance criteria mapping

### 1. Two distinct composite PKs never render to the same `__pk`; a `|`-containing component is handled; a golden test pins the former-collision cases; clippy + fmt pass
The composite branch of `pk_text_expr` now wraps each part in `REPLACE(REPLACE(CAST(... AS TEXT), '\', '\\'), '|', '\|')` before the `|` join, so a `|` inside a value is escaped and can no longer be confused with the delimiter -- the join becomes injective. The two former colliders now render distinctly: `{a:'x|', b:'y'} -> x\||y` and `{a:'x', b:'|y'} -> x|\|y`. Single-column PKs take a fast path that skips escaping (no delimiter, no collision possible) and render exactly as before, so only composite-PK tables change. Two tests pin this: `pk_text_expr_single_and_composite` golden-pins the exact escaped composite SQL (and the unchanged single-PK form), and `pk_text_expr_composite_is_injective` pins `x\||y` / `x|\|y` for the two former colliders and asserts they differ (the test mirrors the SQL escaping in Rust because `rowhash.rs` is compiled DB-free). Both static checks are clean.
Evidence: `crates/smugglr-core/src/rowhash.rs::pk_text_expr` + its two tests -- `cargo test -p smugglr-core rowhash` reports 11 passed / 0 failed; `cargo clippy -p smugglr-core --all-targets -- -D warnings` clean; `cargo fmt -p smugglr-core -- --check` exit 0.

## Not done

- The content-hash separator is deliberately **not** changed -- its per-value type tags already disambiguate the delimiter (spike R), so only `pk_text_expr` (bare `|`, no tags) needed the fix.
- `pk_text_expr` is a wire contract: composite-PK tables re-render their `__pk` once and re-sync (single-PK tables are unaffected). This is the intended, versioned behavior change -- and no data is lost by the re-sync; it is the fix for the case where data was being lost.

Closes #285
