### PR TITLE
docs(migrate): 0.5.0 sequencing plan + safehouse crate correction

### DIFF
--- a/docs/plans/migrate-sequencing.md
+++ b/docs/plans/migrate-sequencing.md
@@ -1,7 +1,7 @@
 # migrate 0.5.0 -- build sequencing & merge-queue plan
 
-**Status:** planning
-**Scope:** the 20 open migrate + core-fix issues (#268-#282, #289-#293).
+**Status:** planning -- validated by a 27-agent code-grounded review (2026-07-18)
+**Scope:** the 21 open migrate + core-fix issues (#268-#282, #289-#293, #296).
 **Companion:** `docs/plans/migration.md` (the design).
 
 ## Why this doc
@@ -11,21 +11,18 @@ only one of them is a queue-enforced *stopper*:
 
 - **Queue-enforced (the real stoppers): co-queue collisions.** Two PRs that each pass alone
   but, combined against the tip, either conflict on a shared file (the second is ejected) or
-  fail CI (a change one makes breaks the other). The queue forces these on me; I can only
-  avoid them by not letting the two be in flight together.
+  fail CI. The queue forces these on me; I avoid them by not letting the two be in flight
+  together.
 - **Self-enforced (not a stopper): dependency order.** A dependent PR must not be queued
-  before the code it needs has *merged* -- but I control when I queue, so the phase order
-  prevents this by construction. It is discipline, not a hazard the queue imposes.
+  before its dependency has *merged* -- but I control when I queue, so the phase order
+  prevents this by construction.
 
-So: the phase order handles dependencies (mine to enforce); the **collision lanes** handle
-the co-queue stoppers (the queue's to enforce). This doc gives both, plus the 0.5.0 cut line.
+**Squash merge is on.** It does not relax the collision lanes (the queue still builds each
+branch against the tip). It does mean: **do not stack PRs** (squash rewrites SHAs). Keep every
+PR independent off `main`, and merge a phase's foundation before *opening* its dependents.
 
-**Squash merge is on.** Squash does **not** relax the collision lanes -- the queue still
-builds each branch against the tip, so a shared-file conflict still ejects the PR. What it
-does add: **do not stack PRs.** Squash rewrites SHAs on merge, so a Phase-2 branch cut from
-an unmerged Phase-1 branch will churn painfully. Keep every PR independent off `main`, and
-merge a phase's foundation (e.g. #271/#272) before *opening* the PRs that depend on it. One
-commit per issue on `main` -- clean bisect, but no stacking.
+So: the phase order handles dependencies; the **collision lanes** handle the co-queue
+stoppers. This doc gives both, the 0.5.0 cut line, and the residual risks.
 
 ## Dependency phases
 
@@ -34,117 +31,115 @@ Files in **bold** are new (no collision). Deps are issue numbers that must merge
 ### Phase 0 -- independent core fixes (no migrate deps; live bugs -- ship first)
 | Issue | What | Files | Deps |
 |-------|------|-------|------|
-| #268 | first-run PK sanity check | **`pk_check.rs`** | none |
-| #292 | blob hex/base64 convergence | `rowhash.rs`, wasm adapters | none |
-| #293 | excluded-col newer-`updated_at` | `diff.rs`, `config.rs` | none |
-| #269 | dup-`__pk` warn -> refuse | `diff.rs`/`sync.rs`, `adapter_common.rs` | none |
+| #268 | first-run PK check -- **WARN in 0.5.0**, refuse in 0.5.x | **`pk_check.rs`**, `lib.rs` | none (serialize before #271) |
+| #292 | blob hex/base64 convergence | `rowhash.rs`, `local.rs`, wasm `adapter_common.rs`, http-sql `adapter.rs`, `Cargo.toml` (+base64) | none |
+| #269 | dup-`__pk` warn -> refuse | 3 builders (`local.rs`, `adapter_common.rs`, `adapter.rs`), `config.rs`, `error.rs` | none (after #292) |
+| #293 | excluded-col newer-`updated_at` (new `converge_columns` class) | `diff.rs`/`sync.rs`/`multicast.rs`, `config.rs` | none (after #269) |
 
 ### Phase 1 -- migrate foundations (the spine's root)
 | Issue | What | Files | Deps |
 |-------|------|-------|------|
-| #271 | manifest + AEAD envelope | **`migrate/manifest.rs`**, `lib.rs`, `Cargo.toml` (un-gate chacha wasm32) | none |
-| #272 | ledger | **`migrate/ledger.rs`**, `lib.rs` | #271 |
-
-Extract the **shared schema-projection helper** here (used by #290 reconcile and #271's
-`target_schema`) -- see the reconcile finding below.
+| #271 | manifest + structured Op enum + **native-only** envelope | **`migrate/manifest.rs`** + pre-stub the whole `migrate/` tree, `lib.rs`, `error.rs` (Migrate bridge) | #268 (lib.rs order) |
+| #272 | ledger (+ nullable `preimage_ref`, `schema_projection` columns up front) | **`migrate/ledger.rs`**, `config.rs`, `error.rs` | #271 |
 
 ### Phase 2 -- apply / reverse / lint / author spine
 | Issue | What | Files | Deps |
 |-------|------|-------|------|
-| #275 | destructive-lint | **`migrate/lint.rs`** | #271 |
-| #273 | forward apply engine | **`migrate/apply.rs`**, http-sql plugin | #271, #272 |
-| #274 | reverse/rollback | **`migrate/reverse.rs`**, `snapshot.rs` | #271, #275, #273 |
-| #270 | rails-style CLI generator | **`migrate/generator`**, `main.rs` | #271 |
+| #275 | destructive-lint | **`migrate/lint.rs`** | #271 only |
+| #273 | forward apply engine -- **LOCAL only** (remote = pure generators) | **`migrate/apply.rs`** (ledger-free; exposes `apply_ops`) | #271, #272 |
+| #270 | rails-style CLI generator | **`migrate/generator.rs`**, **`migrate_cli.rs`**, `main.rs` | #271 |
+| #274 | reverse/rollback (append-only vN+1; delta-scoped pre-image via `stash`) | **`migrate/reverse.rs`** | #271, #272, #273, #275 |
 
-### Phase 3 -- the differentiators (surgical recovery + drift)
+### Phase 3 -- compose + the differentiators
 | Issue | What | Files | Deps |
 |-------|------|-------|------|
-| #289 | recovery: surgical log + `--paranoid` | **`migrate/log.rs`**, `snapshot.rs` | #272, #274, #275 |
-| #290 | reconcile: schema-drift | **`migrate/reconcile.rs`** + projection helper | #271, #272 |
+| **#296** | **apply-driver + `smugglr migrate apply`** (composes lint/capture/apply/ledger) | **`migrate/driver.rs`**, `migrate_cli.rs` | #272, #273, #274, #275, #270 |
+| #289 | recovery: surgical log + `--paranoid` (`VACUUM INTO`) | **`migrate/log.rs`** (+ own sidecar DB) | #296, #272, #273, #274 |
+| #290 | reconcile: schema-drift | **`migrate/schema_projection.rs`** + **`reconcile.rs`** | #296, #271, #272 |
 
 ### Phase 4 -- convergence / multi-node (DEFER to 0.5.x)
-| Issue | What | Files | Deps |
-|-------|------|-------|------|
-| #277 | canonicalizer (+impl-hash binding) | `rowhash.rs`, ledger version row | #272 |
-| #276 | authoring discipline | generator / manifest ops | #270, #271 |
-| #278 | version-gate row-sync + quiesce | `diff.rs`/`sync.rs` | #272 |
-| #279 | identity-minting fills | apply / ledger | #272, #273 |
+#277 canonicalizer (+impl-hash binding), #276 authoring discipline, #278 version-gate
+row-sync + quiesce, #279 identity-minting fills.
 
 ### Phase 5 -- onboarding & library path (DEFER to 0.5.x)
-| Issue | What | Files | Deps |
-|-------|------|-------|------|
-| #281 | FORK: declarative vs delta (decision) | none (needs mail input) | -- |
-| #280 | int->UUIDv7 conversion | **`migrate/convert.rs`**, `Cargo.toml` (uuid) | #273, #274, #275 |
-| #282 | parser fidelity (quoted idents) | manifest/apply diff | #281, #271 |
-| #291 | embedder library API | **`migrate/` public surface** | #272, #273 |
+#281 FORK (declarative vs delta, needs mail), #280 int->UUIDv7 (gates #268's 0.5.x
+refuse-flip), #282 parser fidelity, #291 embedder API (remote apply re-homes here).
 
 ## The 0.5.0 cut line
 
-**Ship in 0.5.0 (thin single-node spine):** Phases 0 + 1 + 2 + 3.
-That delivers the whole headline loop -- PK-safety -> author -> apply (lint + ledger) ->
-**reverse** -> **recover** -> **reconcile** -- single-node, with the live core bugs fixed.
-The two founding value props (surgical Reverse, drift Reconcile) both land.
+**HOLDS at 13 spine nodes** (Phases 0-3, including the new #296 driver). Ship: PK-safety
+(warn) -> author -> apply (local) -> **reverse** -> **compose+apply** -> **recover** ->
+**reconcile**, single-node, with the live core bugs fixed. Both founding value props
+(surgical Reverse, drift Reconcile) land -- and they are only non-hollow *because* #296 writes
+the ledger on a real apply.
 
-**Defer to 0.5.x:** Phase 4 (convergence / multi-node) and Phase 5 (the int->UUIDv7
-flagship, the declarative/library fork, the embedder API). None of these are needed for a
-credible single-node 0.5.0, and the flagship conversion (#280) is the hairiest class --
-it wants the full pre-image + hash-rewrite machinery stable first.
+**Defer to 0.5.x:** Phases 4-5. Remote apply (D1/Turso/rqlite transport) is NOT runnable in
+0.5.0 -- #273 ships those as pure, unit-tested statement generators; transport is #291.
 
-**Critical path (longest chain):** #271 -> #272 -> #273 -> #274 -> #289. Five deep.
-#290 and #270 branch off after #271/#272 and run in parallel with the #273->#274->#289 chain.
+**Critical path:** #271 -> #272 -> #273 -> #274 -> **#296** -> #289. #275 and #270 are
+side-prerequisites converging at #296 (#275 -> #274; #270 -> #296's CLI). #290 branches after
+#296. (My pre-ultraplan path omitted the #296 driver.)
 
-## Merge-queue collision lanes
+## Merge-queue collision lanes (validated against real code)
 
-Never let two of these co-queue; land them in the listed order.
+Never let two in a lane co-queue; land them in the listed order.
 
 | Shared file | Issues | Rule |
 |-------------|--------|------|
-| `rowhash.rs` | #292, #277 | #292 first (Phase 0), #277 later (Phase 4) -- naturally separated |
-| `diff.rs`/`sync.rs` | #293, #269, #278 | serialize; one in the queue at a time |
-| `config.rs` | #293, (#278) | minor; follows the `diff.rs` lane |
-| `snapshot.rs` | #274, #289 | #274 before #289 (already the dep order) |
-| `adapter_common.rs` (wasm) | #269, #292 | serialize (both render values) |
-| `main.rs` (CLI) | #270 + apply/reverse/reconcile/`--paranoid` command PRs | serialize CLI PRs |
-| `Cargo.toml` (core) | #271 (chacha wasm32), #280 (uuid) | trivial rebase; low risk |
-| **`lib.rs`** | **every new-migrate-module PR** | see the mitigation below |
+| the 3 metadata builders (`local.rs`, `adapter_common.rs`, `adapter.rs`) | #292, #269 | serialize; #292 first, #269 flips all three to `Result` in lockstep |
+| `config.rs` `SyncConfig`+`Default` | #269 (`duplicate_pk`), #293 (`converge_columns`), #272 (`default_exclude_tables`) | serialize the two field-adders (#269, #293); #272 rebases |
+| `diff.rs`/`sync.rs`/`multicast.rs` | #293, #278(deferred) | #293 in spine; #278 later |
+| `rowhash.rs` | #292, #277(deferred) | #292 first; #277 freezes the hash version #292 mutates -- never invert |
+| `error.rs` `SyncError`+`exit_code()` | #269, #271(Migrate bridge), #272, #290 | append-only; **land the Migrate bridge in #271**; one owner reconciles the exit-code numbers (multiple want 4) |
+| `lib.rs` mod block | #268 (`pk_check`, top-level), #271 (`migrate`) | serialize #268 before #271; see mitigation |
+| `migrate_cli.rs` MigrateCommand enum | #270, #296, #274, #289, #290 | #270 first (creates it); route ALL migrate commands here, never `main.rs` |
+| `migrate/driver.rs` success path | #296, #289 (write-ahead hook), #290 (baseline write) | #296 first; serialize #289/#290 |
+| `Cargo.toml` (core) | #292 (base64) | only real spine toucher -- #271 makes NO change (native-only envelope), #280 deferred |
 
-### The `lib.rs` hazard (the most likely queue-stopper)
+**Dissolved / defused from the pre-ultraplan draft:**
+- `snapshot.rs` lane is GONE -- neither #274 nor #289 touches it (#274 uses `stash::build_store`; #289 uses a new `VACUUM INTO` in `log.rs`).
+- The wasm32 chacha gate is NOT a hazard -- #271's envelope is native-only for 0.5.0 (zero `Cargo.toml`, no wasm32 clippy trigger); wasm/edge envelope defers with remote apply.
 
-Almost every migrate PR adds a `mod <name>;` line to `smugglr-core/src/lib.rs`. In a merge
-queue that means the second migrate PR in flight conflicts on `lib.rs` -- constantly.
+### The `lib.rs` / `migrate/mod.rs` mitigation
 
-**Mitigation:** in the Phase-1 foundation PR (#271), pre-declare the whole migrate module
-tree as empty stubs:
+Add ONE `pub mod migrate;` to `lib.rs` in #271 (after #268's `pk_check`), then pre-declare the
+whole tree with its cfg gates as empty stubs in `migrate/mod.rs`: manifest, ledger, apply,
+reverse, lint, log, reconcile, schema_projection, generator, convert, and a native-gated
+`driver` (#296). Later PRs fill a body only and never re-touch `lib.rs` or `migrate/mod.rs`.
 
-```rust
-// smugglr-core/src/lib.rs
-mod migrate; // -> migrate/mod.rs declares: manifest, ledger, apply, reverse,
-             //    lint, log, reconcile, convert, generator (empty stubs)
-```
+### Dependency order (self-enforced)
 
-Then every later PR only fills in its own **new file body** and never re-touches `lib.rs`
-(or `migrate/mod.rs` only for its own line). `lib.rs` stops being a shared surface and the
-lane collapses.
+#268 before #271 | #271+#272 before #273 | #273+#275 before #274 | #274 before #296 |
+#296 before #289/#290 | #281 before #282.
 
-### The wasm32 gate (#271)
+## Residual risks (from the adversarial pass)
 
-#271 un-gates `chacha20poly1305` for `wasm32`, and CI clippy is gated on the wasm32 target.
-If that PR is not clean on wasm32 it blocks the **entire** queue behind it. Treat #271 as a
-solo, extra-reviewed merge -- do not queue anything behind it until it is green.
-
-### Dependency order (self-enforced -- queue each only after its dep has *merged*)
-
-Not queue-stoppers (I control queueing), but the sequence to hold:
-#271+#272 before #273 | #273 before #274 | #274 before #289 | #272 before #276/#279
-| #281 before #282.
+- **#268 warn, not refuse (Sean's ruling).** 0.5.0 warns on legacy integer-PK instead of
+  refusing, because the remedy (#280) is deferred. A warned user who proceeds can still hit
+  the cross-node data loss the check exists to prevent -- the warning must be unmissable and
+  carry the manual UUIDv7 recipe; the hard refusal flips on in 0.5.x with #280.
+- **#269 covers only the builder path.** The multicast gossip `on_delta` path (`local.rs:302`,
+  `INSERT OR REPLACE`) bypasses the builders -- a duplicate `__pk` arriving as a Delta is not
+  caught until #278 (deferred). Changelog must not claim full cross-node enforcement.
+- **#293 is inert until config migration.** The fix applies to the new `converge_columns`
+  class; deployments using `exclude_columns` for pii stay buggy until operators move columns.
+  Needs an explicit changelog config-migration note.
+- **#274 Inline pre-image is unbounded.** Pin the size boundary where Inline refuses and a
+  relay store becomes mandatory, or a large DROP-COLUMN silently fails at capture.
+- **#289 two-file non-atomicity.** The sidecar log and the migrated DB are separate files;
+  recovery treats pending as maybe-applied and leans on #273 idempotent redo; `--paranoid`
+  restore must close all migrated-DB handles before the file swap or it corrupts an open WAL.
+- **#296 is the sole apply path.** #291's future programmatic applier must build ON
+  `apply_migration`, not fork a second loop, or the two drift on ledger/lint/capture order.
 
 ## The reconcile finding (informs #290 and #271)
 
 A schema-drift hash must be a **pragma-derived semantic projection** (`table_info` +
 `foreign_key_list` + `index_list`/`index_info`), **not** a hash of `sqlite_master` text. A
-12-step rebuild that recreates a logically-identical schema rewrites the stored `CREATE`
-text (`ALTER ... RENAME TO` quotes the name, reorders) -- so a raw or whitespace-normalized
-text hash false-positives drift on every rebuild. The semantic projection is stable across
+12-step rebuild that recreates a logically-identical schema rewrites the stored `CREATE` text
+(`ALTER ... RENAME TO` quotes the name, reorders) -- so a raw or whitespace-normalized text
+hash false-positives drift on every rebuild. The semantic projection is stable across
 rebuilds yet still catches out-of-band `ALTER`/`DROP INDEX`, and is PRAGMA-portable to
-D1/Turso. #271's `target_schema` precondition has the same latent bug and must reuse the
-projection. (Toy-verified 2026-07-18; reflection `019f766a`.)
+D1/Turso. #271's `target_schema` precondition has the same latent bug and reuses the
+projection. (Toy-verified 2026-07-18; reflection `019f766a`. Indexes canonicalized by
+(cols, unique, origin), never the generated index name.)

--- a/docs/plans/migrate-sequencing.md
+++ b/docs/plans/migrate-sequencing.md
@@ -1,0 +1,150 @@
+# migrate 0.5.0 -- build sequencing & merge-queue plan
+
+**Status:** planning
+**Scope:** the 20 open migrate + core-fix issues (#268-#282, #289-#293).
+**Companion:** `docs/plans/migration.md` (the design).
+
+## Why this doc
+
+GitHub's merge queue merges PRs **serially against the tip**. Two distinct concerns, and
+only one of them is a queue-enforced *stopper*:
+
+- **Queue-enforced (the real stoppers): co-queue collisions.** Two PRs that each pass alone
+  but, combined against the tip, either conflict on a shared file (the second is ejected) or
+  fail CI (a change one makes breaks the other). The queue forces these on me; I can only
+  avoid them by not letting the two be in flight together.
+- **Self-enforced (not a stopper): dependency order.** A dependent PR must not be queued
+  before the code it needs has *merged* -- but I control when I queue, so the phase order
+  prevents this by construction. It is discipline, not a hazard the queue imposes.
+
+So: the phase order handles dependencies (mine to enforce); the **collision lanes** handle
+the co-queue stoppers (the queue's to enforce). This doc gives both, plus the 0.5.0 cut line.
+
+**Squash merge is on.** Squash does **not** relax the collision lanes -- the queue still
+builds each branch against the tip, so a shared-file conflict still ejects the PR. What it
+does add: **do not stack PRs.** Squash rewrites SHAs on merge, so a Phase-2 branch cut from
+an unmerged Phase-1 branch will churn painfully. Keep every PR independent off `main`, and
+merge a phase's foundation (e.g. #271/#272) before *opening* the PRs that depend on it. One
+commit per issue on `main` -- clean bisect, but no stacking.
+
+## Dependency phases
+
+Files in **bold** are new (no collision). Deps are issue numbers that must merge first.
+
+### Phase 0 -- independent core fixes (no migrate deps; live bugs -- ship first)
+| Issue | What | Files | Deps |
+|-------|------|-------|------|
+| #268 | first-run PK sanity check | **`pk_check.rs`** | none |
+| #292 | blob hex/base64 convergence | `rowhash.rs`, wasm adapters | none |
+| #293 | excluded-col newer-`updated_at` | `diff.rs`, `config.rs` | none |
+| #269 | dup-`__pk` warn -> refuse | `diff.rs`/`sync.rs`, `adapter_common.rs` | none |
+
+### Phase 1 -- migrate foundations (the spine's root)
+| Issue | What | Files | Deps |
+|-------|------|-------|------|
+| #271 | manifest + AEAD envelope | **`migrate/manifest.rs`**, `lib.rs`, `Cargo.toml` (un-gate chacha wasm32) | none |
+| #272 | ledger | **`migrate/ledger.rs`**, `lib.rs` | #271 |
+
+Extract the **shared schema-projection helper** here (used by #290 reconcile and #271's
+`target_schema`) -- see the reconcile finding below.
+
+### Phase 2 -- apply / reverse / lint / author spine
+| Issue | What | Files | Deps |
+|-------|------|-------|------|
+| #275 | destructive-lint | **`migrate/lint.rs`** | #271 |
+| #273 | forward apply engine | **`migrate/apply.rs`**, http-sql plugin | #271, #272 |
+| #274 | reverse/rollback | **`migrate/reverse.rs`**, `snapshot.rs` | #271, #275, #273 |
+| #270 | rails-style CLI generator | **`migrate/generator`**, `main.rs` | #271 |
+
+### Phase 3 -- the differentiators (surgical recovery + drift)
+| Issue | What | Files | Deps |
+|-------|------|-------|------|
+| #289 | recovery: surgical log + `--paranoid` | **`migrate/log.rs`**, `snapshot.rs` | #272, #274, #275 |
+| #290 | reconcile: schema-drift | **`migrate/reconcile.rs`** + projection helper | #271, #272 |
+
+### Phase 4 -- convergence / multi-node (DEFER to 0.5.x)
+| Issue | What | Files | Deps |
+|-------|------|-------|------|
+| #277 | canonicalizer (+impl-hash binding) | `rowhash.rs`, ledger version row | #272 |
+| #276 | authoring discipline | generator / manifest ops | #270, #271 |
+| #278 | version-gate row-sync + quiesce | `diff.rs`/`sync.rs` | #272 |
+| #279 | identity-minting fills | apply / ledger | #272, #273 |
+
+### Phase 5 -- onboarding & library path (DEFER to 0.5.x)
+| Issue | What | Files | Deps |
+|-------|------|-------|------|
+| #281 | FORK: declarative vs delta (decision) | none (needs mail input) | -- |
+| #280 | int->UUIDv7 conversion | **`migrate/convert.rs`**, `Cargo.toml` (uuid) | #273, #274, #275 |
+| #282 | parser fidelity (quoted idents) | manifest/apply diff | #281, #271 |
+| #291 | embedder library API | **`migrate/` public surface** | #272, #273 |
+
+## The 0.5.0 cut line
+
+**Ship in 0.5.0 (thin single-node spine):** Phases 0 + 1 + 2 + 3.
+That delivers the whole headline loop -- PK-safety -> author -> apply (lint + ledger) ->
+**reverse** -> **recover** -> **reconcile** -- single-node, with the live core bugs fixed.
+The two founding value props (surgical Reverse, drift Reconcile) both land.
+
+**Defer to 0.5.x:** Phase 4 (convergence / multi-node) and Phase 5 (the int->UUIDv7
+flagship, the declarative/library fork, the embedder API). None of these are needed for a
+credible single-node 0.5.0, and the flagship conversion (#280) is the hairiest class --
+it wants the full pre-image + hash-rewrite machinery stable first.
+
+**Critical path (longest chain):** #271 -> #272 -> #273 -> #274 -> #289. Five deep.
+#290 and #270 branch off after #271/#272 and run in parallel with the #273->#274->#289 chain.
+
+## Merge-queue collision lanes
+
+Never let two of these co-queue; land them in the listed order.
+
+| Shared file | Issues | Rule |
+|-------------|--------|------|
+| `rowhash.rs` | #292, #277 | #292 first (Phase 0), #277 later (Phase 4) -- naturally separated |
+| `diff.rs`/`sync.rs` | #293, #269, #278 | serialize; one in the queue at a time |
+| `config.rs` | #293, (#278) | minor; follows the `diff.rs` lane |
+| `snapshot.rs` | #274, #289 | #274 before #289 (already the dep order) |
+| `adapter_common.rs` (wasm) | #269, #292 | serialize (both render values) |
+| `main.rs` (CLI) | #270 + apply/reverse/reconcile/`--paranoid` command PRs | serialize CLI PRs |
+| `Cargo.toml` (core) | #271 (chacha wasm32), #280 (uuid) | trivial rebase; low risk |
+| **`lib.rs`** | **every new-migrate-module PR** | see the mitigation below |
+
+### The `lib.rs` hazard (the most likely queue-stopper)
+
+Almost every migrate PR adds a `mod <name>;` line to `smugglr-core/src/lib.rs`. In a merge
+queue that means the second migrate PR in flight conflicts on `lib.rs` -- constantly.
+
+**Mitigation:** in the Phase-1 foundation PR (#271), pre-declare the whole migrate module
+tree as empty stubs:
+
+```rust
+// smugglr-core/src/lib.rs
+mod migrate; // -> migrate/mod.rs declares: manifest, ledger, apply, reverse,
+             //    lint, log, reconcile, convert, generator (empty stubs)
+```
+
+Then every later PR only fills in its own **new file body** and never re-touches `lib.rs`
+(or `migrate/mod.rs` only for its own line). `lib.rs` stops being a shared surface and the
+lane collapses.
+
+### The wasm32 gate (#271)
+
+#271 un-gates `chacha20poly1305` for `wasm32`, and CI clippy is gated on the wasm32 target.
+If that PR is not clean on wasm32 it blocks the **entire** queue behind it. Treat #271 as a
+solo, extra-reviewed merge -- do not queue anything behind it until it is green.
+
+### Dependency order (self-enforced -- queue each only after its dep has *merged*)
+
+Not queue-stoppers (I control queueing), but the sequence to hold:
+#271+#272 before #273 | #273 before #274 | #274 before #289 | #272 before #276/#279
+| #281 before #282.
+
+## The reconcile finding (informs #290 and #271)
+
+A schema-drift hash must be a **pragma-derived semantic projection** (`table_info` +
+`foreign_key_list` + `index_list`/`index_info`), **not** a hash of `sqlite_master` text. A
+12-step rebuild that recreates a logically-identical schema rewrites the stored `CREATE`
+text (`ALTER ... RENAME TO` quotes the name, reorders) -- so a raw or whitespace-normalized
+text hash false-positives drift on every rebuild. The semantic projection is stable across
+rebuilds yet still catches out-of-band `ALTER`/`DROP INDEX`, and is PRAGMA-portable to
+D1/Turso. #271's `target_schema` precondition has the same latent bug and must reuse the
+projection. (Toy-verified 2026-07-18; reflection `019f766a`.)

--- a/docs/plans/migration.md
+++ b/docs/plans/migration.md
@@ -1,7 +1,7 @@
 # smugglr migrate (v0.1 design)
 
 **Status:** draft, in design
-**Crate:** `@smugglr/safehouse` (houses migrate now; the parked GDPR crypto-shred layer when we return to it). `migrate` is the feature/command; the migration-tracking table keeps the name "ledger" (`@smugglr/ledger`).
+**Crate:** migrate lives in `smugglr-core` (`crates/smugglr-core/src/migrate/`). `@smugglr/safehouse` is reserved for the **crypto / field-protection** layer (the parked GDPR crypto-shred thesis), not migrate itself. `migrate` is the feature/command; the migration-tracking table keeps the name "ledger" (`@smugglr/ledger`).
 **Author:** smugglr
 **Research:** legion reflection chain `019f684a..019f698e`
 (`legion recall --repo smugglr --context "smugglr migrate design"`)
@@ -638,7 +638,8 @@ Full catalog: `legion recall --repo smugglr --context "adversarial spike sweep"`
 ## Parked: GDPR crypto-shred (future layer)
 
 Explored with platform + mail; **parked, not built** -- migrate ships without it, and it is a
-separable additive layer. The idea: combine `@rafters/ledger`'s subject-accounting with
+separable additive layer. This is the layer the `@smugglr/safehouse` crate is reserved for
+(not migrate, which lives in `smugglr-core`). The idea: combine `@rafters/ledger`'s subject-accounting with
 smugglr's crypto substrate to make *replicated SQLite GDPR-erasure-compatible* via
 **crypto-shredding** (encrypt subject data under a key; erase = destroy the key; ciphertext
 stays everywhere but irrecoverable -- solving the resurrection problem physical delete cannot on

--- a/docs/plans/migration.md
+++ b/docs/plans/migration.md
@@ -110,6 +110,13 @@ A locally-sequential key (`AUTOINCREMENT`, or a bare `INTEGER PRIMARY KEY` rowid
 machines both mint `id = 5` for different rows, and the fabric silently overwrites one with the
 other. Guaranteed data loss -- so smugglr does not merely warn, it **refuses**:
 
+> **0.5.0 exception (Sean, 2026-07-18):** the sanctioned remedy -- the in-tool `int -> UUIDv7`
+> conversion -- is deferred to 0.5.x, so hard-refusing the onboarding user with no in-tool fix
+> is worse than warning. 0.5.0 therefore emits a loud, unmissable **warning** (carrying the
+> manual UUIDv7 recipe) rather than refusing; the hard refusal below flips on in 0.5.x once the
+> conversion exists. A warned user who proceeds can still hit the cross-node data loss this
+> check exists to prevent -- accepted tradeoff for the onboarding window only.
+
 - **First-run sanity check (keyed on the _declared_ PK, per rd2 consensus).** smugglr
   inspects the schema on first run and refuses an incompatible one. The check keys on the
   **declared primary-key type** and rejects exactly three shapes: `INTEGER PRIMARY KEY` (the


### PR DESCRIPTION
## Summary

Pre-plans the migrate 0.5.0 build order so nothing stalls the (squash) merge queue, and corrects the stale crate reference in the design doc. Docs only.

## Acceptance criteria mapping

### 1. A sequencing doc orders the 20 issues into dependency phases, names the 0.5.0 cut line, and lists the merge-queue collision lanes
`docs/plans/migrate-sequencing.md` groups the 20 open issues (#268-#282, #289-#293) into six dependency phases (Phase 0 independent core fixes through Phase 5 onboarding/library path), each row naming the touched files and the issue-number deps. The "The 0.5.0 cut line" section draws the thin single-node spine (Phases 0-3: PK-safety -> author -> apply -> reverse -> recover -> reconcile) and defers convergence/multi-node and the int->UUIDv7 flagship to 0.5.x, with the critical path #271->#272->#273->#274->#289 called out. The "Merge-queue collision lanes" section tables every file touched by more than one PR; the `lib.rs` mod-churn hazard gets a pre-stub mitigation and #271's wasm32-gate gets a solo-merge callout. The intro distinguishes queue-enforced stoppers (co-queue collisions) from self-enforced dependency order.
Evidence: `docs/plans/migrate-sequencing.md` -- the phase tables, the "## The 0.5.0 cut line" and "## Merge-queue collision lanes" sections, and the "## The `lib.rs` hazard" subsection.

### 2. migration.md's crate line is corrected
`docs/plans/migration.md` line 4 now reads that migrate lives in `smugglr-core` and `@smugglr/safehouse` is reserved for the crypto/field-protection layer (per Sean's ruling), replacing the prior "safehouse houses migrate". A matching clause in the "## Parked: GDPR crypto-shred" section names safehouse as that layer's crate, so the two references agree instead of contradicting.
Evidence: `docs/plans/migration.md` -- the `**Crate:**` line and the parked-section clause.

## Not done

- No code changes and no issue re-filing here -- this is planning + a doc correction. The actual build PRs follow the phases in the new doc.
- The #281 declarative-vs-delta fork still needs mail's input before its phase can proceed; noted in the plan, not resolved here.

Closes #294
