### PR TITLE
fix(#292): converge blob columns across hex/base64 backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,7 @@ name = "smugglr-core"
 version = "0.4.3"
 dependencies = [
  "anyhow",
+ "base64",
  "chacha20poly1305",
  "chrono",
  "hex",

--- a/crates/smugglr-core/Cargo.toml
+++ b/crates/smugglr-core/Cargo.toml
@@ -48,6 +48,11 @@ anyhow = "1"
 sha2 = "0.10"
 hex = "0.4"
 
+# Blob canonicalization for the content hash: a JSON backend renders BLOB
+# columns as base64, native renders lowercase hex; the hash pins hex, so the
+# base64 rendering is decoded here before folding. Always-on, WASM-compatible. (#292)
+base64 = "0.22"
+
 # Timestamps
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 

--- a/crates/smugglr-core/src/rowhash.rs
+++ b/crates/smugglr-core/src/rowhash.rs
@@ -18,6 +18,7 @@
 
 use std::collections::HashMap;
 
+use base64::Engine as _;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -78,11 +79,13 @@ fn canonical_number(n: &serde_json::Number) -> String {
 /// sources. An absent column is treated as NULL (a missing JSON field and an
 /// explicit null are the same row).
 ///
-/// BLOB wire contract: the native path renders blobs as lowercase hex (via
-/// `local.rs::get_json_value`). For a remote (JSON) source to converge, its
-/// endpoint MUST also transport blob columns as lowercase-hex strings; a backend
-/// that returns base64 or a byte array will hash differently. Backends that
-/// cannot meet this should `exclude` their blob columns. (Residual of #202.)
+/// BLOB wire contract: blobs fold as lowercase hex on EVERY path. The native
+/// path emits hex directly (`local.rs::get_json_value`); a JSON backend that
+/// renders base64 (or another encoding) MUST canonicalize its blob columns to
+/// hex via [`canonicalize_blob_columns`] before calling this, so the same bytes
+/// hash identically everywhere. A value that cannot be canonicalized should be
+/// `exclude`d on both peers -- one-sided exclusion does not converge, since the
+/// hex-rendering native side still folds it. (#292, residual of #202.)
 pub fn content_hash(
     row: &HashMap<String, Value>,
     columns_in_order: &[String],
@@ -121,6 +124,85 @@ pub fn content_hash(
         hasher.update(b"|");
     }
     hex::encode(hasher.finalize())
+}
+
+/// How a backend renders a BLOB column's bytes into the JSON string that
+/// reaches [`content_hash`].
+///
+/// The native rusqlite path renders lowercase hex (`local.rs::get_json_value`);
+/// JSON SQL endpoints (Turso/rqlite/D1 and the wasm executors) commonly render
+/// standard base64. Two peers that fold different renderings of the SAME bytes
+/// never converge -- the row reads `content_differs` forever. The content hash
+/// pins ONE canonical form (lowercase hex), so a non-hex backend must declare
+/// its encoding and canonicalize before hashing. (#292, residual of #202.)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlobEncoding {
+    /// Lowercase hexadecimal -- the canonical form; the native path already
+    /// emits this, so canonicalizing it only validates and normalizes case.
+    Hex,
+    /// Standard (padded) base64 -- what the JSON SQL backends emit.
+    Base64,
+}
+
+/// True when a declared SQLite column type denotes a BLOB, so its rendered
+/// string value must be canonicalized to hex before hashing.
+///
+/// Match is on the declared type containing `BLOB` (case-insensitive), the
+/// affinity rule SQLite itself uses. An EMPTY declared type is deliberately NOT
+/// treated as a blob: although SQLite gives it BLOB affinity, such columns hold
+/// arbitrary dynamically-typed values, and base64-decoding a genuine text value
+/// would corrupt it. Only explicitly-declared BLOB columns are canonicalized --
+/// the unambiguous, common case that the divergence bug concerns.
+pub fn is_blob_column(col_type: &str) -> bool {
+    col_type.to_ascii_uppercase().contains("BLOB")
+}
+
+/// Re-encode a backend's rendered BLOB string to the canonical lowercase-hex
+/// form the content hash folds.
+///
+/// Returns `None` when `value` does not decode under `encoding`. The caller must
+/// then leave the value untouched and warn -- a value we cannot canonicalize is
+/// never silently re-folded in its divergent encoding (that is the original bug)
+/// and never silently corrupted by a mis-guessed decode.
+pub fn canonical_blob_hex(value: &str, encoding: BlobEncoding) -> Option<String> {
+    let bytes = match encoding {
+        // Already canonical; decode+encode validates and lowercases.
+        BlobEncoding::Hex => hex::decode(value).ok()?,
+        BlobEncoding::Base64 => base64::engine::general_purpose::STANDARD
+            .decode(value)
+            .ok()?,
+    };
+    Some(hex::encode(bytes))
+}
+
+/// Rewrite every listed blob column in `row` from `encoding` to canonical
+/// lowercase hex in place, so a JSON backend's [`content_hash`] converges with
+/// the native (hex) reference.
+///
+/// Absent, NULL, or non-string values are left untouched (a NULL blob folds as
+/// NULL on every path; a byte-array rendering is out of scope). Returns the
+/// names of any columns whose string value could not be decoded under
+/// `encoding`: the caller MUST warn on these -- their raw rendering would hash
+/// divergently and the operator should `exclude` the column. (#292)
+pub fn canonicalize_blob_columns(
+    row: &mut HashMap<String, Value>,
+    blob_columns: &[String],
+    encoding: BlobEncoding,
+) -> Vec<String> {
+    let mut undecodable = Vec::new();
+    for col in blob_columns {
+        let raw = match row.get(col) {
+            Some(Value::String(s)) => s.clone(),
+            _ => continue,
+        };
+        match canonical_blob_hex(&raw, encoding) {
+            Some(hexed) => {
+                row.insert(col.clone(), Value::String(hexed));
+            }
+            None => undecodable.push(col.clone()),
+        }
+    }
+    undecodable
 }
 
 /// Build a SQLite expression that renders the primary key as stable text.
@@ -317,6 +399,112 @@ mod tests {
             content_hash(&with_null, &cols, &[], "updated_at"),
             content_hash(&absent, &cols, &[], "updated_at")
         );
+    }
+
+    #[test]
+    fn blob_converges_across_hex_and_base64_backends() {
+        // Spike S (#292): the blob "He" is rendered as lowercase hex "4865" by the
+        // native rusqlite path and as standard base64 "SGU=" by a JSON backend.
+        // Folding the raw renderings diverges, so the row reads content_differs
+        // forever and the two nodes NEVER converge. Canonicalizing the JSON
+        // backend's blob column to hex before hashing makes them agree.
+        let cols = ["id".to_string(), "data".to_string()];
+        let native = row(&[("id", json!(1)), ("data", json!("4865"))]); // hex reference
+        let json_raw = row(&[("id", json!(1)), ("data", json!("SGU="))]); // base64
+
+        // Pre-fix: the raw renderings hash differently.
+        assert_ne!(
+            content_hash(&native, &cols, &[], "updated_at"),
+            content_hash(&json_raw, &cols, &[], "updated_at"),
+            "raw hex vs base64 renderings must diverge -- this is the bug"
+        );
+
+        // Fix: canonicalize the JSON backend's blob column, then hash.
+        let mut json_canon = json_raw.clone();
+        let undecodable =
+            canonicalize_blob_columns(&mut json_canon, &["data".to_string()], BlobEncoding::Base64);
+        assert!(undecodable.is_empty(), "SGU= must decode as base64");
+        assert_eq!(
+            json_canon.get("data"),
+            Some(&json!("4865")),
+            "base64 SGU= must canonicalize to hex 4865"
+        );
+        assert_eq!(
+            content_hash(&native, &cols, &[], "updated_at"),
+            content_hash(&json_canon, &cols, &[], "updated_at"),
+            "after canonicalization the blob column must converge across backends"
+        );
+    }
+
+    #[test]
+    fn canonical_blob_hex_round_trips_and_lowercases() {
+        // Base64 decodes to the same bytes hex encodes; hex input is normalized
+        // to lowercase so a backend rendering uppercase hex still converges.
+        assert_eq!(
+            canonical_blob_hex("SGU=", BlobEncoding::Base64).as_deref(),
+            Some("4865")
+        );
+        assert_eq!(
+            canonical_blob_hex("4865", BlobEncoding::Hex).as_deref(),
+            Some("4865")
+        );
+        // The ambiguity that forces a caller-supplied encoding: "4865" is valid
+        // base64 too, decoding to DIFFERENT bytes than as hex -- so a blind decode
+        // without knowing the source encoding would corrupt the value.
+        assert_ne!(
+            canonical_blob_hex("4865", BlobEncoding::Base64).as_deref(),
+            Some("4865")
+        );
+        assert_eq!(
+            canonical_blob_hex("DEADBEEF", BlobEncoding::Hex).as_deref(),
+            Some("deadbeef")
+        );
+    }
+
+    #[test]
+    fn canonical_blob_hex_reports_undecodable() {
+        // A value that is not valid under the declared encoding is rejected (None)
+        // rather than silently folded in its divergent form.
+        assert_eq!(
+            canonical_blob_hex("!!!not-base64!!!", BlobEncoding::Base64),
+            None
+        );
+        assert_eq!(canonical_blob_hex("xyz", BlobEncoding::Hex), None);
+    }
+
+    #[test]
+    fn canonicalize_blob_columns_skips_null_absent_and_flags_bad() {
+        // NULL / absent / non-string blob values are left untouched; an
+        // undecodable string is reported for the caller to warn on.
+        let mut r = row(&[
+            ("id", json!(1)),
+            ("good", json!("SGU=")),
+            ("null_blob", Value::Null),
+            ("bad", json!("%%%")),
+        ]);
+        let cols = [
+            "good".to_string(),
+            "null_blob".to_string(),
+            "absent".to_string(),
+            "bad".to_string(),
+        ];
+        let undecodable = canonicalize_blob_columns(&mut r, &cols, BlobEncoding::Base64);
+        assert_eq!(r.get("good"), Some(&json!("4865")));
+        assert_eq!(r.get("null_blob"), Some(&Value::Null));
+        assert_eq!(undecodable, vec!["bad".to_string()]);
+    }
+
+    #[test]
+    fn is_blob_column_matches_declared_blob_only() {
+        assert!(is_blob_column("BLOB"));
+        assert!(is_blob_column("blob"));
+        assert!(is_blob_column("MEDIUMBLOB"));
+        assert!(!is_blob_column("TEXT"));
+        assert!(!is_blob_column("INTEGER"));
+        // Empty declared type has BLOB affinity in SQLite but is deliberately NOT
+        // canonicalized -- it holds dynamically-typed values a base64-decode could
+        // corrupt.
+        assert!(!is_blob_column(""));
     }
 
     #[test]

--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -122,6 +122,45 @@ pub(crate) fn row_maps_to_metadata(
     result
 }
 
+/// Canonicalize every declared BLOB column across `maps` from the backend's
+/// base64 rendering to the lowercase hex the content hash pins, so a blob column
+/// converges with the native (hex) reference instead of reading `content_differs`
+/// forever (#292). BLOB columns are detected from `info` via the shared
+/// `rowhash::is_blob_column`, so the wasm, plugin, and native paths cannot drift
+/// on what counts as a blob. Call this on the row maps BEFORE
+/// [`row_maps_to_metadata`]. A value that fails to decode is left untouched and
+/// warned about -- it hashes divergently and the operator should `exclude` it.
+///
+/// NOTE: base64 is assumed as the wire encoding (per spike S). A backend that
+/// renders blobs as hex instead would be corrupted by this decode; per-endpoint
+/// encoding belongs in the profile (future work).
+pub(crate) fn canonicalize_json_blobs(maps: &mut [HashMap<String, Value>], info: &TableInfo) {
+    let blob_columns: Vec<String> = info
+        .columns
+        .iter()
+        .filter(|c| smugglr_core::rowhash::is_blob_column(&c.col_type))
+        .map(|c| c.name.clone())
+        .collect();
+    if blob_columns.is_empty() {
+        return;
+    }
+    for row in maps.iter_mut() {
+        for col in smugglr_core::rowhash::canonicalize_blob_columns(
+            row,
+            &blob_columns,
+            smugglr_core::rowhash::BlobEncoding::Base64,
+        ) {
+            web_sys::console::warn_1(
+                &format!(
+                    "smugglr: blob column {} in {} did not decode as base64 -- it hashes divergently across backends; add it to exclude_columns",
+                    col, info.name
+                )
+                .into(),
+            );
+        }
+    }
+}
+
 /// Build the incremental-metadata query: every row whose `timestamp_column`
 /// is at or after the cursor, with a synthetic `__pk` text column.
 ///

--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -217,7 +217,8 @@ impl FetchDataSource {
         let response = self.execute(&sql, &params).await?;
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
-        let maps = adapter_common::rows_to_maps(&columns, &rows);
+        let mut maps = adapter_common::rows_to_maps(&columns, &rows);
+        adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
         Ok(adapter_common::row_maps_to_metadata(
             &maps,
@@ -291,7 +292,8 @@ impl DataSource for FetchDataSource {
         let response = self.execute(&sql, &[]).await?;
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
-        let maps = adapter_common::rows_to_maps(&columns, &rows);
+        let mut maps = adapter_common::rows_to_maps(&columns, &rows);
+        adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
         Ok(adapter_common::row_maps_to_metadata(
             &maps,

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -110,7 +110,8 @@ impl LocalSqlDataSource {
             adapter_common::incremental_metadata_sql(table, &info.primary_key, timestamp_column);
         let params = vec![Value::String(since_timestamp.to_string())];
         let result = self.run(&sql, &params).await?;
-        let maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
+        let mut maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
+        adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
         Ok(adapter_common::row_maps_to_metadata(
             &maps,
@@ -181,7 +182,8 @@ impl DataSource for LocalSqlDataSource {
         let column_order: Vec<String> = info.columns.iter().map(|c| c.name.clone()).collect();
         let sql = format!("SELECT *, {} AS __pk FROM \"{}\"", pk_expr, table);
         let result = self.run(&sql, &[]).await?;
-        let maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
+        let mut maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
+        adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
         Ok(adapter_common::row_maps_to_metadata(
             &maps,

--- a/plugins/smugglr-http-sql/src/adapter.rs
+++ b/plugins/smugglr-http-sql/src/adapter.rs
@@ -271,7 +271,10 @@ impl PluginAdapter for HttpSqlAdapter {
         let response = self.execute(&sql, &[]).await?;
         let columns = self.extract_columns(&response)?;
         let rows = self.extract_rows(&response, &columns)?;
-        let maps = smugglr_core::batch_sql::rows_to_maps(&columns, &rows);
+        let mut maps = smugglr_core::batch_sql::rows_to_maps(&columns, &rows);
+        // Canonicalize BLOB columns (base64 on the wire) to the lowercase hex the
+        // content hash pins, so blob columns converge with the native path (#292).
+        canonicalize_row_blobs(&mut maps, &info);
         Ok(build_row_metadata(
             &maps,
             &column_order,
@@ -356,6 +359,42 @@ impl PluginAdapter for HttpSqlAdapter {
 /// it to "" would collapse every such row onto one entry -- silently dropping
 /// rows and provoking spurious deletes. Skip and warn; likewise surface a
 /// duplicate PK-text that overwrites an existing entry.
+/// Canonicalize every declared BLOB column across `maps` from the backend's
+/// base64 rendering to the lowercase hex the content hash pins, so a blob column
+/// converges with the native (hex) reference instead of reading `content_differs`
+/// forever (#292). BLOB columns are detected from `info` via the shared
+/// `rowhash::is_blob_column` so this crate and the wasm/native paths cannot drift
+/// on what counts as a blob. A value that fails to decode is left untouched and
+/// warned about -- it hashes divergently and the operator should `exclude` it.
+///
+/// NOTE: base64 is assumed as the wire encoding (per spike S). A remote that
+/// renders blobs as hex instead would be corrupted by this decode; per-endpoint
+/// encoding belongs in `Profile` (future work).
+fn canonicalize_row_blobs(maps: &mut [HashMap<String, Value>], info: &TableInfo) {
+    let blob_columns: Vec<String> = info
+        .columns
+        .iter()
+        .filter(|c| smugglr_core::rowhash::is_blob_column(&c.col_type))
+        .map(|c| c.name.clone())
+        .collect();
+    if blob_columns.is_empty() {
+        return;
+    }
+    for row in maps.iter_mut() {
+        for col in smugglr_core::rowhash::canonicalize_blob_columns(
+            row,
+            &blob_columns,
+            smugglr_core::rowhash::BlobEncoding::Base64,
+        ) {
+            eprintln!(
+                "smugglr-http-sql: blob column '{}' in {} did not decode as base64 -- it hashes \
+                 divergently across backends; add it to exclude_columns",
+                col, info.name
+            );
+        }
+    }
+}
+
 fn build_row_metadata(
     maps: &[HashMap<String, Value>],
     column_order: &[String],
@@ -423,6 +462,64 @@ mod tests {
             meta.is_empty(),
             "NULL-__pk rows must be skipped, not collapsed onto one key; got {} entries",
             meta.len()
+        );
+    }
+
+    #[test]
+    fn canonicalize_row_blobs_converges_with_native_hex() {
+        // #292: a JSON backend renders a BLOB column as base64 ("SGU="); the
+        // native rusqlite path renders lowercase hex ("4865"). Before the fix the
+        // two content hashes diverge and the row reads content_differs forever.
+        // After canonicalizing the base64 blob to hex, the plugin's content hash
+        // for the row equals the native (hex) rendering's hash -- they converge.
+        // Exercises is_blob_column detection (BLOB canonicalized, INTEGER left).
+        let info = TableInfo {
+            name: "t".to_string(),
+            columns: vec![
+                ColumnInfo {
+                    name: "id".into(),
+                    col_type: "INTEGER".into(),
+                    notnull: true,
+                    pk: true,
+                },
+                ColumnInfo {
+                    name: "data".into(),
+                    col_type: "BLOB".into(),
+                    notnull: false,
+                    pk: false,
+                },
+            ],
+            primary_key: vec!["id".into()],
+        };
+        let column_order = vec!["id".to_string(), "data".to_string()];
+
+        // Native (hex) reference row hash.
+        let mut native = HashMap::new();
+        native.insert("__pk".to_string(), Value::from("1"));
+        native.insert("id".to_string(), Value::from(1));
+        native.insert("data".to_string(), Value::from("4865"));
+        let native_meta = build_row_metadata(&[native], &column_order, "updated_at", &[], "t");
+
+        // JSON backend (base64) row: diverges until canonicalized.
+        let mut json = HashMap::new();
+        json.insert("__pk".to_string(), Value::from("1"));
+        json.insert("id".to_string(), Value::from(1));
+        json.insert("data".to_string(), Value::from("SGU="));
+        let mut maps = vec![json];
+
+        let raw_meta = build_row_metadata(&maps, &column_order, "updated_at", &[], "t");
+        assert_ne!(
+            native_meta.get("1").unwrap().content_hash,
+            raw_meta.get("1").unwrap().content_hash,
+            "raw base64 vs native hex must diverge before canonicalization"
+        );
+
+        canonicalize_row_blobs(&mut maps, &info);
+        let json_meta = build_row_metadata(&maps, &column_order, "updated_at", &[], "t");
+        assert_eq!(
+            native_meta.get("1").unwrap().content_hash,
+            json_meta.get("1").unwrap().content_hash,
+            "blob column must converge after base64->hex canonicalization"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a live cross-backend convergence bug (spike S), independent of migrate: a blob column's content-hash diverged because the native path renders lowercase-hex while the JSON backends (wasm, http-sql) render base64 -- so two nodes never converged on any blob column. The content-hash now canonicalizes blob values to one encoding (lowercase-hex) on every path.

## Acceptance criteria mapping

### 1. A blob column syncs consistently across a native (hex) node and a JSON (base64) backend
The content-hash path canonicalizes blob values to lowercase-hex before hashing. The native path already emitted lowercase-hex and is the reference (left unchanged); the JSON builders (wasm `adapter_common.rs`, http-sql `adapter.rs`) decode their base64 rendering and re-encode to hex before hashing, via one shared `rowhash` helper. `base64` is added to `smugglr-core`'s always-on deps to decode.
Evidence: `rowhash.rs` `canonicalize_blob_columns`, wired through `adapter_common.rs` / `adapter.rs` (+ the fetch/local wasm adapter call sites).

### 2. A test reproduces the divergence and asserts convergence after the fix
A test constructs the classic case (blob `He` -> native hex `4865` vs JSON base64 `SGU=`) and asserts the two content hashes now match.
Evidence: `rowhash.rs` -- `blob_converges_across_hex_and_base64` (and companion blob tests). `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean; smugglr-core suite passes (only pre-existing multicast env failures remain).

## Not done

Three LOW review findings, deliberately left as follow-ups (none affects the convergence fix):
- A non-string blob rendering is silently skipped by `canonicalize_blob_columns` rather than warned -- acceptable (only string-rendered blobs need canonicalizing) but worth a warn later.
- base64 is hardcoded as the JSON-backend encoding; if a future JSON backend rendered blobs differently it would need a per-backend encoding knob.
- A doc-comment on `build_row_metadata` (http-sql) drifted from the function after the edit.

Closes #292
