### PR TITLE
docs(#304): fold drift-audit corrections into design + sequencing docs

### DIFF
--- a/docs/plans/migrate-sequencing.md
+++ b/docs/plans/migrate-sequencing.md
@@ -46,7 +46,7 @@ Files in **bold** are new (no collision). Deps are issue numbers that must merge
 | Issue | What | Files | Deps |
 |-------|------|-------|------|
 | #275 | destructive-lint | **`migrate/lint.rs`** | #271 only |
-| #273 | forward apply engine -- **LOCAL only** (remote = pure generators) | **`migrate/apply.rs`** (ledger-free; exposes `apply_ops`) | #271, #272 |
+| #273 | forward apply engine -- **LOCAL only** (remote = pure generators) | **`migrate/apply.rs`** (ledger-free; exposes `apply_ops`) + `manifest.rs` (2 new `MigrateError` variants: `Apply`, `RemoteTransportUnsupported`) | #271 (code); #272 is a phase convenience -- apply is ledger-free |
 | #270 | rails-style CLI generator | **`migrate/generator.rs`**, **`migrate_cli.rs`**, `main.rs` | #271 |
 | #274 | reverse/rollback (append-only vN+1; delta-scoped pre-image via `stash`) | **`migrate/reverse.rs`** | #271, #272, #273, #275 |
 
@@ -86,11 +86,12 @@ Never let two in a lane co-queue; land them in the listed order.
 
 | Shared file | Issues | Rule |
 |-------------|--------|------|
-| the 3 metadata builders (`local.rs`, `adapter_common.rs`, `adapter.rs`) | #292, #269 | serialize; #292 first, #269 flips all three to `Result` in lockstep |
+| the metadata builders | #292, #269 | serialize; #292 first (merged: it touched `rowhash.rs` + wasm `adapter_common.rs`/`fetch_adapter.rs`/`local_adapter.rs` + http-sql `adapter.rs` -- NOT native `local.rs`, which is the hex reference). #269 flips native `local.rs` + `adapter_common.rs` + `adapter.rs` to `Result`, rebasing on the merged #292 |
 | `config.rs` `SyncConfig`+`Default` | #269 (`duplicate_pk`), #293 (`converge_columns`), #272 (`default_exclude_tables`) | serialize the two field-adders (#269, #293); #272 rebases |
 | `diff.rs`/`sync.rs`/`multicast.rs` | #293, #278(deferred) | #293 in spine; #278 later |
 | `rowhash.rs` | #292, #277(deferred) | #292 first; #277 freezes the hash version #292 mutates -- never invert |
-| `error.rs` `SyncError`+`exit_code()` | #269, #271(Migrate bridge), #272, #290 | append-only; **land the Migrate bridge in #271**; one owner reconciles the exit-code numbers (multiple want 4) |
+| `error.rs` `SyncError`+`exit_code()` | #269, #271(Migrate bridge), #272, #290 | append-only; **land the Migrate bridge in #271**; one owner reconciles the exit-code numbers (multiple want 4). **Every `SyncError`-variant adder ALSO edits `daemon.rs:~264`** -- the no-`_` exhaustiveness guard + its retry-verdict enumeration test -- so `daemon.rs` shares this lane (verified: #271, #272 both touched it). |
+| `migrate/manifest.rs` `MigrateError` | #271 (authored), #273 (adds `Apply`, `RemoteTransportUnsupported`), #289 (log variant) | append-only enum; each adds a variant -- serialize if two are ever in flight together |
 | `lib.rs` mod block | #268 (`pk_check`, top-level), #271 (`migrate`) | serialize #268 before #271; see mitigation |
 | `migrate_cli.rs` MigrateCommand enum | #270, #296, #274, #289, #290 | #270 first (creates it); route ALL migrate commands here, never `main.rs` |
 | `migrate/driver.rs` success path | #296, #289 (write-ahead hook), #290 (baseline write) | #296 first; serialize #289/#290 |

--- a/docs/plans/migration.md
+++ b/docs/plans/migration.md
@@ -420,12 +420,21 @@ alongside `Digest` / `Want` / `Delta`, or a dedicated migration flow -- open que
 ## Apply lifecycle
 
 ```
-dry-run preview  ->  destructive-lint  ->  [capture pre-image if destructive]
-      ->  apply forward (idempotent, IF NOT EXISTS, per-target strategy)
-      ->  record ledger (version, checksum, applied-at, success)
+resolve version (ledger.current_version + 1)  ->  ledger.try_elect(version, checksum)
+      ->  [only if Won] destructive-lint  ->  [capture pre-image if destructive]
+      ->  apply forward (idempotent, per-op, per-target strategy)
+      ->  ledger.mark_success   (ledger.mark_failed on error; the pending/leased
+                                 row is re-driven idempotently, never skipped)
 
-rollback:  apply envelope.down (restoring pre-image where destructive)  ->  pop ledger
+rollback:  apply the `down` ops as a NEW ledgered compensating vN+1 step
+           (restoring pre-image where destructive). The reversed vN row stays
+           byte-unchanged -- the ledger is append-only + chain-hashed, so a
+           `pop`/edit would trip tamper detection (verify_chain -> LedgerTampered).
 ```
+
+Note the ledger write is **two-phase**: election (`try_elect`) runs BEFORE apply, and
+`mark_success`/`mark_failed` after -- there is no single terminal "record" step. The
+composition lives in the apply-driver (#296); `apply.rs` itself is ledger-free.
 
 ## Recovery: surgical log (primary) + `--paranoid` snapshot (fallback)
 


### PR DESCRIPTION
## Summary

Folds the 2026-07-19 drift-audit corrections into the design + sequencing docs so a launch reader and the remaining builders work from as-built reality. (The issue-spec drift for #274/#296/#289/#290 was already folded via issue edits; this closes the doc side.)

## Acceptance criteria mapping

### 1. migration.md Apply-lifecycle corrected to the two-phase ledger + append-only rollback
The Apply-lifecycle pseudocode said `record ledger` (a single terminal step) and `rollback ... pop ledger`. The as-built ledger (#272) is two-phase -- `try_elect(version, checksum)` runs BEFORE apply, `mark_success`/`mark_failed` after -- and append-only + chain-hashed, so a `pop` trips `verify_chain -> LedgerTampered`. The block now shows election-before-apply and rollback as a new compensating vN+1 step, with a note that composition lives in the driver (#296) and apply.rs is ledger-free. This removes a self-contradiction with the doc's own decision 7.
Evidence: `migration.md` -- the fenced block under `## Apply lifecycle`.

### 2. migrate-sequencing.md collision lanes reflect merged reality
The `error.rs` lane now names `daemon.rs` (every `SyncError`-variant adder also edits the no-`_` exhaustiveness guard + its enumeration test -- verified on the merged #271/#272). A `migrate/manifest.rs MigrateError` lane is added (#271 authored, #273 added `Apply`/`RemoteTransportUnsupported`, #289 will add a log variant). #273's file-set gains `manifest.rs`. The metadata-builder lane is corrected to the four files #292 actually touched (wasm `adapter_common`/`fetch_adapter`/`local_adapter` + http-sql `adapter.rs`, not native `local.rs`).
Evidence: `migrate-sequencing.md` -- the `## Merge-queue collision lanes` table.

## Not done

- The design doc's decision-4 "scoped snapshot" pre-image wording is left as-is (conceptually a scoped capture; the concrete `stash::build_store` mechanism is pinned in #274's AC). No code changes -- docs only.

Closes #304
