### PR TITLE
feat(#274): reverse/rollback (faithful verbatim-DDL reverse + delta-scoped pre-image)

### DIFF
--- a/crates/smugglr-core/src/migrate/apply.rs
+++ b/crates/smugglr-core/src/migrate/apply.rs
@@ -85,7 +85,10 @@ fn column_kind_keyword(kind: ColumnKind) -> &'static str {
 ///
 /// Constraints are emitted in declared order. `DEFAULT` and `CHECK` payloads are
 /// carried verbatim (they are author-supplied SQL expressions).
-fn render_column_def(col: &Column) -> String {
+///
+/// Exposed `pub(crate)` so reverse (#274) can render an explicit target schema
+/// into a [`RebuildSpec`] body without duplicating the column-DDL lowering.
+pub(crate) fn render_column_def(col: &Column) -> String {
     let mut s = format!(
         "{} {}",
         quote_ident(&col.name),
@@ -550,28 +553,55 @@ fn rebuild_dropping_column(
 
 // --- The guarded 12-step rebuild -------------------------------------------
 
-/// A fully-formed rebuild plan: the caller (`rebuild_dropping_column`) has
-/// already resolved the primary key, foreign keys, and post-rebuild DDL into
-/// `body` / `post_ddl`.
+/// A fully-formed rebuild plan: the caller (`rebuild_dropping_column`, or reverse
+/// #274 via [`rebuild_to_schema`]) has already resolved the primary key, foreign
+/// keys, and post-rebuild DDL into `body` / `post_ddl`.
+///
+/// The spec is the *explicit target schema*: [`rebuild_to_schema`] renders exactly
+/// these fragments, inferring nothing from pragmas, so a caller that supplies the
+/// full schema (reverse's captured pre-image; convert #280) has none of the
+/// `DROP COLUMN` reconstruction limits documented on this module.
 #[cfg(feature = "native")]
-struct RebuildSpec {
+pub struct RebuildSpec {
     /// The table being rebuilt (dropped and recreated under this final name).
-    table: String,
+    pub table: String,
     /// The full `CREATE TABLE` body fragments (column defs + table-level
     /// constraints), joined by `, `.
-    body: Vec<String>,
+    pub body: Vec<String>,
     /// Whether the rebuilt table is `WITHOUT ROWID`.
-    without_rowid: bool,
+    pub without_rowid: bool,
     /// `(dest_column, source_expr)` pairs for the `INSERT ... SELECT` copy.
-    projection: Vec<(String, String)>,
+    pub projection: Vec<(String, String)>,
     /// Extra statements to run after the rename (e.g. recreate indexes).
-    post_ddl: Vec<String>,
+    pub post_ddl: Vec<String>,
 }
 
 /// The temp table name used mid-rebuild. A single connection rebuilds one table
 /// at a time, and it is dropped-if-exists first, so a fixed name is safe.
 #[cfg(feature = "native")]
 const REBUILD_TMP: &str = "_smugglr_rebuild_tmp";
+
+/// Rebuild a table to an **explicit target schema** (the public entry for reverse
+/// #274 / convert #280).
+///
+/// Unlike the `DROP COLUMN` path -- which *infers* the surviving schema from
+/// `PRAGMA table_info` / `foreign_key_list` and therefore cannot recover `CHECK` /
+/// `UNIQUE` / `COLLATE` / generated columns / `WITHOUT ROWID` -- this takes the
+/// schema as a fully-formed [`RebuildSpec`]: the caller supplies `body` (column
+/// defs + table-level constraints), `projection` (the `INSERT ... SELECT` copy
+/// from the *current* table into the target), and `post_ddl` (indexes to
+/// recreate). Whatever the caller renders is what the rebuilt table gets, so the
+/// reconstruction limits above do not apply. The table being rebuilt must already
+/// exist (the copy reads from it); recreating a *dropped* table is a
+/// `CREATE TABLE`, not a rebuild.
+///
+/// The guarantees of the 12-step rebuild still hold: `foreign_keys` is toggled
+/// outside the transaction, `sqlite_sequence` is preserved, and
+/// `foreign_key_check` + `integrity_check` gate the commit.
+#[cfg(feature = "native")]
+pub fn rebuild_to_schema(conn: &Connection, spec: &RebuildSpec) -> Result<(), MigrateError> {
+    rebuild_table(conn, spec)
+}
 
 /// Run the guarded 12-step table rebuild.
 ///

--- a/crates/smugglr-core/src/migrate/apply.rs
+++ b/crates/smugglr-core/src/migrate/apply.rs
@@ -86,8 +86,8 @@ fn column_kind_keyword(kind: ColumnKind) -> &'static str {
 /// Constraints are emitted in declared order. `DEFAULT` and `CHECK` payloads are
 /// carried verbatim (they are author-supplied SQL expressions).
 ///
-/// Exposed `pub(crate)` so reverse (#274) can render an explicit target schema
-/// into a [`RebuildSpec`] body without duplicating the column-DDL lowering.
+/// Exposed `pub(crate)` so callers assembling a [`RebuildTarget::Fragments`] body
+/// (convert #280) can reuse the column-DDL lowering without duplicating it.
 pub(crate) fn render_column_def(col: &Column) -> String {
     let mut s = format!(
         "{} {}",
@@ -543,8 +543,10 @@ fn rebuild_dropping_column(
 
     let spec = RebuildSpec {
         table: table.to_string(),
-        body,
-        without_rowid: false, // reconstruction does not recover WITHOUT ROWID
+        target: RebuildTarget::Fragments {
+            body,
+            without_rowid: false, // reconstruction does not recover WITHOUT ROWID
+        },
         projection,
         post_ddl,
     };
@@ -553,23 +555,51 @@ fn rebuild_dropping_column(
 
 // --- The guarded 12-step rebuild -------------------------------------------
 
-/// A fully-formed rebuild plan: the caller (`rebuild_dropping_column`, or reverse
-/// #274 via [`rebuild_to_schema`]) has already resolved the primary key, foreign
-/// keys, and post-rebuild DDL into `body` / `post_ddl`.
+/// The target schema for a rebuild: either reassembled DDL fragments or a
+/// verbatim `CREATE TABLE` captured from `sqlite_master`.
 ///
-/// The spec is the *explicit target schema*: [`rebuild_to_schema`] renders exactly
-/// these fragments, inferring nothing from pragmas, so a caller that supplies the
-/// full schema (reverse's captured pre-image; convert #280) has none of the
+/// The distinction is load bearing for constraint fidelity:
+///
+/// - [`RebuildTarget::Fragments`] is only as faithful as the caller's assembly.
+///   `rebuild_dropping_column` builds it from `PRAGMA table_info` /
+///   `foreign_key_list`, which cannot recover `CHECK` / surviving-column `UNIQUE`
+///   / `COLLATE` / generated columns, so that path warns on the loss.
+/// - [`RebuildTarget::Verbatim`] carries the exact pre-mutation DDL, so every
+///   constraint survives byte-for-byte. Reverse (#274) uses it to re-add a dropped
+///   column without re-deriving (and thus stripping) the surviving schema.
+#[cfg(feature = "native")]
+pub(crate) enum RebuildTarget {
+    /// Reassembled `CREATE TABLE` body fragments (column defs + table-level
+    /// constraints), joined by `, `, plus the `WITHOUT ROWID` flag.
+    Fragments {
+        /// The full body fragments (column defs + table-level constraints).
+        body: Vec<String>,
+        /// Whether the rebuilt table is `WITHOUT ROWID`.
+        without_rowid: bool,
+    },
+    /// A verbatim `CREATE TABLE` (as stored in `sqlite_master`); the rebuild
+    /// splices the temp-table name in place of the original before executing it,
+    /// so no constraint is inferred or lost.
+    Verbatim {
+        /// The verbatim `CREATE TABLE` DDL for the target schema.
+        create_sql: String,
+    },
+}
+
+/// A fully-formed rebuild plan: the caller (`rebuild_dropping_column`, or reverse
+/// #274 via [`rebuild_to_schema`]) has already resolved the target schema,
+/// projection, and post-rebuild DDL.
+///
+/// `target` is the *explicit target schema*: [`rebuild_to_schema`] renders exactly
+/// what it carries, inferring nothing from pragmas, so a caller that supplies a
+/// verbatim capture (reverse's pre-image; convert #280) has none of the
 /// `DROP COLUMN` reconstruction limits documented on this module.
 #[cfg(feature = "native")]
-pub struct RebuildSpec {
+pub(crate) struct RebuildSpec {
     /// The table being rebuilt (dropped and recreated under this final name).
     pub table: String,
-    /// The full `CREATE TABLE` body fragments (column defs + table-level
-    /// constraints), joined by `, `.
-    pub body: Vec<String>,
-    /// Whether the rebuilt table is `WITHOUT ROWID`.
-    pub without_rowid: bool,
+    /// The target schema (reassembled fragments or a verbatim capture).
+    pub target: RebuildTarget,
     /// `(dest_column, source_expr)` pairs for the `INSERT ... SELECT` copy.
     pub projection: Vec<(String, String)>,
     /// Extra statements to run after the rename (e.g. recreate indexes).
@@ -581,25 +611,161 @@ pub struct RebuildSpec {
 #[cfg(feature = "native")]
 const REBUILD_TMP: &str = "_smugglr_rebuild_tmp";
 
-/// Rebuild a table to an **explicit target schema** (the public entry for reverse
+/// A byte that can appear inside a bare SQL identifier.
+#[cfg(feature = "native")]
+fn is_ident_byte(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || c == b'_' || c == b'$'
+}
+
+/// Advance past ASCII whitespace from `i`.
+#[cfg(feature = "native")]
+fn skip_ws(b: &[u8], mut i: usize) -> usize {
+    while i < b.len() && b[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+/// Match `word` case-insensitively at `i`, requiring a trailing word boundary.
+/// Returns the index just past the keyword, or `None` if it does not match.
+#[cfg(feature = "native")]
+fn match_kw(b: &[u8], i: usize, word: &str) -> Option<usize> {
+    let w = word.as_bytes();
+    let end = i.checked_add(w.len())?;
+    if end > b.len() || !b[i..end].eq_ignore_ascii_case(w) {
+        return None;
+    }
+    if end < b.len() && is_ident_byte(b[end]) {
+        return None;
+    }
+    Some(end)
+}
+
+/// The end index (exclusive) of one SQL identifier starting at `i`, honouring
+/// `"..."`, `` `...` ``, `[...]`, and bare forms. `None` if `i` is not an
+/// identifier start.
+#[cfg(feature = "native")]
+fn ident_end(b: &[u8], i: usize) -> Option<usize> {
+    if i >= b.len() {
+        return None;
+    }
+    match b[i] {
+        q @ (b'"' | b'`') => {
+            let mut j = i + 1;
+            while j < b.len() {
+                if b[j] == q {
+                    // A doubled quote is an escaped literal, not the terminator.
+                    if j + 1 < b.len() && b[j + 1] == q {
+                        j += 2;
+                    } else {
+                        return Some(j + 1);
+                    }
+                } else {
+                    j += 1;
+                }
+            }
+            None
+        }
+        b'[' => {
+            let mut j = i + 1;
+            while j < b.len() {
+                if b[j] == b']' {
+                    return Some(j + 1);
+                }
+                j += 1;
+            }
+            None
+        }
+        c if is_ident_byte(c) && !c.is_ascii_digit() => {
+            let mut j = i;
+            while j < b.len() && is_ident_byte(b[j]) {
+                j += 1;
+            }
+            Some(j)
+        }
+        _ => None,
+    }
+}
+
+/// Splice `new_name` (quoted) in for the table name of a verbatim
+/// `CREATE TABLE` statement, leaving the rest of the DDL byte-for-byte intact.
+///
+/// Reverse (#274) builds the mid-rebuild temp table this way: the captured
+/// pre-drop DDL keeps every constraint, and only the name is retargeted so it can
+/// coexist with the still-present original during the swap. Scans past
+/// `CREATE [TEMP|TEMPORARY] TABLE [IF NOT EXISTS]` and any `schema.` qualifier to
+/// the name identifier, then replaces just that span.
+#[cfg(feature = "native")]
+fn splice_create_table_name(create_sql: &str, new_name: &str) -> Result<String, MigrateError> {
+    let b = create_sql.as_bytes();
+    let not_create = || {
+        MigrateError::Apply(format!(
+            "captured DDL is not a CREATE TABLE statement: {create_sql:?}"
+        ))
+    };
+
+    let mut i = skip_ws(b, 0);
+    i = match_kw(b, i, "CREATE").ok_or_else(not_create)?;
+    i = skip_ws(b, i);
+    if let Some(j) = match_kw(b, i, "TEMPORARY").or_else(|| match_kw(b, i, "TEMP")) {
+        i = skip_ws(b, j);
+    }
+    i = match_kw(b, i, "TABLE").ok_or_else(not_create)?;
+    i = skip_ws(b, i);
+    // Optional IF NOT EXISTS.
+    if let Some(j) = match_kw(b, i, "IF") {
+        let j = skip_ws(b, j);
+        let j = match_kw(b, j, "NOT").ok_or_else(not_create)?;
+        let j = skip_ws(b, j);
+        let j = match_kw(b, j, "EXISTS").ok_or_else(not_create)?;
+        i = skip_ws(b, j);
+    }
+
+    let name_start = i;
+    let mut name_end = ident_end(b, i).ok_or_else(|| {
+        MigrateError::Apply(format!(
+            "could not locate table name in captured DDL: {create_sql:?}"
+        ))
+    })?;
+    // A `schema.name` qualifier: the replaced span runs through the second ident.
+    let after = skip_ws(b, name_end);
+    if after < b.len() && b[after] == b'.' {
+        let k = skip_ws(b, after + 1);
+        name_end = ident_end(b, k).ok_or_else(|| {
+            MigrateError::Apply(format!(
+                "malformed qualified table name in captured DDL: {create_sql:?}"
+            ))
+        })?;
+    }
+
+    Ok(format!(
+        "{}{}{}",
+        &create_sql[..name_start],
+        quote_ident(new_name),
+        &create_sql[name_end..]
+    ))
+}
+
+/// Rebuild a table to an **explicit target schema** (the crate entry for reverse
 /// #274 / convert #280).
 ///
 /// Unlike the `DROP COLUMN` path -- which *infers* the surviving schema from
 /// `PRAGMA table_info` / `foreign_key_list` and therefore cannot recover `CHECK` /
 /// `UNIQUE` / `COLLATE` / generated columns / `WITHOUT ROWID` -- this takes the
-/// schema as a fully-formed [`RebuildSpec`]: the caller supplies `body` (column
-/// defs + table-level constraints), `projection` (the `INSERT ... SELECT` copy
-/// from the *current* table into the target), and `post_ddl` (indexes to
-/// recreate). Whatever the caller renders is what the rebuilt table gets, so the
-/// reconstruction limits above do not apply. The table being rebuilt must already
-/// exist (the copy reads from it); recreating a *dropped* table is a
-/// `CREATE TABLE`, not a rebuild.
+/// schema as a fully-formed [`RebuildSpec`]: the caller supplies the
+/// [`RebuildTarget`] (reassembled fragments *or* a verbatim capture), a
+/// `projection` (the `INSERT ... SELECT` copy from the *current* table into the
+/// target), and `post_ddl` (indexes to recreate). With a
+/// [`RebuildTarget::Verbatim`] capture the reconstruction limits above do not
+/// apply at all -- every constraint is carried byte-for-byte. The table being
+/// rebuilt must already exist (the copy reads from it); recreating a *dropped*
+/// table is a `CREATE TABLE`, not a rebuild.
 ///
 /// The guarantees of the 12-step rebuild still hold: `foreign_keys` is toggled
 /// outside the transaction, `sqlite_sequence` is preserved, and
 /// `foreign_key_check` + `integrity_check` gate the commit.
 #[cfg(feature = "native")]
-pub fn rebuild_to_schema(conn: &Connection, spec: &RebuildSpec) -> Result<(), MigrateError> {
+pub(crate) fn rebuild_to_schema(conn: &Connection, spec: &RebuildSpec) -> Result<(), MigrateError> {
     rebuild_table(conn, spec)
 }
 
@@ -643,14 +809,25 @@ fn rebuild_inner(conn: &Connection, spec: &RebuildSpec) -> Result<(), MigrateErr
         "DROP TABLE IF EXISTS {}",
         quote_ident(REBUILD_TMP)
     ))?;
-    let mut create = format!(
-        "CREATE TABLE {} ({})",
-        quote_ident(REBUILD_TMP),
-        spec.body.join(", ")
-    );
-    if spec.without_rowid {
-        create.push_str(" WITHOUT ROWID");
-    }
+    let create = match &spec.target {
+        RebuildTarget::Fragments {
+            body,
+            without_rowid,
+        } => {
+            let mut c = format!(
+                "CREATE TABLE {} ({})",
+                quote_ident(REBUILD_TMP),
+                body.join(", ")
+            );
+            if *without_rowid {
+                c.push_str(" WITHOUT ROWID");
+            }
+            c
+        }
+        RebuildTarget::Verbatim { create_sql } => {
+            splice_create_table_name(create_sql, REBUILD_TMP)?
+        }
+    };
     tx.execute_batch(&create)?;
 
     // Copy the data across the projection.
@@ -1312,6 +1489,72 @@ mod tests {
             raw_table_columns(conn, table).unwrap()
         }
 
+        /// The verbatim `CREATE TABLE` sqlite stored for `table`.
+        fn stored_ddl(conn: &Connection, table: &str) -> String {
+            conn.query_row(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?1",
+                params![table],
+                |r| r.get(0),
+            )
+            .unwrap()
+        }
+
+        #[test]
+        fn splice_retargets_real_sqlite_master_ddl_verbatim() {
+            // The splice input that matters is the DDL sqlite ACTUALLY stores, not
+            // hand-written DDL. Round-trip several real forms: the spliced create
+            // must execute, land under the temp name, and preserve constraints.
+            let cases = [
+                // Quoted name (with a space) + WITHOUT ROWID + inline UNIQUE + COLLATE.
+                ("quo ted", "CREATE TABLE \"quo ted\" (id TEXT PRIMARY KEY, h TEXT UNIQUE COLLATE NOCASE) WITHOUT ROWID"),
+                // Bare name + table-level CHECK.
+                ("bare", "CREATE TABLE bare (id TEXT PRIMARY KEY, score INTEGER, CHECK (score >= 0))"),
+                // Composite primary key.
+                ("comp", "CREATE TABLE comp (a TEXT, b TEXT, v TEXT, PRIMARY KEY (a, b))"),
+                // Foreign key to another table.
+                ("child", "CREATE TABLE child (id TEXT PRIMARY KEY, pid TEXT REFERENCES bare(id))"),
+                // Generated (stored) column.
+                ("gen", "CREATE TABLE gen (id TEXT PRIMARY KEY, n INTEGER, n2 INTEGER GENERATED ALWAYS AS (n * 2) STORED)"),
+            ];
+            for (name, original) in cases {
+                let conn = mem();
+                // `child` references `bare`; create the parent first so the FK case
+                // has a target.
+                conn.execute_batch(
+                    "CREATE TABLE bare (id TEXT PRIMARY KEY, score INTEGER, CHECK (score >= 0))",
+                )
+                .ok();
+                if name != "bare" {
+                    conn.execute_batch(original).unwrap();
+                }
+                let stored = stored_ddl(&conn, name);
+                let spliced = splice_create_table_name(&stored, REBUILD_TMP).unwrap();
+                // The spliced DDL executes and creates the temp table.
+                conn.execute_batch(&format!(
+                    "DROP TABLE IF EXISTS {}",
+                    quote_ident(REBUILD_TMP)
+                ))
+                .unwrap();
+                conn.execute_batch(&spliced).unwrap();
+                let tmp_ddl = stored_ddl(&conn, REBUILD_TMP);
+                // The temp DDL is the original body with only the name retargeted:
+                // everything after the spliced name is byte-identical.
+                let orig_after = &stored[stored.find('(').unwrap()..];
+                let tmp_after = &tmp_ddl[tmp_ddl.find('(').unwrap()..];
+                assert_eq!(orig_after, tmp_after, "body must be preserved verbatim");
+                assert!(
+                    tmp_ddl.contains(REBUILD_TMP),
+                    "temp name spliced: {tmp_ddl}"
+                );
+            }
+        }
+
+        #[test]
+        fn splice_rejects_non_create_table() {
+            assert!(splice_create_table_name("SELECT 1", REBUILD_TMP).is_err());
+            assert!(splice_create_table_name("CREATE INDEX i ON t(a)", REBUILD_TMP).is_err());
+        }
+
         #[test]
         fn pre_op_hook_runs_before_each_op_and_can_abort() {
             let conn = mem();
@@ -1881,8 +2124,10 @@ mod tests {
             // Rebuild parent dropping `junk`.
             let spec = RebuildSpec {
                 table: "parent".into(),
-                body: vec!["\"id\" INTEGER PRIMARY KEY".into(), "\"label\" TEXT".into()],
-                without_rowid: false,
+                target: RebuildTarget::Fragments {
+                    body: vec!["\"id\" INTEGER PRIMARY KEY".into(), "\"label\" TEXT".into()],
+                    without_rowid: false,
+                },
                 projection: vec![
                     ("id".into(), "\"id\"".into()),
                     ("label".into(), "\"label\"".into()),
@@ -1926,12 +2171,14 @@ mod tests {
             // (user_id=999) violates it.
             let spec = RebuildSpec {
                 table: "orders".into(),
-                body: vec![
-                    "\"id\" INTEGER PRIMARY KEY".into(),
-                    "\"user_id\" INTEGER".into(),
-                    "FOREIGN KEY (\"user_id\") REFERENCES \"users\"(\"id\")".into(),
-                ],
-                without_rowid: false,
+                target: RebuildTarget::Fragments {
+                    body: vec![
+                        "\"id\" INTEGER PRIMARY KEY".into(),
+                        "\"user_id\" INTEGER".into(),
+                        "FOREIGN KEY (\"user_id\") REFERENCES \"users\"(\"id\")".into(),
+                    ],
+                    without_rowid: false,
+                },
                 projection: vec![
                     ("id".into(), "\"id\"".into()),
                     ("user_id".into(), "\"user_id\"".into()),

--- a/crates/smugglr-core/src/migrate/reverse.rs
+++ b/crates/smugglr-core/src/migrate/reverse.rs
@@ -16,10 +16,15 @@
 //!   **delta-scoped pre-image** (rows-INTERSECT-columns, OQ1) captured *during*
 //!   the forward apply, before the op mutates. The capture rides the `pre_op`
 //!   write-ahead hook [`apply_ops`](crate::migrate::apply::apply_ops) already
-//!   exposes ([`PreimageCapturer::capture_before`]); restore reconstructs the
-//!   structure ([`crate::migrate::apply::rebuild_to_schema`] for a re-added
-//!   column, verbatim DDL for a re-created table) and refills the lost cells with
-//!   an idempotent PK-keyed UPSERT ([`restore_payload`], spike C).
+//!   exposes ([`PreimageCapturer::capture_before`]). Both restores reconstruct the
+//!   structure from the **verbatim pre-mutation DDL** captured from
+//!   `sqlite_master` -- a re-created table runs the captured `CREATE TABLE`
+//!   directly, a re-added column rebuilds through
+//!   [`crate::migrate::apply::rebuild_to_schema`] with a
+//!   [`RebuildTarget::Verbatim`](crate::migrate::apply::RebuildTarget) target --
+//!   so every surviving `CHECK` / `UNIQUE` / `COLLATE` / generated column and
+//!   table-level constraint survives the round-trip. The lost cells are refilled
+//!   with an idempotent PK-keyed UPSERT ([`restore_payload`], spike C).
 //!
 //! # Two compilation surfaces
 //!
@@ -40,17 +45,17 @@
 //! column ([`preimage_ref_of`], OQ2 "read-only"); **writing** that column is the
 //! driver's job (#296), out of scope here.
 
-use crate::migrate::{ClassifiedOp, Column, MigrateError, Op};
+use crate::migrate::{ClassifiedOp, MigrateError, Op};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "native")]
 use crate::config::StashConfig;
 #[cfg(feature = "native")]
-use crate::migrate::apply::{apply_ops, rebuild_to_schema, render_column_def, RebuildSpec};
+use crate::migrate::apply::{apply_ops, rebuild_to_schema, RebuildSpec, RebuildTarget};
 #[cfg(feature = "native")]
 use crate::migrate::ledger::{Election, Ledger, LedgerEntry};
 #[cfg(feature = "native")]
-use crate::migrate::{ColumnKind, Constraint, Preimage};
+use crate::migrate::Preimage;
 #[cfg(feature = "native")]
 use object_store::{path::Path as ObjectPath, ObjectStore, PutPayload};
 #[cfg(feature = "native")]
@@ -149,21 +154,29 @@ pub enum CapturedValue {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "loss", rename_all = "snake_case")]
 pub enum TablePreimage {
-    /// A dropped column. Restore rebuilds the table to the pre-drop schema
-    /// ([`Column`] set), then refills the one lost column by PK-keyed UPSERT.
+    /// A dropped column. Restore rebuilds the table from the verbatim pre-drop
+    /// `CREATE TABLE` (so every surviving constraint is intact), copying the
+    /// surviving columns and leaving the re-added column to its default/NULL, then
+    /// refills the one lost column by PK-keyed UPSERT.
     Column {
         /// The table the column was dropped from.
         table: String,
         /// The dropped column's name.
         dropped: String,
-        /// The full pre-drop column set (the explicit rebuild target). The
-        /// primary key is carried separately in `pk`, so no column here declares
-        /// an inline `PRIMARY KEY`.
-        columns: Vec<Column>,
+        /// The verbatim pre-drop `CREATE TABLE` DDL (all constraints intact). The
+        /// rebuild splices in the temp-table name, so the re-added column and
+        /// every surviving `CHECK` / `UNIQUE` / `COLLATE` / generated column and
+        /// table-level constraint are carried byte-for-byte.
+        create_sql: String,
+        /// Verbatim pre-drop index / trigger DDL to replay after the rebuild
+        /// (including any index that referenced the dropped column).
+        aux_ddl: Vec<String>,
+        /// Whether the dropped column was `NOT NULL` with no default. Such a
+        /// column cannot survive the rebuild-then-fill gap (it is null between the
+        /// copy and the UPSERT), so restore rejects it with a clear error.
+        dropped_requires_value: bool,
         /// The primary-key column names, in key order.
         pk: Vec<String>,
-        /// Whether the pre-drop table was `WITHOUT ROWID`.
-        without_rowid: bool,
         /// The columns present in each captured row (`pk` ++ `dropped`).
         captured_columns: Vec<String>,
         /// Captured rows, each aligned to `captured_columns`.
@@ -213,30 +226,10 @@ fn quote_ident(name: &str) -> String {
     format!("\"{}\"", name.replace('"', "\"\""))
 }
 
-/// Map a SQLite declared column type to a structured [`ColumnKind`] by affinity.
-///
-/// SQLite's type affinity rules (a substring scan of the declared type) decide
-/// storage class; an empty / unknown declared type falls to `Blob` (NUMERIC/none
-/// affinity), matching the `apply` rebuild's typeless-column handling.
-#[cfg(feature = "native")]
-fn kind_from_decl(decl: &str) -> ColumnKind {
-    let up = decl.to_ascii_uppercase();
-    if up.contains("INT") {
-        ColumnKind::Int
-    } else if up.contains("CHAR") || up.contains("CLOB") || up.contains("TEXT") {
-        ColumnKind::Text
-    } else if up.contains("REAL") || up.contains("FLOA") || up.contains("DOUB") {
-        ColumnKind::Real
-    } else {
-        ColumnKind::Blob
-    }
-}
-
 /// One `PRAGMA table_info` row, tolerant of absent tables.
 #[cfg(feature = "native")]
 struct ColRow {
     name: String,
-    decl: String,
     notnull: bool,
     dflt: Option<String>,
     /// 1-based PK position, `0` if not part of the primary key.
@@ -251,7 +244,6 @@ fn table_info(conn: &Connection, table: &str) -> Result<Vec<ColRow>, MigrateErro
         .query_map([], |r| {
             Ok(ColRow {
                 name: r.get::<_, String>(1)?,
-                decl: r.get::<_, String>(2)?,
                 notnull: r.get::<_, i64>(3)? != 0,
                 dflt: r.get::<_, Option<String>>(4)?,
                 pk: r.get::<_, i64>(5)?,
@@ -269,23 +261,25 @@ fn primary_key(info: &[ColRow]) -> Vec<String> {
     pk.into_iter().map(|c| c.name.clone()).collect()
 }
 
-/// Reconstruct a structured [`Column`] from a pragma row. The primary key is
-/// emitted table-level by the caller, so no `Constraint::Pk` is attached here.
+/// The generated (`GENERATED ALWAYS AS`) column names of a table, via
+/// `PRAGMA table_xinfo`'s `hidden` flag (`2` = virtual, `3` = stored). A rebuild
+/// must never project into these -- inserting a value into a generated column is
+/// an error; they self-populate from the copied base columns.
 #[cfg(feature = "native")]
-fn column_from_row(row: &ColRow) -> Column {
-    let mut constraints = Vec::new();
-    if row.notnull {
-        constraints.push(Constraint::NotNull);
-    }
-    if let Some(d) = &row.dflt {
-        constraints.push(Constraint::Default(d.clone()));
-    }
-    Column {
-        name: row.name.clone(),
-        kind: kind_from_decl(&row.decl),
-        constraints,
-        tags: Vec::new(),
-    }
+fn generated_columns(conn: &Connection, table: &str) -> Result<Vec<String>, MigrateError> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_xinfo({})", quote_ident(table)))?;
+    let rows = stmt
+        .query_map([], |r| {
+            let name: String = r.get(1)?;
+            let hidden: i64 = r.get(6)?;
+            Ok((name, hidden))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows
+        .into_iter()
+        .filter(|(_, hidden)| *hidden == 2 || *hidden == 3)
+        .map(|(name, _)| name)
+        .collect())
 }
 
 /// The verbatim `CREATE` DDL of a `sqlite_master` object, if present.
@@ -445,9 +439,26 @@ impl PreimageCapturer {
                  surgical pre-image"
             )));
         }
-        let columns: Vec<Column> = info.iter().map(column_from_row).collect();
-        let without_rowid = object_sql(conn, "table", table)?
-            .map(|s| s.to_ascii_uppercase().contains("WITHOUT ROWID"))
+
+        // Capture the VERBATIM pre-drop DDL: the column still exists here (capture
+        // runs before the drop), so every surviving constraint -- CHECK, UNIQUE,
+        // COLLATE, generated columns, table-level constraints, WITHOUT ROWID -- is
+        // carried faithfully, exactly as the DropTable path does. Rebuilding from
+        // inferred columns would strip them silently.
+        let create_sql = object_sql(conn, "table", table)?.ok_or_else(|| {
+            MigrateError::Apply(format!(
+                "cannot capture pre-image: no DDL for table {table:?}"
+            ))
+        })?;
+        let aux_ddl = aux_object_ddl(conn, table)?;
+
+        // A NOT NULL column with no default cannot survive the rebuild-then-fill
+        // gap (it is null between the copy and the UPSERT); record that now so the
+        // restore fails with a clear message rather than a raw SQL error.
+        let dropped_requires_value = info
+            .iter()
+            .find(|c| c.name == *column)
+            .map(|c| c.notnull && c.dflt.is_none())
             .unwrap_or(false);
 
         let mut captured_columns = pk.clone();
@@ -457,9 +468,10 @@ impl PreimageCapturer {
         Ok(TablePreimage::Column {
             table: table.to_string(),
             dropped: column.to_string(),
-            columns,
+            create_sql,
+            aux_ddl,
+            dropped_requires_value,
             pk,
-            without_rowid,
             captured_columns,
             rows,
         })
@@ -515,18 +527,20 @@ pub fn restore_payload(conn: &Connection, payload: &PreimagePayload) -> Result<(
             TablePreimage::Column {
                 table,
                 dropped,
-                columns,
+                create_sql,
+                aux_ddl,
+                dropped_requires_value,
                 pk,
-                without_rowid,
                 captured_columns,
                 rows,
             } => restore_column(
                 conn,
                 table,
                 dropped,
-                columns,
+                create_sql,
+                aux_ddl,
+                *dropped_requires_value,
                 pk,
-                *without_rowid,
                 captured_columns,
                 rows,
             )?,
@@ -543,39 +557,27 @@ pub fn restore_payload(conn: &Connection, payload: &PreimagePayload) -> Result<(
     Ok(())
 }
 
-/// Restore a dropped column: rebuild the table to the explicit pre-drop schema
-/// (re-adding the column, structurally faithful via
-/// [`rebuild_to_schema`](crate::migrate::apply::rebuild_to_schema)), then UPSERT
-/// the captured values back into it.
+/// Restore a dropped column: rebuild the table from the verbatim pre-drop
+/// `CREATE TABLE` (re-adding the column and carrying every surviving constraint
+/// byte-for-byte via a [`RebuildTarget::Verbatim`] rebuild), then UPSERT the
+/// captured values back into it.
 #[cfg(feature = "native")]
 #[allow(clippy::too_many_arguments)]
 fn restore_column(
     conn: &Connection,
     table: &str,
     dropped: &str,
-    columns: &[Column],
+    create_sql: &str,
+    aux_ddl: &[String],
+    dropped_requires_value: bool,
     pk: &[String],
-    without_rowid: bool,
     captured_columns: &[String],
     rows: &[Vec<CapturedValue>],
 ) -> Result<(), MigrateError> {
-    let dropped_col = columns.iter().find(|c| c.name == dropped).ok_or_else(|| {
-        MigrateError::Apply(format!(
-            "pre-image for {table:?} is missing the dropped column {dropped:?}"
-        ))
-    })?;
     // The rebuild copies the surviving columns and leaves the re-added column
     // empty until the UPSERT fills it. A NOT NULL column with no default cannot
     // survive that gap -- fail with a clear message, not a raw SQL error.
-    let not_null = dropped_col
-        .constraints
-        .iter()
-        .any(|c| matches!(c, Constraint::NotNull));
-    let has_default = dropped_col
-        .constraints
-        .iter()
-        .any(|c| matches!(c, Constraint::Default(_)));
-    if not_null && !has_default {
+    if dropped_requires_value {
         return Err(MigrateError::Apply(format!(
             "cannot restore NOT NULL column {dropped:?} on {table:?} without a default \
              (rebuild-then-fill leaves it null until the row-level UPSERT)"
@@ -589,30 +591,22 @@ fn restore_column(
         .map(|c| c.name)
         .collect();
     if !present.iter().any(|c| c == dropped) {
-        let mut body: Vec<String> = columns.iter().map(render_column_def).collect();
-        if !pk.is_empty() {
-            body.push(format!(
-                "PRIMARY KEY ({})",
-                pk.iter()
-                    .map(|c| quote_ident(c))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ));
-        }
-        // Copy every surviving column identity-wise; the re-added column is left
-        // out of the projection so it defaults to null/its default.
-        let projection: Vec<(String, String)> = columns
+        // Copy every surviving, non-generated column identity-wise; the re-added
+        // column is left out of the projection so it takes its default/NULL, and
+        // generated columns self-populate (inserting into them is an error).
+        let generated = generated_columns(conn, table)?;
+        let projection: Vec<(String, String)> = present
             .iter()
-            .filter(|c| c.name != dropped)
-            .map(|c| (c.name.clone(), quote_ident(&c.name)))
+            .filter(|c| !generated.iter().any(|g| g == *c))
+            .map(|c| (c.clone(), quote_ident(c)))
             .collect();
-        let post_ddl = aux_object_ddl(conn, table)?;
         let spec = RebuildSpec {
             table: table.to_string(),
-            body,
-            without_rowid,
+            target: RebuildTarget::Verbatim {
+                create_sql: create_sql.to_string(),
+            },
             projection,
-            post_ddl,
+            post_ddl: aux_ddl.to_vec(),
         };
         rebuild_to_schema(conn, &spec)?;
     }
@@ -741,7 +735,9 @@ pub async fn store_preimage(
     let bytes =
         serde_json::to_vec(payload).map_err(|e| MigrateError::Serialization(e.to_string()))?;
     if bytes.len() <= INLINE_MAX_BYTES {
-        let rows = serde_json::to_value(payload)
+        // Fold the inline branch onto the already-serialized bytes: parse them
+        // back into a `Value` rather than serializing the payload a second time.
+        let rows = serde_json::from_slice(&bytes)
             .map_err(|e| MigrateError::Serialization(e.to_string()))?;
         return Ok(Preimage::Inline { rows });
     }
@@ -874,6 +870,7 @@ pub fn apply_compensating(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::migrate::{Column, ColumnKind};
 
     fn col(name: &str, kind: ColumnKind) -> Column {
         Column {
@@ -1003,9 +1000,10 @@ mod tests {
             tables: vec![TablePreimage::Column {
                 table: "t".into(),
                 dropped: "c".into(),
-                columns: vec![col("id", ColumnKind::Text), col("c", ColumnKind::Blob)],
+                create_sql: "CREATE TABLE t (id TEXT PRIMARY KEY, c BLOB)".into(),
+                aux_ddl: vec![],
+                dropped_requires_value: false,
                 pk: vec!["id".into()],
-                without_rowid: false,
                 captured_columns: vec!["id".into(), "c".into()],
                 rows: vec![
                     vec![CapturedValue::Text("k1".into()), CapturedValue::Null],
@@ -1295,6 +1293,253 @@ mod tests {
             assert!(matches!(err, MigrateError::Apply(m) if m.contains("NOT NULL")));
         }
 
+        #[test]
+        fn drop_column_reverse_preserves_surviving_and_table_constraints() {
+            // HIGH-1: dropping an UNCONSTRAINED column then reversing must not
+            // silently strip the surviving-column UNIQUE / COLLATE or the
+            // table-level CHECK. The verbatim-DDL rebuild carries them all.
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(
+                "CREATE TABLE t (
+                     id TEXT PRIMARY KEY,
+                     handle TEXT UNIQUE COLLATE NOCASE,
+                     score INTEGER,
+                     doomed TEXT,
+                     CHECK (score >= 0)
+                 );
+                 INSERT INTO t (id, handle, score, doomed) VALUES ('u1','alice',5,'x');",
+            )
+            .unwrap();
+
+            let drop = ClassifiedOp::new(Op::DropColumn {
+                table: "t".into(),
+                column: "doomed".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+            assert!(table_info(&conn, "t")
+                .unwrap()
+                .iter()
+                .all(|c| c.name != "doomed"));
+
+            restore_payload(&conn, &payload).unwrap();
+
+            // Surviving-column UNIQUE + COLLATE NOCASE survived: a case-
+            // insensitive duplicate is REJECTED.
+            let dup = conn.execute(
+                "INSERT INTO t (id, handle, score) VALUES ('u2','ALICE',1)",
+                [],
+            );
+            assert!(
+                dup.is_err(),
+                "UNIQUE + COLLATE NOCASE must reject a case-insensitive duplicate"
+            );
+
+            // Table-level CHECK survived: a CHECK-violating row is REJECTED.
+            let bad = conn.execute(
+                "INSERT INTO t (id, handle, score) VALUES ('u3','bob',-5)",
+                [],
+            );
+            assert!(
+                bad.is_err(),
+                "table-level CHECK(score >= 0) must reject a negative score"
+            );
+
+            // The dropped column's data round-tripped.
+            let doomed: Option<String> = conn
+                .query_row("SELECT doomed FROM t WHERE id = 'u1'", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(doomed.as_deref(), Some("x"));
+        }
+
+        #[test]
+        fn drop_column_reverse_with_surviving_generated_column() {
+            // A surviving GENERATED column must not be projected into during the
+            // rebuild (inserting into a generated column errors); it self-populates
+            // from the copied base columns. Exercises the generated_columns filter.
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(
+                "CREATE TABLE t (
+                     id TEXT PRIMARY KEY,
+                     n INTEGER,
+                     n2 INTEGER GENERATED ALWAYS AS (n * 2) STORED,
+                     doomed TEXT
+                 );
+                 INSERT INTO t (id, n, doomed) VALUES ('u1', 21, 'x');",
+            )
+            .unwrap();
+
+            let drop = ClassifiedOp::new(Op::DropColumn {
+                table: "t".into(),
+                column: "doomed".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+
+            restore_payload(&conn, &payload).unwrap();
+
+            // The generated column survives and recomputes correctly...
+            let n2: i64 = conn
+                .query_row("SELECT n2 FROM t WHERE id = 'u1'", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(n2, 42, "generated column must recompute as n*2");
+            // ...and the dropped column round-tripped.
+            let doomed: Option<String> = conn
+                .query_row("SELECT doomed FROM t WHERE id = 'u1'", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(doomed.as_deref(), Some("x"));
+        }
+
+        #[test]
+        fn drop_table_reverse_restores_index_and_without_rowid() {
+            // MED-2: restoring a dropped table must replay its aux DDL (an
+            // explicit index) and recreate it WITHOUT ROWID from the verbatim DDL.
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(
+                "CREATE TABLE gone (id TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+                 CREATE INDEX gone_v ON gone(v);
+                 INSERT INTO gone VALUES ('g1','one'),('g2','two');",
+            )
+            .unwrap();
+
+            let drop = ClassifiedOp::new(Op::DropTable {
+                table: "gone".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+            assert!(!table_exists(&conn, "gone"));
+
+            restore_payload(&conn, &payload).unwrap();
+
+            // The explicit index is back.
+            let idx: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='gone_v'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(idx, 1, "the dropped table's index must be restored");
+
+            // The table is WITHOUT ROWID again.
+            let ddl: String = conn
+                .query_row(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='gone'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert!(
+                ddl.to_ascii_uppercase().contains("WITHOUT ROWID"),
+                "table must be restored WITHOUT ROWID: {ddl}"
+            );
+
+            // And the rows came back.
+            let v1: String = conn
+                .query_row("SELECT v FROM gone WHERE id='g1'", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(v1, "one");
+        }
+
+        #[test]
+        fn compensating_step_marks_failed_and_reelectable_on_error() {
+            // MED-3: a compensating step whose restore ERRORS mid-apply must
+            // propagate the Err, mark the vN+1 ledger row Failed, and leave it
+            // re-electable (mark_failed recovery path).
+            let conn = Connection::open_in_memory().unwrap();
+            Ledger::ensure_schema(&conn).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE t (id TEXT PRIMARY KEY, needed TEXT NOT NULL);
+                 INSERT INTO t VALUES ('a','x');",
+            )
+            .unwrap();
+
+            let drop = ClassifiedOp::new(Op::DropColumn {
+                table: "t".into(),
+                column: "needed".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+
+            // Restoring a NOT NULL column with no default errors mid-apply.
+            let res = apply_compensating(&conn, 7, "c7", &[], Some(&payload), 300);
+            assert!(res.is_err(), "the mid-apply error must propagate");
+
+            // The vN+1 row is Failed...
+            let v7 = Ledger::entry(&conn, 7).unwrap().unwrap();
+            assert_eq!(v7.status, MigrationStatus::Failed);
+            // ...and immediately re-electable (a fresh election wins the slot).
+            assert_eq!(
+                Ledger::try_elect(&conn, 7, "c7", 300).unwrap(),
+                Election::Won
+            );
+        }
+
+        #[test]
+        fn additive_reverse_removes_added_column_from_live_schema() {
+            // MED-4: an AddColumn down-op (its inverse, DropColumn) must leave the
+            // live schema without the added column.
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch("CREATE TABLE t (id TEXT PRIMARY KEY, extra TEXT);")
+                .unwrap();
+            let up = vec![ClassifiedOp::new(Op::AddColumn {
+                table: "t".into(),
+                column: col("extra", ColumnKind::Text),
+            })];
+            let down = additive_down_ops(&up).unwrap();
+            apply_ops(&conn, &down, &mut noop).unwrap();
+            let cols: Vec<String> = table_info(&conn, "t")
+                .unwrap()
+                .into_iter()
+                .map(|c| c.name)
+                .collect();
+            assert_eq!(cols, vec!["id".to_string()]);
+        }
+
+        #[test]
+        fn additive_reverse_drops_created_index_from_live_schema() {
+            // MED-4: a CreateIndex down-op (its inverse, DropIndex) must remove
+            // the index from the live schema.
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(
+                "CREATE TABLE t (id TEXT PRIMARY KEY, v TEXT);
+                 CREATE INDEX t_v ON t(v);",
+            )
+            .unwrap();
+            let up = vec![ClassifiedOp::new(Op::CreateIndex {
+                name: "t_v".into(),
+                table: "t".into(),
+                columns: vec!["v".into()],
+                unique: false,
+            })];
+            let down = additive_down_ops(&up).unwrap();
+            apply_ops(&conn, &down, &mut noop).unwrap();
+            let n: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='t_v'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(n, 0);
+        }
+
         fn table_exists(conn: &Connection, table: &str) -> bool {
             let n: i64 = conn
                 .query_row(
@@ -1402,9 +1647,10 @@ mod tests {
                 tables: vec![TablePreimage::Column {
                     table: "t".into(),
                     dropped: "c".into(),
-                    columns: vec![col("id", ColumnKind::Text), col("c", ColumnKind::Text)],
+                    create_sql: "CREATE TABLE t (id TEXT PRIMARY KEY, c TEXT)".into(),
+                    aux_ddl: vec![],
+                    dropped_requires_value: false,
                     pk: vec!["id".into()],
-                    without_rowid: false,
                     captured_columns: vec!["id".into(), "c".into()],
                     rows: data,
                 }],
@@ -1418,6 +1664,47 @@ mod tests {
             assert!(matches!(stored, Preimage::Inline { .. }));
             let back = load_preimage(&stored, None).await.unwrap();
             assert_eq!(back, payload);
+        }
+
+        #[tokio::test]
+        async fn inline_boundary_is_pinned_behaviorally() {
+            // MED-1: pin the boundary by BEHAVIOR, not just the const. A payload
+            // serializing to exactly INLINE_MAX_BYTES rides inline; one byte over
+            // is refused. Pad a single ASCII text value (1 JSON byte per char, no
+            // escaping) so the serialized length lands precisely on the boundary.
+            let mk = |pad: usize| PreimagePayload {
+                tables: vec![TablePreimage::Table {
+                    table: "t".into(),
+                    create_sql: "CREATE TABLE t (id TEXT PRIMARY KEY)".into(),
+                    aux_ddl: vec![],
+                    pk: vec!["id".into()],
+                    columns: vec!["id".into()],
+                    rows: vec![vec![CapturedValue::Text("a".repeat(pad))]],
+                }],
+            };
+            let base = serde_json::to_vec(&mk(0)).unwrap().len();
+            let pad = INLINE_MAX_BYTES - base;
+
+            let at = mk(pad);
+            assert_eq!(serde_json::to_vec(&at).unwrap().len(), INLINE_MAX_BYTES);
+            assert!(
+                matches!(
+                    store_preimage(&at, None).await.unwrap(),
+                    Preimage::Inline { .. }
+                ),
+                "a payload exactly at the boundary must ride inline"
+            );
+
+            let over = mk(pad + 1);
+            assert_eq!(
+                serde_json::to_vec(&over).unwrap().len(),
+                INLINE_MAX_BYTES + 1
+            );
+            let err = store_preimage(&over, None).await.unwrap_err();
+            assert!(
+                matches!(err, MigrateError::Apply(m) if m.contains("inline limit")),
+                "one byte over the boundary must be refused without a relay"
+            );
         }
 
         #[tokio::test]

--- a/crates/smugglr-core/src/migrate/reverse.rs
+++ b/crates/smugglr-core/src/migrate/reverse.rs
@@ -1,3 +1,1498 @@
-//! Reverse / rollback (pre-stub). Body lands in #274 -- rollback as an
-//! append-only compensating forward step (vN+1) restoring the delta-scoped
-//! pre-image via `stash`. Empty until then.
+//! Reverse / rollback (#274).
+//!
+//! Rollback is a **compensating forward step**, never a transactional undo
+//! (design decisions 3/4, "Recovery"). Reversing `vN` assembles the inverse of
+//! its `up` ops and applies them as a *new* ledgered `vN+1` step; the reversed
+//! `vN` ledger row stays byte-unchanged, because the ledger is append-only and
+//! chain-hashed and an edit would trip [`crate::migrate::ledger::Ledger::verify_chain`]
+//! ([`crate::error::SyncError::LedgerTampered`]).
+//!
+//! Two reverse classes (decision 4):
+//!
+//! - **Additive** (`CreateTable` / `AddColumn` / `CreateIndex` / rename): the
+//!   reverse is the *structural inverse* -- drop what was added, swap a rename --
+//!   carrying no data. [`structural_inverse`] / [`additive_down_ops`].
+//! - **Destructive** (`DropTable` / `DropColumn`): reversible only from a
+//!   **delta-scoped pre-image** (rows-INTERSECT-columns, OQ1) captured *during*
+//!   the forward apply, before the op mutates. The capture rides the `pre_op`
+//!   write-ahead hook [`apply_ops`](crate::migrate::apply::apply_ops) already
+//!   exposes ([`PreimageCapturer::capture_before`]); restore reconstructs the
+//!   structure ([`crate::migrate::apply::rebuild_to_schema`] for a re-added
+//!   column, verbatim DDL for a re-created table) and refills the lost cells with
+//!   an idempotent PK-keyed UPSERT ([`restore_payload`], spike C).
+//!
+//! # Two compilation surfaces
+//!
+//! Like `apply`, this module is declared `pub mod reverse;` with no `native`
+//! gate, so the pure inverse ([`structural_inverse`]) and the serializable
+//! pre-image types compile on `wasm32`. Everything touching `rusqlite`,
+//! `object_store`, or the ledger is internally `#[cfg(feature = "native")]`.
+//!
+//! # Pre-image storage (resolved)
+//!
+//! The captured pre-image serializes to JSON and is carried as a
+//! [`Preimage`](crate::migrate::Preimage): **small payloads inline**
+//! ([`Preimage::Inline`], no relay) and **large payloads in a content-addressed
+//! store** ([`Preimage::Ref`], keyed by the SHA-256 of the payload, written
+//! through [`crate::stash::build_store`]). [`INLINE_MAX_BYTES`] pins the boundary
+//! where inline refuses and a relay becomes mandatory ([`store_preimage`]). A
+//! large payload's key is *read* from the ledger's forward-compat `preimage_ref`
+//! column ([`preimage_ref_of`], OQ2 "read-only"); **writing** that column is the
+//! driver's job (#296), out of scope here.
+
+use crate::migrate::{ClassifiedOp, Column, MigrateError, Op};
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "native")]
+use crate::config::StashConfig;
+#[cfg(feature = "native")]
+use crate::migrate::apply::{apply_ops, rebuild_to_schema, render_column_def, RebuildSpec};
+#[cfg(feature = "native")]
+use crate::migrate::ledger::{Election, Ledger, LedgerEntry};
+#[cfg(feature = "native")]
+use crate::migrate::{ColumnKind, Constraint, Preimage};
+#[cfg(feature = "native")]
+use object_store::{path::Path as ObjectPath, ObjectStore, PutPayload};
+#[cfg(feature = "native")]
+use rusqlite::{params_from_iter, types::Value as SqlValue, Connection};
+#[cfg(feature = "native")]
+use sha2::{Digest, Sha256};
+
+// ===========================================================================
+// Structural inverse (always compiled -- no rusqlite)
+// ===========================================================================
+
+/// The structural inverse of an **additive** op (decision 4): drop what was
+/// added, swap a rename. Carries no data.
+///
+/// Returns [`MigrateError::Apply`] for an op whose reverse needs a captured
+/// pre-image (`DropTable`, `DropColumn`) or is not structurally recoverable in
+/// 0.5.0 (`DropIndex` -- the index definition is not carried by the op). Those
+/// reverse through the pre-image path, not this pure inverse.
+pub fn structural_inverse(op: &Op) -> Result<Op, MigrateError> {
+    match op {
+        Op::CreateTable { table, .. } => Ok(Op::DropTable {
+            table: table.clone(),
+        }),
+        Op::AddColumn { table, column } => Ok(Op::DropColumn {
+            table: table.clone(),
+            column: column.name.clone(),
+        }),
+        Op::CreateIndex { name, .. } => Ok(Op::DropIndex { name: name.clone() }),
+        Op::RenameTable { from, to } => Ok(Op::RenameTable {
+            from: to.clone(),
+            to: from.clone(),
+        }),
+        Op::RenameColumn { table, from, to } => Ok(Op::RenameColumn {
+            table: table.clone(),
+            from: to.clone(),
+            to: from.clone(),
+        }),
+        Op::DropTable { table } => Err(MigrateError::Apply(format!(
+            "reverse of DROP TABLE {table:?} needs a captured pre-image, not a structural inverse"
+        ))),
+        Op::DropColumn { table, column } => Err(MigrateError::Apply(format!(
+            "reverse of DROP COLUMN {column:?} on {table:?} needs a captured pre-image, \
+             not a structural inverse"
+        ))),
+        Op::DropIndex { name } => Err(MigrateError::Apply(format!(
+            "reverse of DROP INDEX {name:?} is not structurally recoverable in 0.5.0 \
+             (the op does not carry the index definition)"
+        ))),
+    }
+}
+
+/// The additive `down` ops for a manifest's `up`: the [`structural_inverse`] of
+/// each op, in **reverse order** (the last thing applied is the first thing
+/// undone). Errors if any op is destructive -- those need the pre-image path.
+pub fn additive_down_ops(up: &[ClassifiedOp]) -> Result<Vec<ClassifiedOp>, MigrateError> {
+    up.iter()
+        .rev()
+        .map(|c| structural_inverse(&c.op).map(ClassifiedOp::new))
+        .collect()
+}
+
+// ===========================================================================
+// Pre-image payload (serializable; always compiled)
+// ===========================================================================
+
+/// The inline-vs-relay boundary (64 KiB of serialized payload).
+///
+/// At or under this, a pre-image rides inline in the manifest
+/// ([`Preimage::Inline`]); over it, inline **refuses** and a content-addressed
+/// relay store becomes mandatory ([`Preimage::Ref`]) -- otherwise a large
+/// `DROP COLUMN` pre-image would silently fail to travel. Pinned in
+/// [`store_preimage`].
+pub const INLINE_MAX_BYTES: usize = 64 * 1024;
+
+/// A single captured SQLite cell value, losslessly serializable.
+///
+/// Mirrors [`rusqlite::types::Value`]'s five storage classes; `Blob` round-trips
+/// as a byte array so binary keys/columns survive JSON.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "t", content = "v", rename_all = "snake_case")]
+pub enum CapturedValue {
+    /// SQL `NULL`.
+    Null,
+    /// A 64-bit integer.
+    Int(i64),
+    /// A floating-point value.
+    Real(f64),
+    /// UTF-8 text.
+    Text(String),
+    /// Opaque bytes.
+    Blob(Vec<u8>),
+}
+
+/// One table's delta-scoped pre-image: exactly the rows-INTERSECT-columns a
+/// destructive op is about to lose, plus the structure needed to put them back.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "loss", rename_all = "snake_case")]
+pub enum TablePreimage {
+    /// A dropped column. Restore rebuilds the table to the pre-drop schema
+    /// ([`Column`] set), then refills the one lost column by PK-keyed UPSERT.
+    Column {
+        /// The table the column was dropped from.
+        table: String,
+        /// The dropped column's name.
+        dropped: String,
+        /// The full pre-drop column set (the explicit rebuild target). The
+        /// primary key is carried separately in `pk`, so no column here declares
+        /// an inline `PRIMARY KEY`.
+        columns: Vec<Column>,
+        /// The primary-key column names, in key order.
+        pk: Vec<String>,
+        /// Whether the pre-drop table was `WITHOUT ROWID`.
+        without_rowid: bool,
+        /// The columns present in each captured row (`pk` ++ `dropped`).
+        captured_columns: Vec<String>,
+        /// Captured rows, each aligned to `captured_columns`.
+        rows: Vec<Vec<CapturedValue>>,
+    },
+    /// A dropped table. Restore re-creates it from the captured DDL (verbatim, so
+    /// indexes / triggers / `CHECK` / `WITHOUT ROWID` survive), then re-inserts
+    /// every row by PK-keyed UPSERT.
+    Table {
+        /// The dropped table's name.
+        table: String,
+        /// The verbatim `CREATE TABLE` DDL captured from `sqlite_master`.
+        create_sql: String,
+        /// Verbatim index / trigger DDL to replay after the table is recreated.
+        aux_ddl: Vec<String>,
+        /// The primary-key column names, in key order.
+        pk: Vec<String>,
+        /// Every column name, in table order (the row layout).
+        columns: Vec<String>,
+        /// Captured rows, each aligned to `columns`.
+        rows: Vec<Vec<CapturedValue>>,
+    },
+}
+
+/// The whole captured pre-image for one destructive migration: one
+/// [`TablePreimage`] per destructive op, in apply order.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct PreimagePayload {
+    /// Per-op captures, in the order the destructive ops were applied.
+    pub tables: Vec<TablePreimage>,
+}
+
+impl PreimagePayload {
+    /// Whether nothing was captured (no destructive op ran).
+    pub fn is_empty(&self) -> bool {
+        self.tables.is_empty()
+    }
+}
+
+// ===========================================================================
+// Native: capture, restore, storage, rollback
+// ===========================================================================
+
+/// Quote a SQL identifier, escaping embedded double-quotes by doubling.
+#[cfg(feature = "native")]
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Map a SQLite declared column type to a structured [`ColumnKind`] by affinity.
+///
+/// SQLite's type affinity rules (a substring scan of the declared type) decide
+/// storage class; an empty / unknown declared type falls to `Blob` (NUMERIC/none
+/// affinity), matching the `apply` rebuild's typeless-column handling.
+#[cfg(feature = "native")]
+fn kind_from_decl(decl: &str) -> ColumnKind {
+    let up = decl.to_ascii_uppercase();
+    if up.contains("INT") {
+        ColumnKind::Int
+    } else if up.contains("CHAR") || up.contains("CLOB") || up.contains("TEXT") {
+        ColumnKind::Text
+    } else if up.contains("REAL") || up.contains("FLOA") || up.contains("DOUB") {
+        ColumnKind::Real
+    } else {
+        ColumnKind::Blob
+    }
+}
+
+/// One `PRAGMA table_info` row, tolerant of absent tables.
+#[cfg(feature = "native")]
+struct ColRow {
+    name: String,
+    decl: String,
+    notnull: bool,
+    dflt: Option<String>,
+    /// 1-based PK position, `0` if not part of the primary key.
+    pk: i64,
+}
+
+/// Read `PRAGMA table_info` for a table (empty if absent).
+#[cfg(feature = "native")]
+fn table_info(conn: &Connection, table: &str) -> Result<Vec<ColRow>, MigrateError> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({})", quote_ident(table)))?;
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(ColRow {
+                name: r.get::<_, String>(1)?,
+                decl: r.get::<_, String>(2)?,
+                notnull: r.get::<_, i64>(3)? != 0,
+                dflt: r.get::<_, Option<String>>(4)?,
+                pk: r.get::<_, i64>(5)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// The primary-key column names of a table, in key order.
+#[cfg(feature = "native")]
+fn primary_key(info: &[ColRow]) -> Vec<String> {
+    let mut pk: Vec<&ColRow> = info.iter().filter(|c| c.pk > 0).collect();
+    pk.sort_by_key(|c| c.pk);
+    pk.into_iter().map(|c| c.name.clone()).collect()
+}
+
+/// Reconstruct a structured [`Column`] from a pragma row. The primary key is
+/// emitted table-level by the caller, so no `Constraint::Pk` is attached here.
+#[cfg(feature = "native")]
+fn column_from_row(row: &ColRow) -> Column {
+    let mut constraints = Vec::new();
+    if row.notnull {
+        constraints.push(Constraint::NotNull);
+    }
+    if let Some(d) = &row.dflt {
+        constraints.push(Constraint::Default(d.clone()));
+    }
+    Column {
+        name: row.name.clone(),
+        kind: kind_from_decl(&row.decl),
+        constraints,
+        tags: Vec::new(),
+    }
+}
+
+/// The verbatim `CREATE` DDL of a `sqlite_master` object, if present.
+#[cfg(feature = "native")]
+fn object_sql(conn: &Connection, kind: &str, name: &str) -> Result<Option<String>, MigrateError> {
+    use rusqlite::OptionalExtension;
+    let sql = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = ?1 AND name = ?2",
+            rusqlite::params![kind, name],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()?;
+    Ok(sql.flatten())
+}
+
+/// Verbatim `CREATE INDEX` / `CREATE TRIGGER` DDL attached to a table.
+#[cfg(feature = "native")]
+fn aux_object_ddl(conn: &Connection, table: &str) -> Result<Vec<String>, MigrateError> {
+    let mut stmt = conn.prepare(
+        "SELECT sql FROM sqlite_master \
+         WHERE tbl_name = ?1 AND type IN ('index', 'trigger') AND sql IS NOT NULL \
+         ORDER BY type, name",
+    )?;
+    let rows = stmt
+        .query_map(rusqlite::params![table], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// Read the captured rows for `columns` from `table`, in table order.
+#[cfg(feature = "native")]
+fn capture_rows(
+    conn: &Connection,
+    table: &str,
+    columns: &[String],
+) -> Result<Vec<Vec<CapturedValue>>, MigrateError> {
+    let list = columns
+        .iter()
+        .map(|c| quote_ident(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut stmt = conn.prepare(&format!("SELECT {} FROM {}", list, quote_ident(table)))?;
+    let n = columns.len();
+    let rows = stmt
+        .query_map([], |r| {
+            let mut out = Vec::with_capacity(n);
+            for i in 0..n {
+                out.push(captured_from_sql(r.get::<_, SqlValue>(i)?));
+            }
+            Ok(out)
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// Lower a rusqlite value into the serializable [`CapturedValue`].
+#[cfg(feature = "native")]
+fn captured_from_sql(v: SqlValue) -> CapturedValue {
+    match v {
+        SqlValue::Null => CapturedValue::Null,
+        SqlValue::Integer(i) => CapturedValue::Int(i),
+        SqlValue::Real(r) => CapturedValue::Real(r),
+        SqlValue::Text(s) => CapturedValue::Text(s),
+        SqlValue::Blob(b) => CapturedValue::Blob(b),
+    }
+}
+
+/// Raise a serializable [`CapturedValue`] back into a bindable rusqlite value.
+#[cfg(feature = "native")]
+fn captured_to_sql(v: &CapturedValue) -> SqlValue {
+    match v {
+        CapturedValue::Null => SqlValue::Null,
+        CapturedValue::Int(i) => SqlValue::Integer(*i),
+        CapturedValue::Real(r) => SqlValue::Real(*r),
+        CapturedValue::Text(s) => SqlValue::Text(s.clone()),
+        CapturedValue::Blob(b) => SqlValue::Blob(b.clone()),
+    }
+}
+
+/// Accumulates the delta-scoped pre-image while a destructive forward apply runs.
+///
+/// Drive it as the `pre_op` write-ahead hook of
+/// [`apply_ops`](crate::migrate::apply::apply_ops): the hook fires *before* each
+/// op's own transaction, so [`Self::capture_before`] snapshots committed,
+/// pre-mutation state. Additive ops are ignored (their reverse carries no data).
+///
+/// ```ignore
+/// let mut cap = PreimageCapturer::new();
+/// apply_ops(conn, &up, &mut |op| cap.capture_before(conn, op))?;
+/// let payload = cap.into_payload();
+/// ```
+#[cfg(feature = "native")]
+#[derive(Debug, Default)]
+pub struct PreimageCapturer {
+    payload: PreimagePayload,
+}
+
+#[cfg(feature = "native")]
+impl PreimageCapturer {
+    /// A fresh, empty capturer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot the pre-image of `op` if it is destructive; no-op otherwise.
+    ///
+    /// Must run **before** `op` mutates (it reads the current table). Additive
+    /// ops carry no data, so they are skipped.
+    pub fn capture_before(
+        &mut self,
+        conn: &Connection,
+        op: &ClassifiedOp,
+    ) -> Result<(), MigrateError> {
+        match &op.op {
+            Op::DropColumn { table, column } => {
+                let capture = self.capture_drop_column(conn, table, column)?;
+                self.payload.tables.push(capture);
+            }
+            Op::DropTable { table } => {
+                let capture = self.capture_drop_table(conn, table)?;
+                self.payload.tables.push(capture);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Consume the capturer, yielding the accumulated pre-image.
+    pub fn into_payload(self) -> PreimagePayload {
+        self.payload
+    }
+
+    #[cfg(feature = "native")]
+    fn capture_drop_column(
+        &self,
+        conn: &Connection,
+        table: &str,
+        column: &str,
+    ) -> Result<TablePreimage, MigrateError> {
+        let info = table_info(conn, table)?;
+        if info.is_empty() {
+            return Err(MigrateError::Apply(format!(
+                "cannot capture pre-image: table {table:?} does not exist"
+            )));
+        }
+        let pk = primary_key(&info);
+        if pk.is_empty() {
+            return Err(MigrateError::Apply(format!(
+                "cannot capture pre-image for {table:?}: no primary key (needed to key the \
+                 surgical restore)"
+            )));
+        }
+        if pk.iter().any(|k| k == column) {
+            return Err(MigrateError::Apply(format!(
+                "cannot reverse dropping primary-key column {column:?} on {table:?} via a \
+                 surgical pre-image"
+            )));
+        }
+        let columns: Vec<Column> = info.iter().map(column_from_row).collect();
+        let without_rowid = object_sql(conn, "table", table)?
+            .map(|s| s.to_ascii_uppercase().contains("WITHOUT ROWID"))
+            .unwrap_or(false);
+
+        let mut captured_columns = pk.clone();
+        captured_columns.push(column.to_string());
+        let rows = capture_rows(conn, table, &captured_columns)?;
+
+        Ok(TablePreimage::Column {
+            table: table.to_string(),
+            dropped: column.to_string(),
+            columns,
+            pk,
+            without_rowid,
+            captured_columns,
+            rows,
+        })
+    }
+
+    #[cfg(feature = "native")]
+    fn capture_drop_table(
+        &self,
+        conn: &Connection,
+        table: &str,
+    ) -> Result<TablePreimage, MigrateError> {
+        let info = table_info(conn, table)?;
+        if info.is_empty() {
+            return Err(MigrateError::Apply(format!(
+                "cannot capture pre-image: table {table:?} does not exist"
+            )));
+        }
+        let create_sql = object_sql(conn, "table", table)?.ok_or_else(|| {
+            MigrateError::Apply(format!(
+                "cannot capture pre-image: no DDL for table {table:?}"
+            ))
+        })?;
+        let pk = primary_key(&info);
+        let columns: Vec<String> = info.iter().map(|c| c.name.clone()).collect();
+        let rows = capture_rows(conn, table, &columns)?;
+        let aux_ddl = aux_object_ddl(conn, table)?;
+
+        Ok(TablePreimage::Table {
+            table: table.to_string(),
+            create_sql,
+            aux_ddl,
+            pk,
+            columns,
+            rows,
+        })
+    }
+}
+
+/// Restore a captured pre-image: reconstruct the lost structure, then refill the
+/// lost cells with an idempotent PK-keyed UPSERT (surgical, re-runnable -- spike
+/// C). Concurrent rows not in the pre-image are never touched.
+///
+/// Captures are undone in **reverse capture order** (last dropped, first
+/// restored). Two ops on one table must unwind LIFO: restoring an earlier
+/// capture whose schema still references a column a later drop removed would try
+/// to copy a column the current table no longer has. Reverse order restores the
+/// later (narrower) capture first, so each rebuild's projection matches the live
+/// table.
+#[cfg(feature = "native")]
+pub fn restore_payload(conn: &Connection, payload: &PreimagePayload) -> Result<(), MigrateError> {
+    for table in payload.tables.iter().rev() {
+        match table {
+            TablePreimage::Column {
+                table,
+                dropped,
+                columns,
+                pk,
+                without_rowid,
+                captured_columns,
+                rows,
+            } => restore_column(
+                conn,
+                table,
+                dropped,
+                columns,
+                pk,
+                *without_rowid,
+                captured_columns,
+                rows,
+            )?,
+            TablePreimage::Table {
+                table,
+                create_sql,
+                aux_ddl,
+                pk,
+                columns,
+                rows,
+            } => restore_table(conn, table, create_sql, aux_ddl, pk, columns, rows)?,
+        }
+    }
+    Ok(())
+}
+
+/// Restore a dropped column: rebuild the table to the explicit pre-drop schema
+/// (re-adding the column, structurally faithful via
+/// [`rebuild_to_schema`](crate::migrate::apply::rebuild_to_schema)), then UPSERT
+/// the captured values back into it.
+#[cfg(feature = "native")]
+#[allow(clippy::too_many_arguments)]
+fn restore_column(
+    conn: &Connection,
+    table: &str,
+    dropped: &str,
+    columns: &[Column],
+    pk: &[String],
+    without_rowid: bool,
+    captured_columns: &[String],
+    rows: &[Vec<CapturedValue>],
+) -> Result<(), MigrateError> {
+    let dropped_col = columns.iter().find(|c| c.name == dropped).ok_or_else(|| {
+        MigrateError::Apply(format!(
+            "pre-image for {table:?} is missing the dropped column {dropped:?}"
+        ))
+    })?;
+    // The rebuild copies the surviving columns and leaves the re-added column
+    // empty until the UPSERT fills it. A NOT NULL column with no default cannot
+    // survive that gap -- fail with a clear message, not a raw SQL error.
+    let not_null = dropped_col
+        .constraints
+        .iter()
+        .any(|c| matches!(c, Constraint::NotNull));
+    let has_default = dropped_col
+        .constraints
+        .iter()
+        .any(|c| matches!(c, Constraint::Default(_)));
+    if not_null && !has_default {
+        return Err(MigrateError::Apply(format!(
+            "cannot restore NOT NULL column {dropped:?} on {table:?} without a default \
+             (rebuild-then-fill leaves it null until the row-level UPSERT)"
+        )));
+    }
+
+    // Only rebuild if the column is actually gone (idempotent re-run: a second
+    // restore finds the column present and skips straight to the UPSERT).
+    let present: Vec<String> = table_info(conn, table)?
+        .into_iter()
+        .map(|c| c.name)
+        .collect();
+    if !present.iter().any(|c| c == dropped) {
+        let mut body: Vec<String> = columns.iter().map(render_column_def).collect();
+        if !pk.is_empty() {
+            body.push(format!(
+                "PRIMARY KEY ({})",
+                pk.iter()
+                    .map(|c| quote_ident(c))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        // Copy every surviving column identity-wise; the re-added column is left
+        // out of the projection so it defaults to null/its default.
+        let projection: Vec<(String, String)> = columns
+            .iter()
+            .filter(|c| c.name != dropped)
+            .map(|c| (c.name.clone(), quote_ident(&c.name)))
+            .collect();
+        let post_ddl = aux_object_ddl(conn, table)?;
+        let spec = RebuildSpec {
+            table: table.to_string(),
+            body,
+            without_rowid,
+            projection,
+            post_ddl,
+        };
+        rebuild_to_schema(conn, &spec)?;
+    }
+
+    upsert_rows(
+        conn,
+        table,
+        captured_columns,
+        pk,
+        &[dropped.to_string()],
+        rows,
+    )
+}
+
+/// Restore a dropped table: recreate it from the verbatim captured DDL if it is
+/// absent, then UPSERT every captured row back in.
+#[cfg(feature = "native")]
+fn restore_table(
+    conn: &Connection,
+    table: &str,
+    create_sql: &str,
+    aux_ddl: &[String],
+    pk: &[String],
+    columns: &[String],
+    rows: &[Vec<CapturedValue>],
+) -> Result<(), MigrateError> {
+    let exists: i64 = conn.query_row(
+        "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        rusqlite::params![table],
+        |r| r.get(0),
+    )?;
+    if exists == 0 {
+        let tx = conn.unchecked_transaction()?;
+        tx.execute_batch(create_sql)?;
+        for ddl in aux_ddl {
+            tx.execute_batch(ddl)?;
+        }
+        tx.commit()?;
+    }
+    let non_pk: Vec<String> = columns
+        .iter()
+        .filter(|c| !pk.contains(c))
+        .cloned()
+        .collect();
+    upsert_rows(conn, table, columns, pk, &non_pk, rows)
+}
+
+/// Idempotent PK-keyed UPSERT: insert each row, and on a PK conflict update only
+/// `update_columns` from the incoming row (`excluded`). Surgical -- an untouched
+/// column of a matched row, and any row not in `rows`, is left exactly as it was.
+#[cfg(feature = "native")]
+fn upsert_rows(
+    conn: &Connection,
+    table: &str,
+    insert_columns: &[String],
+    pk: &[String],
+    update_columns: &[String],
+    rows: &[Vec<CapturedValue>],
+) -> Result<(), MigrateError> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let cols = insert_columns
+        .iter()
+        .map(|c| quote_ident(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let placeholders = (0..insert_columns.len())
+        .map(|_| "?")
+        .collect::<Vec<_>>()
+        .join(", ");
+    let conflict = pk
+        .iter()
+        .map(|c| quote_ident(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let action = if update_columns.is_empty() {
+        "DO NOTHING".to_string()
+    } else {
+        let sets = update_columns
+            .iter()
+            .map(|c| format!("{q} = excluded.{q}", q = quote_ident(c)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("DO UPDATE SET {sets}")
+    };
+    let sql = format!(
+        "INSERT INTO {t} ({cols}) VALUES ({placeholders}) ON CONFLICT ({conflict}) {action}",
+        t = quote_ident(table)
+    );
+
+    let tx = conn.unchecked_transaction()?;
+    {
+        let mut stmt = tx.prepare(&sql)?;
+        for row in rows {
+            if row.len() != insert_columns.len() {
+                return Err(MigrateError::Apply(format!(
+                    "pre-image row width {} does not match {} captured columns for {table:?}",
+                    row.len(),
+                    insert_columns.len()
+                )));
+            }
+            stmt.execute(params_from_iter(row.iter().map(captured_to_sql)))?;
+        }
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+// ===========================================================================
+// Native: content-addressed pre-image storage (inline vs relay)
+// ===========================================================================
+
+/// Persist a captured pre-image as a [`Preimage`].
+///
+/// Small payloads (serialized `<= `[`INLINE_MAX_BYTES`]) ride inline; larger ones
+/// **require** a relay -- the pre-image is written to the content-addressed store
+/// (`config`) keyed by its SHA-256 and returned as [`Preimage::Ref`]. A payload
+/// over the boundary with no `config` is a hard error (a large pre-image must not
+/// silently fail to travel).
+#[cfg(feature = "native")]
+pub async fn store_preimage(
+    payload: &PreimagePayload,
+    config: Option<&StashConfig>,
+) -> Result<Preimage, MigrateError> {
+    let bytes =
+        serde_json::to_vec(payload).map_err(|e| MigrateError::Serialization(e.to_string()))?;
+    if bytes.len() <= INLINE_MAX_BYTES {
+        let rows = serde_json::to_value(payload)
+            .map_err(|e| MigrateError::Serialization(e.to_string()))?;
+        return Ok(Preimage::Inline { rows });
+    }
+    let config = config.ok_or_else(|| {
+        MigrateError::Apply(format!(
+            "pre-image is {} bytes, over the {} byte inline limit; a relay store (StashConfig) \
+             is required to carry it",
+            bytes.len(),
+            INLINE_MAX_BYTES
+        ))
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let key = hex::encode(hasher.finalize());
+    let (store, _) =
+        crate::stash::build_store(config).map_err(|e| MigrateError::Apply(e.to_string()))?;
+    let path = ObjectPath::from(format!("{key}.preimage"));
+    store
+        .put(&path, PutPayload::from(bytes))
+        .await
+        .map_err(|e| MigrateError::Apply(format!("pre-image store put failed: {e}")))?;
+    Ok(Preimage::Ref { key })
+}
+
+/// Load a pre-image back from its [`Preimage`] reference. An inline payload
+/// deserializes directly; a [`Preimage::Ref`] is fetched from the content-
+/// addressed store (`config` required).
+#[cfg(feature = "native")]
+pub async fn load_preimage(
+    preimage: &Preimage,
+    config: Option<&StashConfig>,
+) -> Result<PreimagePayload, MigrateError> {
+    match preimage {
+        Preimage::Inline { rows } => serde_json::from_value(rows.clone())
+            .map_err(|e| MigrateError::Serialization(e.to_string())),
+        Preimage::Ref { key } => {
+            let config = config.ok_or_else(|| {
+                MigrateError::Apply(
+                    "pre-image is a store reference but no StashConfig was provided".to_string(),
+                )
+            })?;
+            let (store, _) = crate::stash::build_store(config)
+                .map_err(|e| MigrateError::Apply(e.to_string()))?;
+            let path = ObjectPath::from(format!("{key}.preimage"));
+            let got = store
+                .get(&path)
+                .await
+                .map_err(|e| MigrateError::Apply(format!("pre-image store get failed: {e}")))?;
+            let bytes = got
+                .bytes()
+                .await
+                .map_err(|e| MigrateError::Apply(format!("pre-image store read failed: {e}")))?;
+            serde_json::from_slice(&bytes).map_err(|e| MigrateError::Serialization(e.to_string()))
+        }
+    }
+}
+
+/// The pre-image reference recorded on a ledger row, if any (OQ2, read-only).
+///
+/// The forward driver (#296) *writes* `preimage_ref` when it stashes a large
+/// destructive pre-image; reverse only *reads* it here, resolving the stored key
+/// to a [`Preimage::Ref`] to feed [`load_preimage`]. `None` means the reverse's
+/// pre-image (if any) travels inline in the manifest instead.
+#[cfg(feature = "native")]
+pub fn preimage_ref_of(entry: &LedgerEntry) -> Option<Preimage> {
+    entry
+        .preimage_ref
+        .as_ref()
+        .map(|key| Preimage::Ref { key: key.clone() })
+}
+
+// ===========================================================================
+// Native: append-only compensating rollback step
+// ===========================================================================
+
+/// Apply a reverse as a **new, append-only compensating `version` step**.
+///
+/// Elects `version` (`vN+1`) through the ledger's normal two-phase flow
+/// ([`Ledger::try_elect`] -> apply -> [`Ledger::mark_success`]); the reversed
+/// `vN` row is never popped, marked, or edited (that would trip the chain-hash
+/// tamper check). Additive reverses ride `down_ops` through
+/// [`apply_ops`](crate::migrate::apply::apply_ops); a destructive reverse's
+/// structural + data restore rides `payload` through [`restore_payload`]. On a
+/// mid-apply failure the row is marked failed so it is immediately reclaimable.
+///
+/// Scope: this composes a **pure-additive** reverse (`down_ops`, empty `payload`)
+/// or a **pure-destructive** one (empty `down_ops`, `payload`). A reverse that
+/// interleaves the two -- dropping a column whose data a later restore's captured
+/// schema still references -- cannot be expressed as "all `down_ops`, then all
+/// restores" and is the composing driver's concern (#296). The seam already
+/// enforces this: [`additive_down_ops`] errors on any destructive op, so a caller
+/// cannot assemble a mixed `down_ops` from a mixed `up` here.
+///
+/// Returns the [`Election`] outcome: `Won` means the step applied, anything else
+/// means it was already applied or is held by another node (the caller backs off).
+#[cfg(feature = "native")]
+pub fn apply_compensating(
+    conn: &Connection,
+    version: u64,
+    checksum: &str,
+    down_ops: &[ClassifiedOp],
+    payload: Option<&PreimagePayload>,
+    lease_secs: i64,
+) -> crate::error::Result<Election> {
+    let election = Ledger::try_elect(conn, version, checksum, lease_secs)?;
+    if election != Election::Won {
+        return Ok(election);
+    }
+    let outcome = (|| -> crate::error::Result<()> {
+        let mut noop = |_: &ClassifiedOp| -> Result<(), MigrateError> { Ok(()) };
+        apply_ops(conn, down_ops, &mut noop)?;
+        if let Some(p) = payload {
+            restore_payload(conn, p)?;
+        }
+        Ok(())
+    })();
+    match outcome {
+        Ok(()) => {
+            Ledger::mark_success(conn, version)?;
+            Ok(Election::Won)
+        }
+        Err(e) => {
+            // Best-effort: leave the row reclaimable. The original error wins.
+            let _ = Ledger::mark_failed(conn, version);
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn col(name: &str, kind: ColumnKind) -> Column {
+        Column {
+            name: name.to_string(),
+            kind,
+            constraints: Vec::new(),
+            tags: Vec::new(),
+        }
+    }
+
+    // -- Structural inverse (pure, both feature sets) -----------------------
+
+    #[test]
+    fn create_table_inverts_to_drop_table() {
+        let inv = structural_inverse(&Op::CreateTable {
+            table: "t".into(),
+            columns: vec![col("id", ColumnKind::Text)],
+            without_rowid: false,
+        })
+        .unwrap();
+        assert_eq!(inv, Op::DropTable { table: "t".into() });
+    }
+
+    #[test]
+    fn add_column_inverts_to_drop_column() {
+        let inv = structural_inverse(&Op::AddColumn {
+            table: "t".into(),
+            column: col("email", ColumnKind::Text),
+        })
+        .unwrap();
+        assert_eq!(
+            inv,
+            Op::DropColumn {
+                table: "t".into(),
+                column: "email".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn create_index_inverts_to_drop_index() {
+        let inv = structural_inverse(&Op::CreateIndex {
+            name: "idx".into(),
+            table: "t".into(),
+            columns: vec!["a".into()],
+            unique: false,
+        })
+        .unwrap();
+        assert_eq!(inv, Op::DropIndex { name: "idx".into() });
+    }
+
+    #[test]
+    fn renames_invert_by_swapping() {
+        assert_eq!(
+            structural_inverse(&Op::RenameTable {
+                from: "a".into(),
+                to: "b".into(),
+            })
+            .unwrap(),
+            Op::RenameTable {
+                from: "b".into(),
+                to: "a".into(),
+            }
+        );
+        assert_eq!(
+            structural_inverse(&Op::RenameColumn {
+                table: "t".into(),
+                from: "a".into(),
+                to: "b".into(),
+            })
+            .unwrap(),
+            Op::RenameColumn {
+                table: "t".into(),
+                from: "b".into(),
+                to: "a".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn destructive_ops_have_no_structural_inverse() {
+        assert!(structural_inverse(&Op::DropTable { table: "t".into() }).is_err());
+        assert!(structural_inverse(&Op::DropColumn {
+            table: "t".into(),
+            column: "c".into(),
+        })
+        .is_err());
+        assert!(structural_inverse(&Op::DropIndex { name: "i".into() }).is_err());
+    }
+
+    #[test]
+    fn additive_down_ops_reverses_order() {
+        let up = vec![
+            ClassifiedOp::new(Op::CreateTable {
+                table: "a".into(),
+                columns: vec![col("id", ColumnKind::Text)],
+                without_rowid: false,
+            }),
+            ClassifiedOp::new(Op::AddColumn {
+                table: "a".into(),
+                column: col("email", ColumnKind::Text),
+            }),
+        ];
+        let down = additive_down_ops(&up).unwrap();
+        // Last applied (AddColumn) is undone first.
+        assert_eq!(
+            down[0].op,
+            Op::DropColumn {
+                table: "a".into(),
+                column: "email".into(),
+            }
+        );
+        assert_eq!(down[1].op, Op::DropTable { table: "a".into() });
+    }
+
+    #[test]
+    fn additive_down_ops_rejects_destructive() {
+        let up = vec![ClassifiedOp::new(Op::DropTable { table: "t".into() })];
+        assert!(additive_down_ops(&up).is_err());
+    }
+
+    // -- Pre-image payload serde (pure, both feature sets) -------------------
+
+    #[test]
+    fn captured_value_round_trips_every_class() {
+        let payload = PreimagePayload {
+            tables: vec![TablePreimage::Column {
+                table: "t".into(),
+                dropped: "c".into(),
+                columns: vec![col("id", ColumnKind::Text), col("c", ColumnKind::Blob)],
+                pk: vec!["id".into()],
+                without_rowid: false,
+                captured_columns: vec!["id".into(), "c".into()],
+                rows: vec![
+                    vec![CapturedValue::Text("k1".into()), CapturedValue::Null],
+                    vec![
+                        CapturedValue::Text("k2".into()),
+                        CapturedValue::Blob(vec![0, 1, 2, 255]),
+                    ],
+                    vec![CapturedValue::Int(7), CapturedValue::Real(1.5)],
+                ],
+            }],
+        };
+        let json = serde_json::to_vec(&payload).unwrap();
+        let back: PreimagePayload = serde_json::from_slice(&json).unwrap();
+        assert_eq!(payload, back);
+    }
+
+    #[test]
+    fn inline_boundary_is_pinned() {
+        assert_eq!(INLINE_MAX_BYTES, 64 * 1024);
+    }
+
+    // -- Native round trips -------------------------------------------------
+    #[cfg(feature = "native")]
+    mod native {
+        use super::*;
+        use crate::migrate::apply::apply_ops;
+        use crate::migrate::ledger::{Ledger, MigrationStatus};
+        use rusqlite::Connection;
+
+        fn noop(_: &ClassifiedOp) -> Result<(), MigrateError> {
+            Ok(())
+        }
+
+        fn apply(conn: &Connection, op: Op) {
+            apply_ops(conn, &[ClassifiedOp::new(op)], &mut noop).unwrap();
+        }
+
+        fn seed_users(conn: &Connection) {
+            conn.execute_batch(
+                "CREATE TABLE users (id TEXT PRIMARY KEY, email TEXT, keep TEXT);
+                 INSERT INTO users VALUES ('u1', 'a@x', 'ka');
+                 INSERT INTO users VALUES ('u2', 'b@x', 'kb');",
+            )
+            .unwrap();
+        }
+
+        fn email_of(conn: &Connection, id: &str) -> Option<String> {
+            conn.query_row(
+                "SELECT email FROM users WHERE id = ?1",
+                rusqlite::params![id],
+                |r| r.get::<_, Option<String>>(0),
+            )
+            .unwrap()
+        }
+
+        fn keep_of(conn: &Connection, id: &str) -> Option<String> {
+            conn.query_row(
+                "SELECT keep FROM users WHERE id = ?1",
+                rusqlite::params![id],
+                |r| r.get::<_, Option<String>>(0),
+            )
+            .unwrap()
+        }
+
+        #[test]
+        fn additive_reverse_drops_created_table() {
+            let conn = Connection::open_in_memory().unwrap();
+            apply(
+                &conn,
+                Op::CreateTable {
+                    table: "t".into(),
+                    columns: vec![col("id", ColumnKind::Text)],
+                    without_rowid: false,
+                },
+            );
+            let up = vec![ClassifiedOp::new(Op::CreateTable {
+                table: "t".into(),
+                columns: vec![col("id", ColumnKind::Text)],
+                without_rowid: false,
+            })];
+            let down = additive_down_ops(&up).unwrap();
+            apply_ops(&conn, &down, &mut noop).unwrap();
+            let n: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='t'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(n, 0);
+        }
+
+        #[test]
+        fn drop_column_reverse_restores_data_surgically() {
+            let conn = Connection::open_in_memory().unwrap();
+            seed_users(&conn);
+
+            // Capture the delta-scoped pre-image DURING the destructive apply.
+            let drop = ClassifiedOp::new(Op::DropColumn {
+                table: "users".into(),
+                column: "email".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+
+            // The column really is gone.
+            assert!(table_info(&conn, "users")
+                .unwrap()
+                .iter()
+                .all(|c| c.name != "email"));
+
+            // A concurrent write lands after the drop: a new row, and an edit to
+            // a surviving column of an existing row. Neither is in the pre-image.
+            conn.execute_batch(
+                "INSERT INTO users (id, keep) VALUES ('u3', 'kc');
+                 UPDATE users SET keep = 'kb-edited' WHERE id = 'u2';",
+            )
+            .unwrap();
+
+            restore_payload(&conn, &payload).unwrap();
+
+            // Lost column restored for captured rows...
+            assert_eq!(email_of(&conn, "u1").as_deref(), Some("a@x"));
+            assert_eq!(email_of(&conn, "u2").as_deref(), Some("b@x"));
+            // ...the concurrent edit to a surviving column survives untouched...
+            assert_eq!(keep_of(&conn, "u2").as_deref(), Some("kb-edited"));
+            assert_eq!(keep_of(&conn, "u1").as_deref(), Some("ka"));
+            // ...and the concurrent row keeps its data with a null restored column.
+            assert_eq!(keep_of(&conn, "u3").as_deref(), Some("kc"));
+            assert_eq!(email_of(&conn, "u3"), None);
+        }
+
+        #[test]
+        fn restore_is_idempotent_on_rerun() {
+            let conn = Connection::open_in_memory().unwrap();
+            seed_users(&conn);
+            let drop = ClassifiedOp::new(Op::DropColumn {
+                table: "users".into(),
+                column: "email".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+
+            restore_payload(&conn, &payload).unwrap();
+            // Re-running the restore (rebuild is skipped, UPSERT re-keys) is a no-op.
+            restore_payload(&conn, &payload).unwrap();
+
+            assert_eq!(email_of(&conn, "u1").as_deref(), Some("a@x"));
+            assert_eq!(email_of(&conn, "u2").as_deref(), Some("b@x"));
+            let n: i64 = conn
+                .query_row("SELECT count(*) FROM users", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(n, 2);
+        }
+
+        #[test]
+        fn drop_column_reverse_preserves_primary_key() {
+            // The faithful rebuild must re-add the column AND keep the PK, so the
+            // idempotent UPSERT has a conflict target to key on.
+            let conn = Connection::open_in_memory().unwrap();
+            seed_users(&conn);
+            let drop = ClassifiedOp::new(Op::DropColumn {
+                table: "users".into(),
+                column: "email".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+            restore_payload(&conn, &payload).unwrap();
+
+            let pk_cols: Vec<String> = table_info(&conn, "users")
+                .unwrap()
+                .into_iter()
+                .filter(|c| c.pk > 0)
+                .map(|c| c.name)
+                .collect();
+            assert_eq!(pk_cols, vec!["id".to_string()]);
+        }
+
+        #[test]
+        fn two_drops_on_one_table_restore_lifo() {
+            // Two DropColumns on the same table capture progressively narrower
+            // schemas. restore_payload must unwind them LIFO (last dropped first),
+            // or the earlier capture's rebuild would copy a column already gone.
+            let conn = Connection::open_in_memory().unwrap();
+            seed_users(&conn); // (id PK, email, keep)
+            let drops = vec![
+                ClassifiedOp::new(Op::DropColumn {
+                    table: "users".into(),
+                    column: "email".into(),
+                }),
+                ClassifiedOp::new(Op::DropColumn {
+                    table: "users".into(),
+                    column: "keep".into(),
+                }),
+            ];
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, &drops, &mut |op| cap.capture_before(&conn, op)).unwrap();
+            let payload = cap.into_payload();
+            assert_eq!(payload.tables.len(), 2);
+
+            // Both columns are gone.
+            let cols: Vec<String> = table_info(&conn, "users")
+                .unwrap()
+                .into_iter()
+                .map(|c| c.name)
+                .collect();
+            assert_eq!(cols, vec!["id".to_string()]);
+
+            restore_payload(&conn, &payload).unwrap();
+
+            assert_eq!(email_of(&conn, "u1").as_deref(), Some("a@x"));
+            assert_eq!(email_of(&conn, "u2").as_deref(), Some("b@x"));
+            assert_eq!(keep_of(&conn, "u1").as_deref(), Some("ka"));
+            assert_eq!(keep_of(&conn, "u2").as_deref(), Some("kb"));
+        }
+
+        #[test]
+        fn drop_table_reverse_restores_rows_and_leaves_others_untouched() {
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(
+                "CREATE TABLE gone (id TEXT PRIMARY KEY, v TEXT);
+                 INSERT INTO gone VALUES ('g1', 'one'), ('g2', 'two');
+                 CREATE TABLE other (id TEXT PRIMARY KEY, v TEXT);
+                 INSERT INTO other VALUES ('o1', 'keep');",
+            )
+            .unwrap();
+
+            let drop = ClassifiedOp::new(Op::DropTable {
+                table: "gone".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+            assert!(!table_exists(&conn, "gone"));
+
+            restore_payload(&conn, &payload).unwrap();
+
+            let v1: String = conn
+                .query_row("SELECT v FROM gone WHERE id = 'g1'", [], |r| r.get(0))
+                .unwrap();
+            let v2: String = conn
+                .query_row("SELECT v FROM gone WHERE id = 'g2'", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(v1, "one");
+            assert_eq!(v2, "two");
+            // The untouched table is exactly as it was.
+            let other: String = conn
+                .query_row("SELECT v FROM other WHERE id = 'o1'", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(other, "keep");
+        }
+
+        #[test]
+        fn not_null_column_without_default_is_a_clear_error() {
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(
+                "CREATE TABLE t (id TEXT PRIMARY KEY, needed TEXT NOT NULL);
+                 INSERT INTO t VALUES ('a', 'x');",
+            )
+            .unwrap();
+            let drop = ClassifiedOp::new(Op::DropColumn {
+                table: "t".into(),
+                column: "needed".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+            let err = restore_payload(&conn, &payload).unwrap_err();
+            assert!(matches!(err, MigrateError::Apply(m) if m.contains("NOT NULL")));
+        }
+
+        fn table_exists(conn: &Connection, table: &str) -> bool {
+            let n: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    rusqlite::params![table],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            n > 0
+        }
+
+        // -- Compensating vN+1 ledger step ----------------------------------
+
+        #[test]
+        fn compensating_step_is_append_only() {
+            let conn = Connection::open_in_memory().unwrap();
+            Ledger::ensure_schema(&conn).unwrap();
+            // v1 lands: create a table.
+            apply(
+                &conn,
+                Op::CreateTable {
+                    table: "t".into(),
+                    columns: vec![col("id", ColumnKind::Text)],
+                    without_rowid: false,
+                },
+            );
+            assert_eq!(
+                Ledger::try_elect(&conn, 1, "c1", 300).unwrap(),
+                Election::Won
+            );
+            Ledger::mark_success(&conn, 1).unwrap();
+            let v1_before = Ledger::entry(&conn, 1).unwrap().unwrap();
+
+            // Reverse v1 as an append-only compensating v2 (drop the table).
+            let down = additive_down_ops(&[ClassifiedOp::new(Op::CreateTable {
+                table: "t".into(),
+                columns: vec![col("id", ColumnKind::Text)],
+                without_rowid: false,
+            })])
+            .unwrap();
+            let outcome =
+                apply_compensating(&conn, 2, "c2-compensating", &down, None, 300).unwrap();
+            assert_eq!(outcome, Election::Won);
+
+            // The reversed v1 row is byte-for-byte unchanged...
+            let v1_after = Ledger::entry(&conn, 1).unwrap().unwrap();
+            assert_eq!(v1_before, v1_after);
+            // ...a v2 row exists and succeeded...
+            let v2 = Ledger::entry(&conn, 2).unwrap().unwrap();
+            assert_eq!(v2.status, MigrationStatus::Success);
+            // ...the chain is intact...
+            Ledger::verify_chain(&conn).unwrap();
+            // ...and the table is gone.
+            assert!(!table_exists(&conn, "t"));
+        }
+
+        #[test]
+        fn compensating_step_skips_when_already_applied() {
+            let conn = Connection::open_in_memory().unwrap();
+            Ledger::ensure_schema(&conn).unwrap();
+            Ledger::try_elect(&conn, 2, "c2", 300).unwrap();
+            Ledger::mark_success(&conn, 2).unwrap();
+            let outcome = apply_compensating(&conn, 2, "c2", &[], None, 300).unwrap();
+            assert_eq!(outcome, Election::AlreadyApplied);
+        }
+
+        #[test]
+        fn destructive_compensating_step_restores_via_payload() {
+            let conn = Connection::open_in_memory().unwrap();
+            Ledger::ensure_schema(&conn).unwrap();
+            seed_users(&conn);
+
+            let drop = ClassifiedOp::new(Op::DropColumn {
+                table: "users".into(),
+                column: "email".into(),
+            });
+            let mut cap = PreimageCapturer::new();
+            apply_ops(&conn, std::slice::from_ref(&drop), &mut |op| {
+                cap.capture_before(&conn, op)
+            })
+            .unwrap();
+            let payload = cap.into_payload();
+
+            // The compensating step's structural restore rides the payload (there
+            // is no simple `down` op that faithfully re-adds a constrained column).
+            let outcome = apply_compensating(&conn, 5, "c5", &[], Some(&payload), 300).unwrap();
+            assert_eq!(outcome, Election::Won);
+            assert_eq!(email_of(&conn, "u1").as_deref(), Some("a@x"));
+            let v5 = Ledger::entry(&conn, 5).unwrap().unwrap();
+            assert_eq!(v5.status, MigrationStatus::Success);
+        }
+
+        // -- Inline vs Ref storage boundary ---------------------------------
+
+        fn big_payload(rows: usize) -> PreimagePayload {
+            let data: Vec<Vec<CapturedValue>> = (0..rows)
+                .map(|i| {
+                    vec![
+                        CapturedValue::Text(format!("key-{i:08}")),
+                        CapturedValue::Text("x".repeat(64)),
+                    ]
+                })
+                .collect();
+            PreimagePayload {
+                tables: vec![TablePreimage::Column {
+                    table: "t".into(),
+                    dropped: "c".into(),
+                    columns: vec![col("id", ColumnKind::Text), col("c", ColumnKind::Text)],
+                    pk: vec!["id".into()],
+                    without_rowid: false,
+                    captured_columns: vec!["id".into(), "c".into()],
+                    rows: data,
+                }],
+            }
+        }
+
+        #[tokio::test]
+        async fn small_payload_stores_inline() {
+            let payload = big_payload(1);
+            let stored = store_preimage(&payload, None).await.unwrap();
+            assert!(matches!(stored, Preimage::Inline { .. }));
+            let back = load_preimage(&stored, None).await.unwrap();
+            assert_eq!(back, payload);
+        }
+
+        #[tokio::test]
+        async fn large_payload_without_relay_is_refused() {
+            let payload = big_payload(2000);
+            let bytes = serde_json::to_vec(&payload).unwrap();
+            assert!(
+                bytes.len() > INLINE_MAX_BYTES,
+                "payload must exceed the boundary"
+            );
+            let err = store_preimage(&payload, None).await.unwrap_err();
+            assert!(matches!(err, MigrateError::Apply(m) if m.contains("inline limit")));
+        }
+
+        #[tokio::test]
+        async fn large_payload_round_trips_through_relay() {
+            let dir = tempfile::TempDir::new().unwrap();
+            std::fs::create_dir_all(dir.path()).unwrap();
+            let config = StashConfig {
+                url: format!("file://{}/manifest.json", dir.path().display()),
+                access_key_id: None,
+                secret_access_key: None,
+                region: None,
+                endpoint: None,
+            };
+            let payload = big_payload(2000);
+            let stored = store_preimage(&payload, Some(&config)).await.unwrap();
+            let key = match &stored {
+                Preimage::Ref { key } => key.clone(),
+                other => panic!("expected a Ref, got {other:?}"),
+            };
+            // The reference is the content hash of the payload.
+            assert_eq!(key.len(), 64);
+            let back = load_preimage(&stored, Some(&config)).await.unwrap();
+            assert_eq!(back, payload);
+        }
+
+        #[tokio::test]
+        async fn large_ref_without_config_is_refused() {
+            let stored = Preimage::Ref {
+                key: "deadbeef".into(),
+            };
+            let err = load_preimage(&stored, None).await.unwrap_err();
+            assert!(matches!(err, MigrateError::Apply(_)));
+        }
+
+        // -- Ledger preimage_ref is read-only for reverse -------------------
+
+        #[test]
+        fn preimage_ref_reads_from_the_ledger_row() {
+            let conn = Connection::open_in_memory().unwrap();
+            Ledger::ensure_schema(&conn).unwrap();
+            Ledger::try_elect(&conn, 1, "c1", 300).unwrap();
+            Ledger::mark_success(&conn, 1).unwrap();
+            // No ref yet.
+            let entry = Ledger::entry(&conn, 1).unwrap().unwrap();
+            assert!(preimage_ref_of(&entry).is_none());
+            // The driver (#296) writes the forward-compat column out of band.
+            conn.execute(
+                &format!(
+                    "UPDATE \"{}\" SET preimage_ref = 'abc123' WHERE version = 1",
+                    crate::migrate::ledger::LEDGER_TABLE
+                ),
+                [],
+            )
+            .unwrap();
+            let entry = Ledger::entry(&conn, 1).unwrap().unwrap();
+            assert_eq!(
+                preimage_ref_of(&entry),
+                Some(Preimage::Ref {
+                    key: "abc123".into()
+                })
+            );
+            // Writing the column did not break the chain.
+            Ledger::verify_chain(&conn).unwrap();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fills `migrate/reverse.rs` with reverse/rollback. Additive ops reverse via structural inverse; destructive ops reverse from a delta-scoped pre-image captured during forward apply (through the `apply_ops` `pre_op` hook); a restore is an idempotent PK-keyed UPSERT. Rollback is an APPEND-ONLY compensating vN+1 ledger step -- it never edits the reversed vN row (which is chain-hashed). The DropColumn/DropTable reverse rebuilds from the VERBATIM pre-drop `CREATE TABLE` DDL, so every surviving constraint (UNIQUE/CHECK/COLLATE/FK/generated/WITHOUT ROWID) survives the round-trip.

## Acceptance criteria mapping

### 1. Additive reverse (structural inverse) + destructive reverse (from delta-scoped pre-image)
`structural_inverse` maps each up-op to its inverse (CreateTable<->DropTable, AddColumn<->DropColumn, CreateIndex<->DropIndex, renames swapped). Destructive ops capture a delta-scoped pre-image via a `pre_op` capture closure supplied to `apply_ops` (snapshotting the rows-intersect-columns before the op mutates); restore replays it.
Evidence: `reverse.rs` -- `fn structural_inverse`, `fn capture_drop_column`/`capture_drop_table`, and the public-path round-trip tests (`drop_column_reverse_restores_data_surgically`, constraint-preservation test).

### 2. Faithful reconstruction: surviving constraints survive the round-trip (HIGH fix)
DropColumn/DropTable reverse captures the verbatim pre-drop `CREATE TABLE` DDL from `sqlite_master` and rebuilds via `RebuildTarget::Verbatim` (positional name-splice). Surviving-column UNIQUE/CHECK/COLLATE/FK, table-level constraints, generated columns, and WITHOUT ROWID all survive -- verified against real sqlite3 (a case-insensitive duplicate and a CHECK-violating row are both REJECTED after reverse).
Evidence: `reverse.rs` constraint-preservation test + `apply.rs` `fn splice_create_table_name`; independently re-verified vs sqlite3 across FK/generated/composite-UNIQUE/type-precision variants and adversarial splice cases (name in a literal, self-FK, quoted/bare, WITHOUT ROWID).

### 3. Append-only rollback; idempotent restore; pinned pre-image boundary
Rollback assembles the reverse as a NEW compensating vN+1 step recorded via the ledger's two-phase election (`try_elect`/`mark_success`, `mark_failed` on error); the reversed vN row is byte-unchanged (`verify_chain` intact). Restore is a PK-keyed UPSERT safe to re-run. The pre-image inlines at `<= INLINE_MAX_BYTES` (64 KiB) and hard-errors (no silent failure) when a relay is needed but no `StashConfig` is present.
Evidence: `reverse.rs` -- `fn apply_compensating`, `fn store_preimage`; tests `compensating_step_is_append_only`, `restore_is_idempotent_on_rerun`, the behavioral Inline/Ref boundary test, and `compensating_step_marks_failed_and_is_reelectable`.

### Tests / clippy / fmt
`cargo build` (default + `--no-default-features`), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` on `-p smugglr-core` all clean; 31 reverse + 32 apply tests pass (only pre-existing multicast env failures remain).

## Not done

- **LOW (documented, deferred per severity gates):** if a dropped column's DEFAULT violates a *surviving* CHECK that references it, reverse FAILS LOUD and rolls back (no corruption) during the copy-before-UPSERT window -- a narrow shape, and the strictly-safer flip side of the fixed HIGH. Optional future fix: fold the captured value into a single `INSERT...SELECT`.
- Composition (wiring the capture closure into forward apply + calling reverse on rollback) is the driver's job (#296); this issue provides the reverse primitives + capture closure.
- `DropIndex` reverse errors (the index definition is not carried) -- documented; a full index-def carry is out of 0.5.0 scope.

Closes #274
