### PR TITLE
docs(#307): correct the D1 atomic citation in decision 6 (SPEC.md S4.2 misread)

### DIFF
--- a/crates/smugglr-core/src/migrate/apply.rs
+++ b/crates/smugglr-core/src/migrate/apply.rs
@@ -219,9 +219,10 @@ impl RemoteTarget {
 
 /// Statements for a Cloudflare **D1** apply.
 ///
-/// D1 has no explicit transactions; it applies a batch, and cross-table DDL
-/// wants `defer_foreign_keys` so an out-of-order reference does not trip mid
-/// batch. The first statement enables it; the rest are the ops in order.
+/// D1 has no interactive `BEGIN..COMMIT`; a batch *is* its transaction unit, so
+/// this lowers to one batch. Cross-table DDL wants `defer_foreign_keys` so an
+/// out-of-order reference does not trip mid batch. The first statement enables
+/// it; the rest are the ops in order.
 pub fn d1_statements(ops: &[ClassifiedOp]) -> Vec<String> {
     let mut out = Vec::with_capacity(ops.len() + 1);
     out.push("PRAGMA defer_foreign_keys = ON".to_string());

--- a/docs/plans/migration.md
+++ b/docs/plans/migration.md
@@ -280,7 +280,7 @@ explicit override. Better a loud false positive than a silent prod-nuke.
 
 ### 6. Safety without transactions
 
-Design as if **no transaction exists** -- because migrate cannot *detect* whether a
+Design as if **no transaction exists** -- because migrate cannot *confirm* whether a
 remote target gave it one. The primary safety mechanism is therefore **expand-contract +
 idempotent forward-only + `IF NOT EXISTS` + ledger skip-if-applied**: every step is
 additive and re-runnable, so a half-applied migration is safe to re-run.
@@ -296,18 +296,21 @@ transaction"). Both reference servers honor it: the D1 worker via `db.batch()`
 
 Citations into http-sql name **sections and constructs, never line numbers** -- that repo
 is edited independently, so a line number here rots silently and a stale citation is the
-exact defect this correction exists to fix.
+exact defect this correction exists to fix. A claim that rests on what the spec does *not*
+have has no section to anchor to at all; pin those to a **spec version**, which no edit of
+theirs can move. And where two true premises are available, take the one that survives
+their *pending* changes over the one that reads stronger.
 
-The conclusion stands and the corrected reason is stronger. The spec gives a server no
-conforming way to **decline** atomicity: S10.1 item 5 qualifies the
-obligation with "when not rejected," but no rejection mechanism exists -- there is no
-`not_supported` code in the S7 table, and S4.2's only rejection clause is statement-count
-overflow to `413`. A server that cannot do transactions must either lie or misuse an error
-code, and **the client cannot tell which**. There is no negotiation and no signal, so
-migrate can never confirm a given target honored `atomic`. Correctness must not rest on a
-primitive whose presence is unobservable -- which holds even if every server honors it
-perfectly. Local SQLite's transactional DDL stays a free bonus we use where present, never
-the foundation.
+The conclusion stands and the corrected reason is stronger. In **http-sql v0.1** a
+successful batch response carries no atomicity signal: S6.2's batch envelope has a single
+field (`results`) and S9 defines no atomicity response header, so a `200` is
+shape-identical whether or not a transaction ran. Migrate can therefore never *confirm*
+that a target honored `atomic`. That holds even if every server honors it perfectly, and
+it is indifferent to how a server **declines**: S7's `vendor:` namespace already lets one
+reject a batch it cannot transact, and a decline still only says a server refuses, never
+that one delivered. Correctness must not rest on a primitive whose presence is
+unobservable. Local SQLite's transactional DDL stays a free bonus we use where present,
+never the foundation.
 
 Note the related premise: D1 has no *interactive* `BEGIN..COMMIT`, but its batch API is a
 transaction unit (see the quirk table above). "D1 has no transactions" overstated it; the

--- a/docs/plans/migration.md
+++ b/docs/plans/migration.md
@@ -96,7 +96,7 @@ only per-target variance is **how a migration lands**, not **what SQL it is**:
 | Target        | Apply quirk                                                      |
 |---------------|-----------------------------------------------------------------|
 | local SQLite  | `BEGIN..COMMIT`, transactional DDL, `PRAGMA foreign_keys=OFF`    |
-| Cloudflare D1 | no explicit transactions -- batch API, `defer_foreign_keys=ON`  |
+| Cloudflare D1 | no interactive `BEGIN..COMMIT` -- the batch API is the txn unit, `defer_foreign_keys=ON` |
 | Turso/libSQL  | extended `ALTER TABLE` -> fewer 12-step rebuilds; embedded replicas |
 | rqlite        | Raft leader apply; bulk-transaction request                     |
 
@@ -280,14 +280,34 @@ explicit override. Better a loud false positive than a silent prod-nuke.
 
 ### 6. Safety without transactions
 
-Design as if **no transaction exists**. D1 (a major target) has none, and the http-sql
-spec's `atomic: true` is optional and server-rejectable (SPEC.md S4.2). So the primary
-safety mechanism is **expand-contract + idempotent forward-only + `IF NOT EXISTS` +
-ledger skip-if-applied**: every step is additive and re-runnable, so a half-applied
-migration is safe to re-run.
+Design as if **no transaction exists** -- because migrate cannot *detect* whether a
+remote target gave it one. The primary safety mechanism is therefore **expand-contract +
+idempotent forward-only + `IF NOT EXISTS` + ledger skip-if-applied**: every step is
+additive and re-runnable, so a half-applied migration is safe to re-run.
 
-**Why:** we cannot make correctness depend on a primitive half our targets lack. Local
-SQLite's transactional DDL is a free bonus we use where present -- never the foundation.
+**Why (corrected 2026-07-28; the first draft's reason was wrong).** This doc previously
+said the http-sql spec's `atomic: true` is "optional and server-rejectable." That misread
+S4.2. `OPTIONAL` at SPEC.md:64 governs whether the *field appears in the request*, not the
+server's obligation once it is there -- the same sentence puts a **MUST** on the server
+("when `true`, the server MUST execute all statements in a single transaction"). Both
+reference servers honor it: the D1 worker via `db.batch()`
+(`examples/cloudflare-worker-to-d1/src/index.ts:86-93`), the Durable Object via
+`ctx.storage.transactionSync` (`examples/cloudflare-durable-object/src/index.ts:123-125`).
+
+The conclusion stands and the corrected reason is stronger. The spec gives a server no
+conforming way to **decline** atomicity: S10.1 item 5 (SPEC.md:206) qualifies the
+obligation with "when not rejected," but no rejection mechanism exists -- there is no
+`not_supported` code in the S7 table, and S4.2's only rejection clause is statement-count
+overflow to `413`. A server that cannot do transactions must either lie or misuse an error
+code, and **the client cannot tell which**. There is no negotiation and no signal, so
+migrate can never confirm a given target honored `atomic`. Correctness must not rest on a
+primitive whose presence is unobservable -- which holds even if every server honors it
+perfectly. Local SQLite's transactional DDL stays a free bonus we use where present, never
+the foundation.
+
+Note the related premise: D1 has no *interactive* `BEGIN..COMMIT`, but its batch API is a
+transaction unit (see the quirk table above). "D1 has no transactions" overstated it; the
+baseline does not depend on that claim.
 
 **Trade-off:** expand-contract means some changes take two migrations (expand, then a
 later contract) instead of one in-place edit. That is the accepted cost of surviving a
@@ -297,7 +317,7 @@ never a transactional undo.
 
 **Concurrent-writer race + crash window (RESOLVED, rd2).** skip-if-applied covers *re-run*
 (the same node applying vN twice, a no-op) but not two *different* writers racing the insert
-against a transactionless D1, nor a crash mid-apply. Transaction-free resolution: a
+across D1's non-interactive apply, nor a crash mid-apply. Transaction-free resolution: a
 `UNIQUE(version)` ledger row elects a single apply-winner; the winner runs the idempotent DDL,
 then marks `success = TRUE`. **The skip-gate keys on `success = TRUE`, never on
 row-existence** -- otherwise a crash between insert-pending and mark-success leaves a

--- a/docs/plans/migration.md
+++ b/docs/plans/migration.md
@@ -287,15 +287,19 @@ additive and re-runnable, so a half-applied migration is safe to re-run.
 
 **Why (corrected 2026-07-28; the first draft's reason was wrong).** This doc previously
 said the http-sql spec's `atomic: true` is "optional and server-rejectable." That misread
-S4.2. `OPTIONAL` at SPEC.md:64 governs whether the *field appears in the request*, not the
-server's obligation once it is there -- the same sentence puts a **MUST** on the server
-("when `true`, the server MUST execute all statements in a single transaction"). Both
-reference servers honor it: the D1 worker via `db.batch()`
-(`examples/cloudflare-worker-to-d1/src/index.ts:86-93`), the Durable Object via
-`ctx.storage.transactionSync` (`examples/cloudflare-durable-object/src/index.ts:123-125`).
+S4.2. The `OPTIONAL` on S4.2's `atomic` field governs whether the *field appears in the
+request*, not the server's obligation once it is there -- the same sentence puts a **MUST**
+on the server ("when `true`, the server MUST execute all statements in a single
+transaction"). Both reference servers honor it: the D1 worker via `db.batch()`
+(`examples/cloudflare-worker-to-d1/src/index.ts`), the Durable Object via
+`ctx.storage.transactionSync` (`examples/cloudflare-durable-object/src/index.ts`).
+
+Citations into http-sql name **sections and constructs, never line numbers** -- that repo
+is edited independently, so a line number here rots silently and a stale citation is the
+exact defect this correction exists to fix.
 
 The conclusion stands and the corrected reason is stronger. The spec gives a server no
-conforming way to **decline** atomicity: S10.1 item 5 (SPEC.md:206) qualifies the
+conforming way to **decline** atomicity: S10.1 item 5 qualifies the
 obligation with "when not rejected," but no rejection mechanism exists -- there is no
 `not_supported` code in the S7 table, and S4.2's only rejection clause is statement-count
 overflow to `413`. A server that cannot do transactions must either lie or misuse an error


### PR DESCRIPTION
Closes #307.

Decision 6 of the migrate design rested on a misreading of the http-sql spec. It
said `atomic: true` is "optional and server-rejectable (SPEC.md S4.2)." That is
wrong, and it was wrong in a way that mattered: the conclusion it supported
(design as if no transaction exists) is correct, so the bad premise was never
stress-tested by an outcome that looked wrong. This corrects the premise, keeps
the conclusion, and gives it a reason that actually holds -- plus the four other
places in the tree that carried the same overstatement about D1.

Line numbers below are same-repo and pinned to head `8d7845c`. Every citation
into **rafters-studio/http-sql** names a section, never a line, for the reason
stated in the patch itself.

## Acceptance criteria mapping

### Claim A carrier 1 -- `docs/plans/migration.md:99` (quirk table D1 row)

Was "no explicit transactions -- batch API". Now "no interactive `BEGIN..COMMIT`
-- the batch API is the txn unit". This row is the canonical statement of D1's
apply mechanism in the doc, which is why the corrected decision-6 note points
here instead of restating it.

### Claim A carrier 2 -- `docs/plans/migration.md:283` (decision 6 opening)

Was "D1 (a major target) has none." That sentence is gone. The opening now reads
"Design as if **no transaction exists** -- because migrate cannot *confirm*
whether a remote target gave it one," which is the true reason and does not
depend on any claim about D1's capability.

It reads *confirm*, not *detect*, and that word is load-bearing -- see the
review-driven correction at the end of this body. A target can conformingly tell
migrate that it did **not** transact; what no target can tell migrate is that it
**did**.

### Claim A carrier 3 -- `docs/plans/migration.md:327` (concurrent-writer race)

Was "two different writers racing the insert against a transactionless D1." Now
"across D1's non-interactive apply." The race and its `UNIQUE(version)`
resolution are unchanged -- only the false characterisation of the target. This
carrier was missed by the first pass and found by the corrected
case-insensitive sweep.

### Claim A carrier 4 -- `crates/smugglr-core/src/migrate/apply.rs:222` (`d1_statements` doc-comment)

Was "D1 has no explicit transactions; it applies a batch." Now "D1 has no
interactive `BEGIN..COMMIT`; a batch *is* its transaction unit, so this lowers to
one batch." The `defer_foreign_keys` sentence is retained verbatim because it was
already correct. This is the only code-side carrier, and its presence is why the
issue's original "no code change expected" criterion was replaced.

### Claim B carrier -- `docs/plans/migration.md:288-295` ("optional and server-rejectable")

Replaced with the actual mechanism, cited. `OPTIONAL` in S4.2 governs whether the
field appears in the *request*; the same sentence puts a **MUST** on the server
once it is there. Both reference servers honor it -- the D1 worker via
`db.batch()`, the Durable Object via `ctx.storage.transactionSync`.

The stronger replacement reason, at `:304-313`: in **http-sql v0.1** a successful
batch response carries no atomicity signal. S6.2's batch envelope has a single
field (`results`) and S9 defines no atomicity response header, so a `200` is
shape-identical whether or not a transaction ran. Migrate can therefore never
*confirm* that a target honored `atomic`, which is why correctness must not rest
on it -- and that holds even if every server implements it perfectly, and however
a server declines. Strictly stronger than the claim it replaces, which only argued
some servers might say no.

Scoped to the **success** path on purpose. The failure-path version of the same
argument is true today and reads stronger, and it is deliberately absent -- see the
review-correction section below for why it would rot on http-sql #9.

The reason is pinned to `v0.1` because it rests on an absence, and an absence has
no section to anchor to. `:297-302` states both rules inline for the next editor:
no line numbers, pin absences to a version, and prefer the premise that survives
the other repo's pending changes.

### Claim C -- too-loose positive ("D1 supports transactions"): 0 carriers, re-verified

Zero in this tree. A negative is only as good as the sweep behind it, so this is
the sweep and its full result set.

Evidence: `legion sym etc find-content '(?i)(transaction|atomic|acid|begin\.\.|commit)' --repo smugglr`
over `--ext rs` and `--ext md`, run against the rebased tree. Observable
behavior: every D1-subject hit is a *negative* claim, never a positive one --
`crates/smugglr-core/src/migrate/apply.rs:222` and
`docs/plans/migration.md:99`, `:283`, `:327` (the four carriers this PR fixes).
The remaining hits have non-D1 subjects: local SQLite at
`crates/smugglr-core/src/migrate/apply.rs:34-44`, rqlite at
`crates/smugglr-core/src/migrate/apply.rs:244-245`, the ledger at
`crates/smugglr-core/src/migrate/ledger.rs:9`, `:148`, `:388`. No line anywhere
in the tree asserts D1 *supports* transactions. Independently corroborated by
platform's own sweep at `9ba3712`, which classified `ledger.rs:388` and
`migration.md:330` as non-carriers and found nothing this inventory missed.

The mirror error lives in platform's reflection corpus, not here, and they closed
it in `019faacf-5a2a`.

### Re-verified against a moved `main` (not the original snapshot)

The sweep behind this issue predates `3ba8bfd` (#274, merged as #306), which added
308 lines to the very file this patch edits. A carrier inventory is a snapshot, so
I re-ran the full case-insensitive sweep against the rebased tree rather than
trusting it. No new carriers: `reverse.rs:3` ("never a transactional undo") and
`reverse.rs:367` ("op's own transaction") are claims about migrate's own design
and about local SQLite, not about D1. Inventory holds at 4 + 1.

### Cross-repo citations name sections, not lines -- and the number they replace has not rotted yet

The Why block cites several constructs in **rafters-studio/http-sql**, a repo edited
independently of this one. Dropping the line numbers is still the right repair,
but the demonstration this body originally gave for it was **false**, and the
correction is worth more than the claim was.

What I originally wrote: that `SPEC.md:206` for S10.1 item 5 "is now `SPEC.md:219`
-- platform landed the non-atomic batch clauses above it (PR #9) the same day."
**Both halves are wrong.** http-sql #9 is **open, not merged**. On http-sql
`origin/main` (`82b715c`) S10.1 item 5 is still at `:206`, exactly where the
original citation put it. My read returned `:219` because
`legion sym etc find-content --repo http-sql` resolves against whatever branch
that repo's single checkout is standing on, prints no ref, and platform had it
parked on `spec/1-non-atomic-batch` -- their own unmerged PR branch. I had no path
to discover the ref from my seat, and the output gave no hint. Both reviewers
caught it independently; platform reproduced it by moving the checkout back to
`main` and watching the same command answer `:206`.

So: the citation **goes stale when http-sql #9 merges**, not before. The repair
holds on its own reasoning -- a cross-repo line number is duplicated state this
repo does not own -- and it turns out to be merge-robust for a reason I was not
aiming at: #9 appends items 6 and 7 *below* item 5, so item 5 stays item 5.

The reviewers filed both follow-ups, not me: platform's legion #826 (ref
disclosure -- commands that read or write against a ref should print which ref)
and astro-data's legion #824 (`quality-gate check` has no head-binding guard while
`pr edit` does). I contributed one new instance to #824 while re-gating this PR;
see the review-correction section.

Evidence, every construct re-verified by reading `SPEC.md` at http-sql
`origin/main` (`82b715c`) directly -- an explicit ref, not `HEAD`, and not a
working tree:

- S4.2 `:64` carries the `OPTIONAL` + `MUST` sentence.
- S10.1 item 5 `:206` carries "when not rejected".
- S7's registered-code table `:161-170` has no `not_supported`; `:172` sanctions
  `vendor:` codes; S10.1's server-MAY list `:213` permits rejection on "any other
  policy". The last two are what falsify the deleted reason.
- S6.2's batch envelope `:130-137` has only `results`; S9 `:178-194` defines only
  version headers. These two absences are what the surviving reason rests on, and
  why it is pinned to `v0.1`.
- S7 `:157` makes `error.statementIndex` OPTIONAL with no persistence rule -- the
  line that makes a failure-path argument branch-dependent on #9.
- `db.batch()` at `examples/cloudflare-worker-to-d1/src/index.ts:92`;
  `ctx.storage.transactionSync` at
  `examples/cloudflare-durable-object/src/index.ts:124`.

Every claim the prose makes about http-sql is true at http-sql `origin/main`;
none of it depends on a line number, and the part that depends on an absence is
pinned to `v0.1`.

### Review correction at `8d7845c`: the rejection-path reason was false, and the repair was a deletion

astro-data's review found the load-bearing sentence of the *corrected* reason
wrong at http-sql main: "the spec gives a server no conforming way to **decline**
atomicity." Two halves make it false and both are on main: S7 `:172` sanctions
vendor-namespaced error codes (the code), and S10.1's server-MAY list `:213`
permits rejection on "any other policy" (the permission). So a server that cannot
transact may reject with `vendor:atomic_not_supported` -- a documented extension
point, neither lying nor misusing a registered code. The disjunction "must either
lie or misuse an error code" had no surviving reading. Verified by reading S7 and
S10.1 at `82b715c`, not taken on the reviewer's word.

The conclusion was untouched and the repair was a **deletion**: the invariant
lives on the success path, where the spec has no atomicity signal at all. That
argument is indifferent to the decline path entirely -- it holds whether or not a
server can refuse, which is what the rejection-path analysis could not claim. It
also removes the three sentences platform's http-sql #12 would have rotted -- one
edit satisfying both reviews.

**Deliberately did not take the failure-path version, though it is true today and
reads stronger.** My first draft of this repair argued the failure path too: an
atomic batch's partway failure and a non-atomic server's partway failure land in
the same S7 envelope, so rolled-back is indistinguishable from partially-applied.
True at `82b715c` -- `error.statementIndex` is OPTIONAL at S7 `:157` with no rule
about what persists. But astro-data's #9 makes it REQUIRED for non-atomic with a
MUST on persistence, so the claim is true in one state of their repo and
differently true in the next. That is the same rot as a line number, one level up,
and it is the reason they withheld the sentence from their own review rather than
hand it to me. Deleted, and the selection rule is now inline at `:302`: where two
true premises are available, take the one that survives their pending changes over
the one that reads stronger. The success-path invariant is merge-invariant across
#9; the failure-path one is not.

Three carriers came out of the same review that my own sweep missed:

- `:283`'s "cannot *detect*" was a stronger claim than the spec supports, one
  line above the paragraph being repaired. Now "cannot *confirm*".
- The sweep regex that cleared the block did not match `cannot *detect*` at all,
  because inline markdown emphasis splits the words. A pattern keyed to the
  deleted sentence's vocabulary rather than to the claim -- the same
  snapshot-sweep failure that produced carrier 3, in a new costume.
- My own first replacement said the argument "survives any *future* mechanism for
  declining," which implies none exists today -- the falsified claim in a weaker
  costume. Caught by re-running the carrier sweep against my replacement text
  rather than only against the text I deleted.

**One new instance for astro-data's legion #824, hit while re-gating.** `legion
quality-gate check` defaulted `--base` to *local* `main` at `6d12d46`, which
predates #306. That silently widened the coverage set with
`crates/smugglr-core/src/migrate/reverse.rs` -- a file this PR never touches, pulled
in from the unmerged `feat/migrate-274-reverse` line -- and refused the gate until it
was articulated. `--base origin/main` (`3ba8bfd`) gives the real two-file set. Same
family as #826: the command resolved a ref I did not name and never printed what it
chose. Worth recording because a stale local `main` is the default state of any
checkout that has not fetched, and note the polarity -- platform's `find-content`
case read a *stranger's* branch, this one read *my own* stale ref.

Evidence: `git -C ../http-sql show origin/main:SPEC.md` read directly at
`82b715c` -- S7's `:172` ("Vendor codes carry the prefix `vendor:`") and S10.1's
server-MAY list `:213` ("or any other policy") are the two lines that falsify "no
conforming way to decline"; S6.2 `:130-137` and S9 `:178-194` are the absences the
replacement rests on; S7 `:157` is the OPTIONAL `statementIndex` with no
persistence rule, which is what makes the failure-path argument branch-dependent
on #9. Carrier sweep:
`git grep -n -i -E 'not_supported|decline|misuse|when not rejected|no rejection'`
returned 4 carriers at `9ba3712` (`:302-305`) and now returns 2 hits at `:309-310`,
both of which *name* the `vendor:` decline path rather than deny it. Also
`git grep -n -i -E 'cannot detect|detect whether'` returned 0 at `9ba3712` while
the carrier was present at `:283` -- the observable behavior demonstrating the
emphasis-splitting miss. Observable behavior: `docs/plans/migration.md:283` now
reads `cannot *confirm*`, and `:304-313` names only sections plus a version pin,
with no line number into http-sql anywhere in the diff.

## What I deliberately did NOT do

- **Did not touch the accurate transaction prose.** `migration.md:239`,
  `:320-321`, `:333`, `:398`, `:400`, `:504`, `:674`, and `ledger.rs:9`, `:12`,
  `:148`, `:191`, `:388` all
  mention transactions correctly -- they describe migrate's own design, the
  ledger's transaction-free SQL, or rqlite. `apply.rs:244-245` ("rqlite ...
  commits them atomically") is accurate about rqlite. Two of these (`:239`,
  `:398`, `:400`) were not in the issue's KEPT list; I examined them in this pass
  and left them alone. Widening a correction patch into correct prose is the
  overreach this issue exists to fix. (`:320-321` "surviving a transactionless
  target" and
  `:333` "survives D1" are the two platform went looking for as unclassified sweep
  hits; #307's KEPT list already covers both with reasons.)
- **Did not change any behavior.** No statement, signature, type, or control-flow
  path is touched. `d1_statements` emits the same `Vec<String>` it always did;
  `cargo check -p smugglr-core --features native` passes.
- **Did not weaken the conclusion.** Decision 6 still says design as if no
  transaction exists. Only the reason changed, twice, and both times to a
  stronger one.
- **Did not re-record the `legion-review` gate.** My commit at `8d7845c`
  orphans the review rows platform and astro-data recorded at `9ba3712`, because
  gates key on the sha. Re-issuing a review gate on my own head is the
  self-review I declined in the first place; astro-data offered to re-read only
  the changed block, and that seat stays theirs.
- **Did not fix platform's corpus, or http-sql.** The mirrored positive-shaped
  error is theirs and closed on their side. http-sql #12 (S10.1 item 5 gates a
  MUST on a rejection the spec never defines) is platform's to resolve; this
  patch is pinned to `v0.1` so it stays true whichever way that lands.
