### PR TITLE
fix(#310): ordering-aware multicast apply -- honor the conflict policy the crate already declares

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Machine A           multicast group 239.255.43.21 (encrypted)          Machine B
 
 1. `smugglr broadcast` joins the multicast group and, each interval, multicasts a `primary_key -> content_hash` digest of every synced table -- the heartbeat.
 2. A node that hears a digest covering rows it lacks (or hashes differently) multicasts a request for exactly those rows.
-3. Whoever holds them multicasts the rows; every listener applies idempotently, so one answer converges the whole group. Last-received-wins on divergence -- UUIDv7 keys make concurrent divergence rare, no CRDTs.
+3. Whoever holds them multicasts the rows; every listener applies idempotently, so one answer converges the whole group. Which side wins a same-key collision is `[broadcast].conflict_resolution` -- `remote_wins` (the default, last-received-wins) or `newer_wins`, which orders by timestamp. No CRDTs; UUIDv7 keys make concurrent divergence rare.
 4. Late joiners and partition rejoins converge through the same heartbeat -- no special case.
 5. All traffic is XChaCha20-Poly1305 encrypted with the pre-shared key. Lost packets are safe: applying a row twice is a no-op and the next heartbeat re-reconciles.
 
@@ -284,6 +284,21 @@ interval_secs = 30
 # ALL broadcast traffic is encrypted when this is set.
 secret = "your-256-bit-hex-key"
 
+# How a received row resolves against a local row with the same primary key.
+#   remote_wins (default) - the received row wins; last-received-wins
+#   newer_wins            - the row with the greater ordering value wins
+#   local_wins            - new rows arrive, existing rows are never overwritten
+# Scoped to [broadcast] on purpose: [sync].conflict_resolution defaults to
+# local_wins, and inheriting it here would silently stop every existing LAN
+# deployment from accepting peer rows.
+conflict_resolution = "newer_wins"
+
+# The ordering signal for newer_wins: max() across whichever of these columns
+# the table has. A LIST, because an ordering key is often a max over several --
+# a tombstone that stamps deleted_at without touching updated_at must still win.
+# Defaults to [ sync.timestamp_column ].
+ordering_columns = ["created_at", "updated_at", "deleted_at"]
+
 [sync]
 # Skip large columns (embeddings, vectors) from broadcast
 exclude_columns = ["*_embedding", "vector"]
@@ -291,6 +306,10 @@ exclude_columns = ["*_embedding", "vector"]
 # UUIDv7 required for master-master sync
 conflict_resolution = "uuid_v7_wins"
 ```
+
+Both peers must opt into `newer_wins`; the policy is apply-side and is not
+negotiated on the wire, so a mesh with mixed settings converges toward the
+permissive node.
 
 ### Security model
 

--- a/crates/smugglr-core/src/broadcast.rs
+++ b/crates/smugglr-core/src/broadcast.rs
@@ -18,6 +18,7 @@
 //! When a pre-shared key is configured, multicast traffic is encrypted with
 //! XChaCha20-Poly1305 AEAD. Plaintext and encrypted modes are mutually exclusive.
 
+use crate::config::ConflictResolution;
 use crate::error::{Result, SyncError};
 use chacha20poly1305::aead::{Aead, NewAead};
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
@@ -77,6 +78,37 @@ pub struct BroadcastConfig {
     /// (decoded via [`BroadcastConfig::encryption_key`] and consumed by
     /// [`crate::multicast`]).
     pub secret: Option<String>,
+
+    /// How a received row resolves against an existing local row with the same
+    /// primary key. Default: `remote_wins`.
+    ///
+    /// Deliberately scoped to `[broadcast]` and NOT read from
+    /// `[sync].conflict_resolution`. That field defaults to
+    /// [`ConflictResolution::LocalWins`], while multicast has always behaved as
+    /// `remote_wins`; honoring the sync-scoped value would silently flip every
+    /// existing multicast deployment to never-accept-a-peer-row -- a
+    /// convergence break shipped as a bugfix. `remote_wins` here preserves the
+    /// historical semantics exactly; `newer_wins` is an explicit opt-in.
+    ///
+    /// `uuid_v7_wins` degenerates to `newer_wins` on this path: a same-PK
+    /// collision means the two rows carry the *same* UUID, so the PK cannot
+    /// break the tie.
+    #[serde(default = "default_broadcast_conflict_resolution")]
+    pub conflict_resolution: ConflictResolution,
+
+    /// Columns forming the ordering signal for `newer_wins`, compared as the
+    /// `max` across whichever of them the table actually has.
+    ///
+    /// A LIST, not a single column, because an ordering key is frequently a
+    /// max over several: legion's is `max(created_at, updated_at, deleted_at)`,
+    /// and a tombstone that sets `deleted_at` without bumping `updated_at`
+    /// would lose every comparison under a single-column compare. One entry is
+    /// exactly the single-column behavior.
+    ///
+    /// Empty (the default) falls back to `[sync].timestamp_column`, so the
+    /// ordering signal has one source of truth until an embedder needs more.
+    #[serde(default)]
+    pub ordering_columns: Vec<String>,
 }
 
 fn default_port() -> u16 {
@@ -87,6 +119,10 @@ fn default_interval_secs() -> u64 {
     DEFAULT_INTERVAL_SECS
 }
 
+fn default_broadcast_conflict_resolution() -> ConflictResolution {
+    ConflictResolution::RemoteWins
+}
+
 impl Default for BroadcastConfig {
     fn default() -> Self {
         Self {
@@ -94,6 +130,8 @@ impl Default for BroadcastConfig {
             interval_secs: DEFAULT_INTERVAL_SECS,
             instance_id: None,
             secret: None,
+            conflict_resolution: default_broadcast_conflict_resolution(),
+            ordering_columns: Vec::new(),
         }
     }
 }
@@ -824,6 +862,46 @@ pub fn broadcast_pid_lock_path(config_path: &std::path::Path) -> std::path::Path
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two default paths must agree. `BroadcastConfig` carries a
+    /// hand-written `impl Default` AND per-field `#[serde(default = ...)]`; a
+    /// config file that omits a key takes the serde path, while an embedder
+    /// constructing the struct takes the other. A disagreement would mean the
+    /// same deployment resolves conflicts differently depending on whether the
+    /// key was written down.
+    #[test]
+    fn omitted_conflict_keys_deserialize_to_the_struct_defaults() {
+        let from_toml: BroadcastConfig = toml::from_str("").expect("empty [broadcast] table");
+        let from_struct = BroadcastConfig::default();
+
+        assert_eq!(
+            from_toml.conflict_resolution, from_struct.conflict_resolution,
+            "serde default and impl Default disagree on conflict_resolution"
+        );
+        assert_eq!(from_toml.ordering_columns, from_struct.ordering_columns);
+        assert_eq!(
+            from_toml.conflict_resolution,
+            ConflictResolution::RemoteWins,
+            "an existing deployment must keep last-received-wins"
+        );
+    }
+
+    /// The opt-in path: legion's shape, spelled the way an operator writes it.
+    #[test]
+    fn newer_wins_and_an_ordering_list_parse_from_toml() {
+        let bc: BroadcastConfig = toml::from_str(
+            r#"
+            conflict_resolution = "newer_wins"
+            ordering_columns = ["created_at", "updated_at", "deleted_at"]
+            "#,
+        )
+        .expect("parse");
+        assert_eq!(bc.conflict_resolution, ConflictResolution::NewerWins);
+        assert_eq!(
+            bc.ordering_columns,
+            vec!["created_at", "updated_at", "deleted_at"]
+        );
+    }
 
     #[test]
     fn test_announcement_roundtrip() {

--- a/crates/smugglr-core/src/diff.rs
+++ b/crates/smugglr-core/src/diff.rs
@@ -24,7 +24,13 @@ use tracing::{debug, info, warn};
 /// side, ISO on the other) has no meaningful ordering -- return `None` so the
 /// caller routes it to `content_differs` rather than inventing a confident
 /// winner from a lexical compare of unlike representations.
-fn compare_ts(a: &str, b: &str) -> Option<Ordering> {
+/// `pub(crate)` so the multicast apply path can be cross-checked against it
+/// (`local.rs::sql_guard_agrees_with_compare_ts_on_same_class_pairs`). The LAN
+/// path cannot *call* this -- its comparison rides inside a SQL statement so it
+/// is atomic against a concurrent local write -- but the two must agree on every
+/// pair the documented precondition admits, and a test is the only thing that
+/// keeps them from drifting.
+pub(crate) fn compare_ts(a: &str, b: &str) -> Option<Ordering> {
     match (a.parse::<i64>(), b.parse::<i64>()) {
         (Ok(x), Ok(y)) => Some(x.cmp(&y)),
         _ => match (a.parse::<f64>(), b.parse::<f64>()) {

--- a/crates/smugglr-core/src/local.rs
+++ b/crates/smugglr-core/src/local.rs
@@ -1085,6 +1085,149 @@ mod tests {
         );
     }
 
+    /// #310 asks that both transports order identically. The remote path orders
+    /// with `diff::compare_ts` in Rust; the LAN path cannot, because its
+    /// comparison has to ride inside the write to stay atomic against a
+    /// concurrent local writer. So the guarantee is pinned here instead: for
+    /// every pair the documented precondition admits -- both sides the same
+    /// storage class -- the SQL guard and `compare_ts` must reach the same
+    /// verdict, or a row would sync one way over D1 and the other way over the
+    /// LAN.
+    #[test]
+    fn sql_guard_agrees_with_compare_ts_on_same_class_pairs() {
+        use std::cmp::Ordering;
+
+        // Same-class pairs only. Numeric pairs are where lexical comparison
+        // would be wrong ("1000" sorts before "999"), text pairs are where
+        // numeric parsing would be.
+        let cases: [(JsonValue, JsonValue, &str, &str); 6] = [
+            (
+                JsonValue::from(999i64),
+                JsonValue::from(1000i64),
+                "999",
+                "1000",
+            ),
+            (
+                JsonValue::from(1000i64),
+                JsonValue::from(999i64),
+                "1000",
+                "999",
+            ),
+            (
+                JsonValue::from(2.5f64),
+                JsonValue::from(10.5f64),
+                "2.5",
+                "10.5",
+            ),
+            (
+                JsonValue::from("2026-01-01T00:00:00+00:00"),
+                JsonValue::from("2026-02-01T00:00:00+00:00"),
+                "2026-01-01T00:00:00+00:00",
+                "2026-02-01T00:00:00+00:00",
+            ),
+            (
+                JsonValue::from("2026-02-01T00:00:00+00:00"),
+                JsonValue::from("2026-01-01T00:00:00+00:00"),
+                "2026-02-01T00:00:00+00:00",
+                "2026-01-01T00:00:00+00:00",
+            ),
+            (
+                JsonValue::from("2026-01-01T00:00:00+00:00"),
+                JsonValue::from("2026-01-01T00:00:00+00:00"),
+                "2026-01-01T00:00:00+00:00",
+                "2026-01-01T00:00:00+00:00",
+            ),
+        ];
+
+        let ordering = vec!["updated_at".to_string()];
+        for (stored, incoming, stored_s, incoming_s) in cases {
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch("CREATE TABLE t (id TEXT PRIMARY KEY, updated_at);")
+                .unwrap();
+            let mk = |ts: &JsonValue| {
+                HashMap::from([
+                    ("id".to_string(), JsonValue::from("a")),
+                    ("updated_at".to_string(), ts.clone()),
+                ])
+            };
+            upsert_rows_guarded_inner(&conn, "t", &[mk(&stored)], UpsertGuard::Replace).unwrap();
+            let out = upsert_rows_guarded_inner(
+                &conn,
+                "t",
+                &[mk(&incoming)],
+                UpsertGuard::NewerBy(&ordering),
+            )
+            .unwrap();
+
+            // The guard accepts exactly when the incoming value is strictly
+            // greater, which is what Ordering::Greater means to compare_ts.
+            let sql_accepted = out.applied == 1;
+            let rust_accepted =
+                crate::diff::compare_ts(incoming_s, stored_s) == Some(Ordering::Greater);
+            assert_eq!(
+                sql_accepted, rust_accepted,
+                "guard and compare_ts disagree on incoming {incoming_s} vs stored {stored_s}"
+            );
+        }
+    }
+
+    /// The one pair where they deliberately differ, recorded so the divergence
+    /// is a decision rather than a surprise. `compare_ts` returns `None` on a
+    /// numeric-vs-text pair rather than inventing a winner; SQLite's ordering
+    /// across storage classes is total and picks one. That difference is what
+    /// makes the LAN path terminate -- exactly one peer accepts, so the mesh
+    /// quiesces instead of re-firing Want/Delta forever -- at the cost of a
+    /// winner that is arbitrary rather than chronological, which is why
+    /// `Gossip::ordering_notes` reports it.
+    #[test]
+    fn sql_guard_orders_a_mixed_representation_that_compare_ts_abstains_on() {
+        assert_eq!(
+            crate::diff::compare_ts("1800000000", "2026-01-01T00:00:00+00:00"),
+            None,
+            "compare_ts must not invent a winner across representations"
+        );
+
+        let ordering = vec!["updated_at".to_string()];
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (id TEXT PRIMARY KEY, updated_at);")
+            .unwrap();
+        let mk = |ts: JsonValue| {
+            HashMap::from([
+                ("id".to_string(), JsonValue::from("a")),
+                ("updated_at".to_string(), ts),
+            ])
+        };
+
+        // Integer stored, ISO text incoming: TEXT sorts above INTEGER, accepted.
+        upsert_rows_guarded_inner(
+            &conn,
+            "t",
+            &[mk(JsonValue::from(1_800_000_000i64))],
+            UpsertGuard::Replace,
+        )
+        .unwrap();
+        let text_over_int = upsert_rows_guarded_inner(
+            &conn,
+            "t",
+            &[mk(JsonValue::from("2026-01-01T00:00:00+00:00"))],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!(text_over_int.applied, 1);
+
+        // The mirror image is rejected -- so across a pair of peers exactly one
+        // side accepts and the exchange terminates.
+        let int_over_text = upsert_rows_guarded_inner(
+            &conn,
+            "t",
+            &[mk(JsonValue::from(1_800_000_000i64))],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!(int_over_text.applied, 0);
+        assert_eq!(int_over_text.rejected, 1);
+    }
+
     #[test]
     fn stored_storage_class_reports_the_first_non_null_class() {
         let conn = ordered_conn();

--- a/crates/smugglr-core/src/local.rs
+++ b/crates/smugglr-core/src/local.rs
@@ -52,6 +52,47 @@ impl LocalDb {
         let tables = list_tables_inner(&conn)?;
         Ok(TableSchema::new(tables))
     }
+
+    /// The SQLite storage class actually stored in `table`.`column` -- one of
+    /// `integer`, `real`, `text`, `blob` -- or `None` when the column does not
+    /// exist or holds only NULLs.
+    ///
+    /// Bounded: the first non-NULL value decides. Used to detect two peers
+    /// disagreeing about how a timestamp is represented, which SQLite will order
+    /// confidently (its cross-class ordering is total) but not chronologically.
+    pub fn stored_storage_class(&self, table: &str, column: &str) -> Result<Option<String>> {
+        let conn = self.conn();
+        let sql = format!(
+            "SELECT typeof(\"{}\") FROM \"{}\" WHERE \"{}\" IS NOT NULL LIMIT 1",
+            column, table, column
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let mut rows = stmt.query([])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row.get::<_, String>(0)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Upsert rows under an explicit same-PK conflict [`UpsertGuard`].
+    ///
+    /// The unguarded [`DataSource::upsert_rows`] is `INSERT OR REPLACE` -- the
+    /// received row always wins. This is the same batch write with the
+    /// resolution policy compiled into the statement, so a peer's stale row can
+    /// be turned away without a read-modify-write.
+    ///
+    /// Inherent to `LocalDb` rather than added to [`DataSource`]: a guarded
+    /// write needs SQLite's `ON CONFLICT` and has no general remote analogue, so
+    /// plugin-SDK implementors are unaffected.
+    pub fn upsert_rows_guarded(
+        &self,
+        table: &str,
+        rows: &[HashMap<String, JsonValue>],
+        guard: UpsertGuard<'_>,
+    ) -> Result<UpsertOutcome> {
+        let conn = self.conn();
+        upsert_rows_guarded_inner(&conn, table, rows, guard)
+    }
 }
 
 impl DataSource for LocalDb {
@@ -304,14 +345,96 @@ fn upsert_rows_inner(
     table: &str,
     rows: &[HashMap<String, JsonValue>],
 ) -> Result<usize> {
+    Ok(upsert_rows_guarded_inner(conn, table, rows, UpsertGuard::Replace)?.applied)
+}
+
+/// How a received row resolves against an existing local row with the same
+/// primary key.
+///
+/// The variant selects the SQL shape; every shape is a single statement per row
+/// so the resolution rides *inside* the write and is atomic against a concurrent
+/// local writer. A read-then-write predicate would be racy and would cost a
+/// round trip per row on the hot apply path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpsertGuard<'a> {
+    /// Overwrite unconditionally -- `INSERT OR REPLACE`. The historical
+    /// multicast behavior, and what `remote_wins` means on the apply side.
+    Replace,
+    /// Keep the local row -- `ON CONFLICT DO NOTHING`. Rows absent locally are
+    /// still inserted; an existing row is never touched. `local_wins`.
+    KeepLocal,
+    /// Accept only when the incoming row's ordering value is strictly greater
+    /// than the stored row's -- `ON CONFLICT DO UPDATE ... WHERE`. `newer_wins`.
+    ///
+    /// The ordering value is `max` across the listed columns that actually exist
+    /// on the table, computed identically for both sides of the comparison.
+    NewerBy(&'a [String]),
+}
+
+/// Result of a guarded upsert batch.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UpsertOutcome {
+    /// Rows the guard admitted (inserted or updated).
+    pub applied: usize,
+    /// Rows the guard turned away -- an older or equally-ordered incoming row
+    /// under [`UpsertGuard::NewerBy`], or any colliding row under
+    /// [`UpsertGuard::KeepLocal`]. Not an error: a rejection is the guard doing
+    /// its job. Surfaced so an embedder can see that peer rows are losing.
+    pub rejected: usize,
+    /// The ordering columns requested were all absent from the table, so the
+    /// batch fell back to [`UpsertGuard::Replace`]. The caller should say so
+    /// once per table: the configuration claims an ordering that the schema
+    /// cannot supply, and silently applying blind is how "I believe I am
+    /// ordered and I am not" happens.
+    pub ordering_unavailable: bool,
+}
+
+/// A null-tolerant `max` over `cols`, each qualified by `qualifier`.
+///
+/// SQLite's scalar `max(a, b, c)` returns NULL if *any* argument is NULL, which
+/// would be fatal here: a live row with `deleted_at IS NULL` would produce a
+/// NULL ordering value and lose every comparison. Rotating the column list
+/// through `coalesce` gives each position a non-NULL fallback, so the `max` sees
+/// NULLs only when *every* column is NULL -- which is exactly when the row has
+/// no ordering signal at all.
+///
+/// One column degenerates to a bare column reference, which is the
+/// single-`timestamp_column` behavior.
+fn ordering_max_expr(qualifier: &str, cols: &[String]) -> String {
+    let qualified: Vec<String> = cols
+        .iter()
+        .map(|c| format!("{}.\"{}\"", qualifier, c))
+        .collect();
+
+    if qualified.len() == 1 {
+        return qualified[0].clone();
+    }
+
+    let args: Vec<String> = (0..qualified.len())
+        .map(|i| {
+            let rotated: Vec<&str> = (0..qualified.len())
+                .map(|j| qualified[(i + j) % qualified.len()].as_str())
+                .collect();
+            format!("coalesce({})", rotated.join(", "))
+        })
+        .collect();
+
+    format!("max({})", args.join(", "))
+}
+
+fn upsert_rows_guarded_inner(
+    conn: &Connection,
+    table: &str,
+    rows: &[HashMap<String, JsonValue>],
+    guard: UpsertGuard<'_>,
+) -> Result<UpsertOutcome> {
     if rows.is_empty() {
-        return Ok(0);
+        return Ok(UpsertOutcome::default());
     }
 
     let info = table_info_inner(conn, table)?;
     let cols: Vec<&str> = info.columns.iter().map(|c| c.name.as_str()).collect();
 
-    // Build INSERT OR REPLACE statement
     let col_list = cols
         .iter()
         .map(|c| format!("\"{}\"", c))
@@ -319,15 +442,77 @@ fn upsert_rows_inner(
         .join(", ");
     let placeholders = cols.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
 
-    let sql = format!(
-        "INSERT OR REPLACE INTO \"{}\" ({}) VALUES ({})",
-        table, col_list, placeholders
-    );
+    // The conflict target must be the table's declared PRIMARY KEY columns.
+    // `table_info_inner` already rejects a table without one (`NoPrimaryKey`),
+    // so every table that reaches here has a target `ON CONFLICT` can bind to.
+    let pk_target = info
+        .primary_key
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect::<Vec<_>>()
+        .join(", ");
 
-    debug!("Upserting {} rows into {}", rows.len(), table);
+    // Ordering columns the table does not have cannot participate. If none of
+    // them exist, there is no ordering signal and the guard degrades to
+    // Replace -- reported, never silent.
+    let mut ordering_unavailable = false;
+    let present: Vec<String> = match guard {
+        UpsertGuard::NewerBy(want) => {
+            let present: Vec<String> = want
+                .iter()
+                .filter(|c| info.columns.iter().any(|ci| &&ci.name == c))
+                .cloned()
+                .collect();
+            if present.is_empty() {
+                ordering_unavailable = true;
+            }
+            present
+        }
+        _ => Vec::new(),
+    };
+
+    let sql = match guard {
+        UpsertGuard::Replace => format!(
+            "INSERT OR REPLACE INTO \"{}\" ({}) VALUES ({})",
+            table, col_list, placeholders
+        ),
+        UpsertGuard::KeepLocal => format!(
+            "INSERT INTO \"{}\" ({}) VALUES ({}) ON CONFLICT({}) DO NOTHING",
+            table, col_list, placeholders, pk_target
+        ),
+        UpsertGuard::NewerBy(_) if ordering_unavailable => format!(
+            "INSERT OR REPLACE INTO \"{}\" ({}) VALUES ({})",
+            table, col_list, placeholders
+        ),
+        UpsertGuard::NewerBy(_) => {
+            // Only non-PK columns are assigned: the PK columns are equal by
+            // definition of the conflict.
+            let assignments = cols
+                .iter()
+                .filter(|c| !info.primary_key.iter().any(|pk| pk == *c))
+                .map(|c| format!("\"{0}\" = excluded.\"{0}\"", c))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let incoming = ordering_max_expr("excluded", &present);
+            let stored = ordering_max_expr(&format!("\"{}\"", table), &present);
+            // An incoming row with no ordering value never displaces a stored
+            // row; a stored row with no ordering value never blocks one. Both
+            // arms are needed and both are symmetric across peers, so exactly
+            // one side of any pair accepts and the mesh quiesces.
+            format!(
+                "INSERT INTO \"{table}\" ({col_list}) VALUES ({placeholders}) \
+                 ON CONFLICT({pk_target}) DO UPDATE SET {assignments} \
+                 WHERE {incoming} IS NOT NULL \
+                 AND ({stored} IS NULL OR {incoming} > {stored})"
+            )
+        }
+    };
+
+    debug!("Upserting {} rows into {}: {}", rows.len(), table, sql);
 
     let tx = conn.unchecked_transaction()?;
-    let mut count = 0;
+    let mut applied = 0;
+    let mut rejected = 0;
 
     {
         let mut stmt = tx.prepare(&sql)?;
@@ -340,14 +525,31 @@ fn upsert_rows_inner(
             let param_refs: Vec<&dyn rusqlite::ToSql> =
                 params.iter().map(|p| p as &dyn rusqlite::ToSql).collect();
 
-            stmt.execute(param_refs.as_slice())?;
-            count += 1;
+            // A guard that turns a row away reports 0 changed rows, so the
+            // statement's own count -- not the batch length -- is the truth
+            // about what landed.
+            if stmt.execute(param_refs.as_slice())? > 0 {
+                applied += 1;
+            } else {
+                rejected += 1;
+            }
         }
     }
 
     tx.commit()?;
-    info!("Upserted {} rows into {}", count, table);
-    Ok(count)
+    if rejected > 0 {
+        info!(
+            "Upserted {} rows into {} ({} turned away by the conflict guard)",
+            applied, table, rejected
+        );
+    } else {
+        info!("Upserted {} rows into {}", applied, table);
+    }
+    Ok(UpsertOutcome {
+        applied,
+        rejected,
+        ordering_unavailable,
+    })
 }
 
 /// Convert a row value to JSON by its SQLite storage class.
@@ -446,6 +648,468 @@ mod tests {
         // not an error -- the fix does not conflate empty with unreadable.
         let conn = one_row_conn("NULL");
         assert_eq!(get_col0(&conn).unwrap(), JsonValue::Null);
+    }
+
+    // -- Guarded upsert (#310) --
+
+    /// A table shaped like legion's: an ordering key that is the max over three
+    /// columns, one of which (`deleted_at`) is NULL on every live row.
+    fn ordered_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE rows_t (
+                 id TEXT PRIMARY KEY,
+                 v TEXT,
+                 created_at TEXT,
+                 updated_at TEXT,
+                 deleted_at TEXT
+             );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn row(
+        id: &str,
+        v: &str,
+        created: Option<&str>,
+        updated: Option<&str>,
+        deleted: Option<&str>,
+    ) -> HashMap<String, JsonValue> {
+        let j = |o: Option<&str>| o.map(JsonValue::from).unwrap_or(JsonValue::Null);
+        HashMap::from([
+            ("id".to_string(), JsonValue::from(id)),
+            ("v".to_string(), JsonValue::from(v)),
+            ("created_at".to_string(), j(created)),
+            ("updated_at".to_string(), j(updated)),
+            ("deleted_at".to_string(), j(deleted)),
+        ])
+    }
+
+    fn read_v(conn: &Connection, id: &str) -> String {
+        conn.query_row("SELECT v FROM rows_t WHERE id = ?1", [id], |r| r.get(0))
+            .unwrap()
+    }
+
+    fn legion_ordering() -> Vec<String> {
+        vec![
+            "created_at".to_string(),
+            "updated_at".to_string(),
+            "deleted_at".to_string(),
+        ]
+    }
+
+    #[test]
+    fn ordering_max_expr_single_column_is_a_bare_reference() {
+        // One entry must degenerate to exactly the single-timestamp_column
+        // behavior -- no coalesce/max wrapper to change its meaning.
+        assert_eq!(
+            ordering_max_expr("excluded", &["updated_at".to_string()]),
+            "excluded.\"updated_at\""
+        );
+    }
+
+    #[test]
+    fn ordering_max_expr_tolerates_nulls_via_rotation() {
+        // The rotation exists because SQLite's scalar max() returns NULL if ANY
+        // argument is NULL. Every position must appear first in some coalesce,
+        // or a NULL in that position would poison the result.
+        let e = ordering_max_expr("excluded", &legion_ordering());
+        for c in ["created_at", "updated_at", "deleted_at"] {
+            assert!(
+                e.contains(&format!("coalesce(excluded.\"{}\"", c)),
+                "{} never leads a coalesce in {}",
+                c,
+                e
+            );
+        }
+    }
+
+    #[test]
+    fn newer_by_rejects_an_older_row_and_accepts_a_newer_one() {
+        let conn = ordered_conn();
+        let ordering = legion_ordering();
+        upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row(
+                "a",
+                "local",
+                Some("2026-01-01"),
+                Some("2026-05-01"),
+                None,
+            )],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+
+        // Older peer row: turned away, counted, local content intact.
+        let older = upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row(
+                "a",
+                "stale",
+                Some("2026-01-01"),
+                Some("2026-04-01"),
+                None,
+            )],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!((older.applied, older.rejected), (0, 1));
+        assert_eq!(read_v(&conn, "a"), "local");
+
+        // Newer peer row: accepted.
+        let newer = upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row(
+                "a",
+                "fresh",
+                Some("2026-01-01"),
+                Some("2026-06-01"),
+                None,
+            )],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!((newer.applied, newer.rejected), (1, 0));
+        assert_eq!(read_v(&conn, "a"), "fresh");
+    }
+
+    #[test]
+    fn newer_by_keeps_the_local_row_on_an_exact_tie() {
+        // Strict greater-than: two writes at the identical instant stay
+        // divergent rather than flapping. Matches the remote path's tie rule.
+        let conn = ordered_conn();
+        let ordering = legion_ordering();
+        let base = row("a", "local", Some("2026-01-01"), Some("2026-05-01"), None);
+        upsert_rows_guarded_inner(&conn, "rows_t", &[base], UpsertGuard::NewerBy(&ordering))
+            .unwrap();
+
+        let tie = upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row(
+                "a",
+                "peer",
+                Some("2026-01-01"),
+                Some("2026-05-01"),
+                None,
+            )],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!((tie.applied, tie.rejected), (0, 1));
+        assert_eq!(read_v(&conn, "a"), "local");
+    }
+
+    #[test]
+    fn tombstone_setting_only_deleted_at_wins() {
+        // legion's exact shape, and the reason the ordering signal is a LIST:
+        // the tombstone stamps deleted_at and leaves updated_at alone. Under a
+        // single-column compare on updated_at this is a tie and the delete is
+        // rejected -- the row resurrects.
+        let conn = ordered_conn();
+        let ordering = legion_ordering();
+        upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row(
+                "a",
+                "live",
+                Some("2026-01-01"),
+                Some("2026-05-01"),
+                None,
+            )],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+
+        let tombstone = upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row(
+                "a",
+                "gone",
+                Some("2026-01-01"),
+                Some("2026-05-01"),
+                Some("2026-06-01"),
+            )],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!((tombstone.applied, tombstone.rejected), (1, 0));
+        assert_eq!(read_v(&conn, "a"), "gone");
+
+        // And the same tombstone must not be undone by a later live row whose
+        // max is lower.
+        let resurrect = upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row(
+                "a",
+                "back",
+                Some("2026-01-01"),
+                Some("2026-05-02"),
+                None,
+            )],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!((resurrect.applied, resurrect.rejected), (0, 1));
+        assert_eq!(read_v(&conn, "a"), "gone");
+    }
+
+    #[test]
+    fn newer_by_handles_a_missing_ordering_value_on_either_side() {
+        let conn = ordered_conn();
+        let ordering = legion_ordering();
+
+        // Stored row has no ordering signal at all -> it cannot block anything.
+        upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row("a", "unstamped", None, None, None)],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        let over = upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row("a", "stamped", None, Some("2026-01-01"), None)],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!((over.applied, over.rejected), (1, 0));
+        assert_eq!(read_v(&conn, "a"), "stamped");
+
+        // Incoming row has no ordering signal -> it never displaces one that
+        // does. The two arms are symmetric, so across a pair of peers exactly
+        // one side accepts and the exchange terminates.
+        let blind = upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row("a", "unstamped-peer", None, None, None)],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!((blind.applied, blind.rejected), (0, 1));
+        assert_eq!(read_v(&conn, "a"), "stamped");
+    }
+
+    #[test]
+    fn newer_by_falls_back_to_replace_when_the_table_has_no_ordering_column() {
+        // Configuration claims an ordering the schema cannot supply. Applying
+        // blind is the terminal choice, but it must be REPORTED -- a user who
+        // believes they are ordered and is not is the failure this guard exists
+        // to remove.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE plain (id TEXT PRIMARY KEY, v TEXT);")
+            .unwrap();
+        let mk = |v: &str| {
+            HashMap::from([
+                ("id".to_string(), JsonValue::from("a")),
+                ("v".to_string(), JsonValue::from(v)),
+            ])
+        };
+        upsert_rows_guarded_inner(&conn, "plain", &[mk("first")], UpsertGuard::Replace).unwrap();
+
+        let ordering = legion_ordering();
+        let out = upsert_rows_guarded_inner(
+            &conn,
+            "plain",
+            &[mk("second")],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert!(out.ordering_unavailable, "the caller must be told");
+        assert_eq!(out.applied, 1);
+        let v: String = conn
+            .query_row("SELECT v FROM plain WHERE id = 'a'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, "second", "fallback is blind overwrite, as before");
+    }
+
+    #[test]
+    fn newer_by_uses_only_the_ordering_columns_the_table_actually_has() {
+        // A table with updated_at but no created_at/deleted_at still orders --
+        // the absent columns are dropped from the comparison rather than
+        // disabling it.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE partial (id TEXT PRIMARY KEY, v TEXT, updated_at TEXT);")
+            .unwrap();
+        let mk = |v: &str, ts: &str| {
+            HashMap::from([
+                ("id".to_string(), JsonValue::from("a")),
+                ("v".to_string(), JsonValue::from(v)),
+                ("updated_at".to_string(), JsonValue::from(ts)),
+            ])
+        };
+        let ordering = legion_ordering();
+        upsert_rows_guarded_inner(
+            &conn,
+            "partial",
+            &[mk("local", "2026-05-01")],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        let out = upsert_rows_guarded_inner(
+            &conn,
+            "partial",
+            &[mk("stale", "2026-04-01")],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert!(!out.ordering_unavailable);
+        assert_eq!((out.applied, out.rejected), (0, 1));
+    }
+
+    #[test]
+    fn newer_by_guards_a_composite_primary_key() {
+        // The conflict target is the table's declared PK columns, not the
+        // rendered `__pk` text, which is a lookup key and not a constraint.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE pair (p TEXT, q TEXT, v TEXT, updated_at TEXT, PRIMARY KEY (p, q));",
+        )
+        .unwrap();
+        let mk = |v: &str, ts: &str| {
+            HashMap::from([
+                ("p".to_string(), JsonValue::from("x")),
+                ("q".to_string(), JsonValue::from("y")),
+                ("v".to_string(), JsonValue::from(v)),
+                ("updated_at".to_string(), JsonValue::from(ts)),
+            ])
+        };
+        let ordering = vec!["updated_at".to_string()];
+        upsert_rows_guarded_inner(
+            &conn,
+            "pair",
+            &[mk("local", "2026-05-01")],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        let out = upsert_rows_guarded_inner(
+            &conn,
+            "pair",
+            &[mk("stale", "2026-01-01")],
+            UpsertGuard::NewerBy(&ordering),
+        )
+        .unwrap();
+        assert_eq!((out.applied, out.rejected), (0, 1));
+        let v: String = conn
+            .query_row("SELECT v FROM pair WHERE p='x' AND q='y'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, "local");
+    }
+
+    #[test]
+    fn keep_local_inserts_new_rows_but_never_overwrites() {
+        let conn = ordered_conn();
+        upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row("a", "local", None, Some("2026-01-01"), None)],
+            UpsertGuard::Replace,
+        )
+        .unwrap();
+
+        let out = upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[
+                row("a", "peer", None, Some("2027-01-01"), None),
+                row("b", "peer", None, Some("2027-01-01"), None),
+            ],
+            UpsertGuard::KeepLocal,
+        )
+        .unwrap();
+        assert_eq!((out.applied, out.rejected), (1, 1));
+        assert_eq!(read_v(&conn, "a"), "local", "even a newer peer row loses");
+        assert_eq!(read_v(&conn, "b"), "peer", "absent rows still arrive");
+    }
+
+    #[test]
+    fn replace_still_overwrites_blindly() {
+        // The default multicast policy is remote_wins, and it must behave
+        // exactly as INSERT OR REPLACE always did -- including accepting a row
+        // that is older by every ordering column.
+        let conn = ordered_conn();
+        upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row("a", "local", None, Some("2026-05-01"), None)],
+            UpsertGuard::Replace,
+        )
+        .unwrap();
+        let out = upsert_rows_guarded_inner(
+            &conn,
+            "rows_t",
+            &[row("a", "older-peer", None, Some("2020-01-01"), None)],
+            UpsertGuard::Replace,
+        )
+        .unwrap();
+        assert_eq!((out.applied, out.rejected), (1, 0));
+        assert_eq!(read_v(&conn, "a"), "older-peer");
+    }
+
+    #[test]
+    fn deleted_at_only_write_changes_the_content_hash() {
+        // The seam that would break legion silently: `deleted_at` must stay
+        // VISIBLE to the content hash. `rowhash` excludes updated_at/created_at
+        // and the configured timestamp_column; if the ordering-column list were
+        // ever folded into that exclusion set, a tombstone that only stamps
+        // deleted_at would hash identically to the live row, produce no digest
+        // mismatch, and never be gossiped at all -- while the config says
+        // newer_wins.
+        let conn = ordered_conn();
+        conn.execute(
+            "INSERT INTO rows_t VALUES ('a','v','2026-01-01','2026-05-01',NULL)",
+            [],
+        )
+        .unwrap();
+        let before = get_row_metadata_inner(&conn, "rows_t", "updated_at", &[]).unwrap();
+
+        conn.execute(
+            "UPDATE rows_t SET deleted_at = '2026-06-01' WHERE id = 'a'",
+            [],
+        )
+        .unwrap();
+        let after = get_row_metadata_inner(&conn, "rows_t", "updated_at", &[]).unwrap();
+
+        assert_ne!(
+            before["a"].content_hash, after["a"].content_hash,
+            "a deleted_at-only write must change the digest, or tombstones never propagate"
+        );
+    }
+
+    #[test]
+    fn stored_storage_class_reports_the_first_non_null_class() {
+        let conn = ordered_conn();
+        conn.execute(
+            "INSERT INTO rows_t VALUES ('a','v',NULL,'2026-05-01',NULL)",
+            [],
+        )
+        .unwrap();
+        // Bypass LocalDb::open (which needs a file) by exercising the same SQL.
+        let class: Option<String> = conn
+            .query_row(
+                "SELECT typeof(\"updated_at\") FROM \"rows_t\" WHERE \"updated_at\" IS NOT NULL LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .ok();
+        assert_eq!(class.as_deref(), Some("text"));
+        let all_null: Option<String> = conn
+            .query_row(
+                "SELECT typeof(\"deleted_at\") FROM \"rows_t\" WHERE \"deleted_at\" IS NOT NULL LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .ok();
+        assert_eq!(all_null, None, "an all-NULL column has no class to compare");
     }
 
     #[test]

--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -10,9 +10,21 @@
 //!   DB-identity scoping: two replicas of one logical database sync regardless of
 //!   where each stores its file. Isolate clusters on one LAN with distinct keys
 //!   (a foreign key's datagrams simply fail to decrypt and are dropped).
-//! - **Idempotent apply / last-received-wins.** An incoming row is applied with
-//!   `INSERT OR REPLACE`; applying the same row twice is a no-op, so lost
-//!   datagrams are safe. On same-PK divergence the received row wins.
+//! - **Idempotent apply under a declared policy.** An incoming row is applied
+//!   with a single guarded statement, so applying the same row twice is a no-op
+//!   and lost datagrams are safe. Which side wins a same-PK collision is
+//!   [`BroadcastConfig::conflict_resolution`], which defaults to `remote_wins`
+//!   -- the historical last-received-wins behavior, unchanged. `newer_wins`
+//!   orders by `max` across
+//!   [`BroadcastConfig::ordering_columns`](crate::broadcast::BroadcastConfig::ordering_columns)
+//!   and is an explicit opt-in; the comparison rides inside the write
+//!   (`ON CONFLICT ... DO UPDATE ... WHERE`), so it is atomic against a
+//!   concurrent local write rather than a read-then-write race.
+//!
+//!   Both peers must opt in. A mesh where one node runs `newer_wins` and
+//!   another `remote_wins` converges toward the permissive node -- the policy
+//!   is apply-side, so it is not negotiated on the wire and
+//!   [`PROTOCOL_VERSION`](crate::broadcast::PROTOCOL_VERSION) is unaffected.
 //! - **Heartbeat reconciliation.** Each node periodically multicasts a
 //!   `primary_key -> content_hash` [`Digest`](Body::Digest) for every syncable
 //!   table. A peer that hears a digest covering rows it lacks (or hashes
@@ -22,8 +34,13 @@
 //!
 //! ## v0.1 boundaries (named, per the smugglr conflict doctrine -- do not hide)
 //!
-//! - **Concurrent same-PK divergence resolves silently** (last-received-wins, no
-//!   vector clocks/CRDTs). UUIDv7 PKs make this rare; the single-writer-per-row
+//! - **Concurrent same-PK divergence resolves without a causal record** (no
+//!   vector clocks/CRDTs). Under the default `remote_wins` it resolves silently;
+//!   under `newer_wins` the loser is counted in
+//!   [`GossipEvent::Applied::rejected`] and per-table anomalies are readable via
+//!   [`Gossip::ordering_notes`]. Two writes at the identical instant still tie,
+//!   and a tie is not accepted -- the two nodes stay divergent and re-exchange
+//!   on each heartbeat. UUIDv7 PKs make this rare; the single-writer-per-row
 //!   workload makes it rarer. Visible-conflict / strict-replay is v0.2.
 //! - **Deletes** ride the live [`Delta`](Body::Delta) `deletes` list only. The
 //!   heartbeat advertises *presence*, so an absent PK is indistinguishable from
@@ -36,10 +53,10 @@ use crate::broadcast::{
     maybe_decrypt, maybe_encrypt, BroadcastConfig, DeltaPacket, ReplayGuard, DEFAULT_PORT,
     PROTOCOL_VERSION, SAFE_PACKET_SIZE,
 };
-use crate::config::Config;
+use crate::config::{Config, ConflictResolution};
 use crate::datasource::DataSource;
 use crate::error::{Result, SyncError};
-use crate::local::LocalDb;
+use crate::local::{LocalDb, UpsertGuard};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddrV4};
@@ -164,8 +181,15 @@ pub enum GossipEvent {
     Digest { table: String, wanted: usize },
     /// A `Want` was answered by multicasting `rows` rows.
     Served { table: String, rows: usize },
-    /// A delta was applied; `rows` rows changed locally.
-    Applied { table: String, rows: usize },
+    /// A delta was applied; `rows` rows changed locally and `rejected` rows were
+    /// turned away by the configured conflict guard (see
+    /// [`BroadcastConfig::conflict_resolution`]). Under the default
+    /// `remote_wins` `rejected` is always 0.
+    Applied {
+        table: String,
+        rows: usize,
+        rejected: usize,
+    },
     /// Dropped without effect; see [`IgnoreReason`].
     Ignored(IgnoreReason),
 }
@@ -279,6 +303,43 @@ pub struct Gossip {
     key: Option<[u8; 32]>,
     seq: Arc<AtomicU64>,
     replay: Arc<Mutex<ReplayGuard>>,
+    /// Same-PK resolution policy, taken from the `BroadcastConfig` this node
+    /// bound with -- alongside port, identity, and key, which are read from the
+    /// same place.
+    conflict_resolution: ConflictResolution,
+    /// Configured ordering columns for `newer_wins` (empty = fall back to
+    /// `[sync].timestamp_column` at apply time).
+    ordering_columns: Vec<String>,
+    /// Per-table apply diagnostics, recorded once and readable via
+    /// [`Gossip::ordering_notes`].
+    notes: Arc<Mutex<HashMap<String, OrderingNote>>>,
+}
+
+/// A once-per-table fact about how `newer_wins` is actually behaving on a table.
+///
+/// Logged once and kept queryable, because both conditions it records are
+/// operator-actionable and neither is visible from the outside: a mesh that has
+/// silently stopped ordering, or two nodes that disagree about how a timestamp
+/// is represented. A per-packet log would be noise; silence would be worse --
+/// the failure this whole issue exists to remove is a user who believes they are
+/// ordered and is not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrderingNote {
+    /// The table this note is about.
+    pub table: String,
+    /// `newer_wins` was configured but the table has none of the ordering
+    /// columns, so apply fell back to blind overwrite for this table.
+    pub ordering_unavailable: bool,
+    /// Ordering columns whose incoming SQLite storage class does not match the
+    /// class already stored locally -- an integer Unix time on one node against
+    /// ISO-8601 text on the other, say.
+    ///
+    /// The comparison still terminates (SQLite's ordering across storage classes
+    /// is total, so exactly one side of any pair accepts and the mesh
+    /// quiesces), but the winner is arbitrary rather than chronological. Two
+    /// nodes disagreeing on a representation is a fact an operator needs, not
+    /// merely a convergence condition.
+    pub representation_mismatch: Vec<String>,
 }
 
 impl Gossip {
@@ -298,7 +359,21 @@ impl Gossip {
             key: broadcast.encryption_key()?,
             seq: Arc::new(AtomicU64::new(0)),
             replay: Arc::new(Mutex::new(ReplayGuard::new())),
+            conflict_resolution: broadcast.conflict_resolution,
+            ordering_columns: broadcast.ordering_columns.clone(),
+            notes: Arc::new(Mutex::new(HashMap::new())),
         })
+    }
+
+    /// The per-table apply diagnostics recorded so far -- see [`OrderingNote`].
+    ///
+    /// Empty under the default `remote_wins`; an entry appears only when
+    /// `newer_wins` is configured and the table cannot honor it as intended.
+    pub async fn ordering_notes(&self) -> Vec<OrderingNote> {
+        let notes = self.notes.lock().await;
+        let mut out: Vec<OrderingNote> = notes.values().cloned().collect();
+        out.sort_by(|a, b| a.table.cmp(&b.table));
+        out
     }
 
     fn next_seq(&self) -> u64 {
@@ -582,9 +657,41 @@ impl Gossip {
         }
 
         let mut changed = 0;
+        let mut rejected = 0;
         if !d.upserts.is_empty() {
-            match local.upsert_rows(&d.table, &d.upserts).await {
-                Ok(n) => changed += n,
+            // Only newer_wins needs an ordering signal; the other policies are
+            // decided by the shape of the write alone.
+            let ordering: Vec<String> = match self.conflict_resolution {
+                ConflictResolution::NewerWins | ConflictResolution::UuidV7Wins
+                    if self.ordering_columns.is_empty() =>
+                {
+                    vec![config.sync.timestamp_column.clone()]
+                }
+                ConflictResolution::NewerWins | ConflictResolution::UuidV7Wins => {
+                    self.ordering_columns.clone()
+                }
+                _ => Vec::new(),
+            };
+            let guard = match self.conflict_resolution {
+                ConflictResolution::RemoteWins => UpsertGuard::Replace,
+                ConflictResolution::LocalWins => UpsertGuard::KeepLocal,
+                // A same-PK collision carries the same UUID on both sides, so
+                // uuid_v7_wins has nothing to break the tie with and is exactly
+                // newer_wins here.
+                ConflictResolution::NewerWins | ConflictResolution::UuidV7Wins => {
+                    UpsertGuard::NewerBy(&ordering)
+                }
+            };
+
+            match local.upsert_rows_guarded(&d.table, &d.upserts, guard) {
+                Ok(outcome) => {
+                    changed += outcome.applied;
+                    rejected += outcome.rejected;
+                    if !ordering.is_empty() {
+                        self.record_ordering(&d.table, &d.upserts, local, &ordering, &outcome)
+                            .await;
+                    }
+                }
                 // Schema is the user's; a row for a missing table is dropped.
                 Err(e) => warn!("drop delta for table '{}': {}", d.table, e),
             }
@@ -600,9 +707,88 @@ impl Gossip {
             GossipEvent::Applied {
                 table: d.table,
                 rows: changed,
+                rejected,
             },
             Vec::new(),
         ))
+    }
+
+    /// Record the once-per-table apply diagnostics for `table`, logging each
+    /// exactly once. Cheap after the first delta for a table: the lock is taken,
+    /// the entry is found, and nothing else runs.
+    ///
+    /// The lock is released across the probe rather than held, so two deltas for
+    /// the same table racing on their very first packet can both probe and both
+    /// log. That is deliberate: holding an async mutex across blocking SQLite
+    /// calls would serialize the apply path to buy a duplicate log line, and the
+    /// recorded note is identical either way.
+    async fn record_ordering(
+        &self,
+        table: &str,
+        upserts: &[HashMap<String, serde_json::Value>],
+        local: &LocalDb,
+        ordering: &[String],
+        outcome: &crate::local::UpsertOutcome,
+    ) {
+        if self.notes.lock().await.contains_key(table) {
+            return;
+        }
+
+        if outcome.ordering_unavailable {
+            warn!(
+                "table '{}' has none of the configured ordering columns {:?}; \
+                 newer_wins cannot order it and rows are applied blind",
+                table, ordering
+            );
+        }
+
+        // Compare the storage class the peer sent against the class already
+        // stored, per ordering column. One bounded probe per column, once per
+        // table, and only under an ordering policy.
+        let mut mismatch = Vec::new();
+        for col in ordering {
+            let Some(remote_class) = upserts
+                .iter()
+                .filter_map(|r| r.get(col))
+                .find_map(json_storage_class)
+            else {
+                continue;
+            };
+            match local.stored_storage_class(table, col) {
+                Ok(Some(local_class)) if local_class != remote_class => {
+                    warn!(
+                        "table '{}' column '{}': peer sends {} but {} is stored locally -- \
+                         newer_wins still converges, but the winner is arbitrary rather than \
+                         chronological",
+                        table, col, remote_class, local_class
+                    );
+                    mismatch.push(col.clone());
+                }
+                Ok(_) => {}
+                Err(e) => debug!("cannot probe '{}'.'{}': {}", table, col, e),
+            }
+        }
+
+        self.notes.lock().await.insert(
+            table.to_string(),
+            OrderingNote {
+                table: table.to_string(),
+                ordering_unavailable: outcome.ordering_unavailable,
+                representation_mismatch: mismatch,
+            },
+        );
+    }
+}
+
+/// The SQLite storage class a JSON value binds as, matching `JsonToSql`. `None`
+/// for JSON null, which carries no class to compare.
+fn json_storage_class(v: &serde_json::Value) -> Option<&'static str> {
+    match v {
+        serde_json::Value::Null => None,
+        serde_json::Value::Bool(_) => Some("integer"),
+        serde_json::Value::Number(n) if n.as_i64().is_some() => Some("integer"),
+        serde_json::Value::Number(n) if n.as_f64().is_some() => Some("real"),
+        _ => Some("text"),
     }
 }
 
@@ -743,6 +929,251 @@ mod tests {
         }
     }
 
+    // -- Ordering-aware apply (#310) --
+
+    /// Seed a legion-shaped table: the ordering key is the max over three
+    /// columns and `deleted_at` is NULL on every live row.
+    fn seed_ordered(path: &str, rows: &[(&str, &str, &str, Option<&str>)]) {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE notes (
+                 id TEXT PRIMARY KEY,
+                 body TEXT,
+                 created_at TEXT,
+                 updated_at TEXT,
+                 deleted_at TEXT
+             );",
+        )
+        .unwrap();
+        for (id, body, updated, deleted) in rows {
+            conn.execute(
+                "INSERT INTO notes VALUES (?1, ?2, '2026-01-01T00:00:00+00:00', ?3, ?4)",
+                rusqlite::params![id, body, updated, deleted],
+            )
+            .unwrap();
+        }
+    }
+
+    fn body_of(path: &str, id: &str) -> Option<String> {
+        rusqlite::Connection::open(path)
+            .unwrap()
+            .query_row("SELECT body FROM notes WHERE id = ?1", [id], |r| r.get(0))
+            .ok()
+    }
+
+    fn legion_policy(bc: &mut BroadcastConfig) {
+        bc.conflict_resolution = ConflictResolution::NewerWins;
+        bc.ordering_columns = vec![
+            "created_at".to_string(),
+            "updated_at".to_string(),
+            "deleted_at".to_string(),
+        ];
+    }
+
+    /// The trap this issue exists to avoid walking into. An existing multicast
+    /// deployment carries no `[broadcast].conflict_resolution`, and
+    /// `[sync].conflict_resolution` defaults to LocalWins. If the apply path
+    /// read the sync-scoped field, every such deployment would silently stop
+    /// accepting peer rows -- a convergence break shipped as a bugfix.
+    #[tokio::test]
+    async fn default_policy_is_remote_wins_not_the_sync_scoped_default() {
+        assert_eq!(
+            BroadcastConfig::default().conflict_resolution,
+            ConflictResolution::RemoteWins,
+        );
+        assert_eq!(
+            crate::config::SyncConfig::default().conflict_resolution,
+            ConflictResolution::LocalWins,
+            "the sync-scoped default is the one we must NOT inherit"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+        // B's row is NEWER. Under the historical behavior A still takes it.
+        seed_ordered(
+            &a_path,
+            &[("1", "a-newer", "2026-09-01T00:00:00+00:00", None)],
+        );
+        seed_ordered(
+            &b_path,
+            &[("1", "b-older", "2026-02-01T00:00:00+00:00", None)],
+        );
+        let (a, a_cfg, a_local, b, b_cfg, b_local) = two_nodes(&a_path, &b_path).await;
+
+        let digest = only(b.digest_bodies(&b_local, &b_cfg).await.unwrap());
+        let (_ev, out) = route(&b, digest, &a, &a_local, &a_cfg).await;
+        let (_ev, out) = route(&a, only(out), &b, &b_local, &b_cfg).await;
+        let (ev, _) = route(&b, only(out), &a, &a_local, &a_cfg).await;
+
+        assert!(
+            matches!(
+                ev,
+                GossipEvent::Applied {
+                    rows: 1,
+                    rejected: 0,
+                    ..
+                }
+            ),
+            "the default must stay last-received-wins, got {ev:?}"
+        );
+        assert_eq!(body_of(&a_path, "1").as_deref(), Some("b-older"));
+    }
+
+    /// The fix, end to end over the gossip path: with `newer_wins` opted in, a
+    /// peer's stale row does not overwrite a newer local row -- and the loss is
+    /// counted rather than silent.
+    #[tokio::test]
+    async fn newer_wins_turns_away_a_stale_peer_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+        seed_ordered(
+            &a_path,
+            &[("1", "a-newer", "2026-09-01T00:00:00+00:00", None)],
+        );
+        seed_ordered(
+            &b_path,
+            &[("1", "b-older", "2026-02-01T00:00:00+00:00", None)],
+        );
+        let (a, a_cfg, a_local, b, b_cfg, b_local) =
+            two_nodes_with(&a_path, &b_path, None, None, legion_policy).await;
+
+        // B advertises; A wants (hashes differ); B serves; A applies -- and
+        // rejects, because B's row is older.
+        let digest = only(b.digest_bodies(&b_local, &b_cfg).await.unwrap());
+        let (_ev, out) = route(&b, digest, &a, &a_local, &a_cfg).await;
+        let (_ev, out) = route(&a, only(out), &b, &b_local, &b_cfg).await;
+        let (ev, _) = route(&b, only(out), &a, &a_local, &a_cfg).await;
+
+        assert!(
+            matches!(
+                ev,
+                GossipEvent::Applied {
+                    rows: 0,
+                    rejected: 1,
+                    ..
+                }
+            ),
+            "got {ev:?}"
+        );
+        assert_eq!(
+            body_of(&a_path, "1").as_deref(),
+            Some("a-newer"),
+            "the newer local row must survive"
+        );
+
+        // And the exchange terminates: the other direction accepts, so the mesh
+        // converges on A's row rather than re-firing forever.
+        let digest = only(a.digest_bodies(&a_local, &a_cfg).await.unwrap());
+        let (_ev, out) = route(&a, digest, &b, &b_local, &b_cfg).await;
+        let (_ev, out) = route(&b, only(out), &a, &a_local, &a_cfg).await;
+        let (ev, _) = route(&a, only(out), &b, &b_local, &b_cfg).await;
+        assert!(
+            matches!(
+                ev,
+                GossipEvent::Applied {
+                    rows: 1,
+                    rejected: 0,
+                    ..
+                }
+            ),
+            "got {ev:?}"
+        );
+        assert_eq!(body_of(&b_path, "1").as_deref(), Some("a-newer"));
+    }
+
+    /// legion's actual case: a tombstone stamps `deleted_at` and leaves
+    /// `updated_at` alone. It must still win, which is only true because the
+    /// ordering signal is a column LIST evaluated with max.
+    #[tokio::test]
+    async fn newer_wins_propagates_a_deleted_at_only_tombstone() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+        let stamp = "2026-05-01T00:00:00+00:00";
+        seed_ordered(&a_path, &[("1", "live", stamp, None)]);
+        seed_ordered(
+            &b_path,
+            &[("1", "tombstoned", stamp, Some("2026-06-01T00:00:00+00:00"))],
+        );
+        let (a, a_cfg, a_local, b, b_cfg, b_local) =
+            two_nodes_with(&a_path, &b_path, None, None, legion_policy).await;
+
+        let digest = only(b.digest_bodies(&b_local, &b_cfg).await.unwrap());
+        let (ev, out) = route(&b, digest, &a, &a_local, &a_cfg).await;
+        assert!(
+            matches!(ev, GossipEvent::Digest { wanted: 1, .. }),
+            "a deleted_at-only write must be visible in the digest, got {ev:?}"
+        );
+        let (_ev, out) = route(&a, only(out), &b, &b_local, &b_cfg).await;
+        let (ev, _) = route(&b, only(out), &a, &a_local, &a_cfg).await;
+
+        assert!(
+            matches!(
+                ev,
+                GossipEvent::Applied {
+                    rows: 1,
+                    rejected: 0,
+                    ..
+                }
+            ),
+            "the tombstone must win on max(deleted_at), got {ev:?}"
+        );
+        assert_eq!(body_of(&a_path, "1").as_deref(), Some("tombstoned"));
+    }
+
+    /// Two nodes disagreeing about how a timestamp is represented is an
+    /// operator-actionable fact, not merely a convergence condition. SQLite's
+    /// cross-class ordering is total, so the exchange still terminates -- but
+    /// the winner is arbitrary rather than chronological, and that must be
+    /// visible.
+    #[tokio::test]
+    async fn representation_mismatch_is_recorded_once_per_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+        seed_ordered(
+            &a_path,
+            &[("1", "iso-local", "2026-09-01T00:00:00+00:00", None)],
+        );
+        seed_ordered(&b_path, &[]);
+        let (a, a_cfg, a_local, _b, _b_cfg, _b_local) =
+            two_nodes_with(&a_path, &b_path, None, None, legion_policy).await;
+
+        // A hears a delta whose ordering column carries an integer Unix time
+        // while A stores ISO-8601 text.
+        let mut row: HashMap<String, serde_json::Value> = HashMap::new();
+        row.insert("id".into(), "1".into());
+        row.insert("body".into(), "int-peer".into());
+        row.insert("created_at".into(), serde_json::Value::Null);
+        row.insert("updated_at".into(), serde_json::json!(1_800_000_000i64));
+        row.insert("deleted_at".into(), serde_json::Value::Null);
+
+        let delta = Body::Delta(crate::broadcast::DeltaPacket {
+            version: PROTOCOL_VERSION,
+            source_id: "node-b".into(),
+            seq: 1,
+            part: 0,
+            total_parts: 1,
+            table: "notes".into(),
+            upserts: vec![row],
+            deletes: Vec::new(),
+        });
+        let sealed = a.seal(delta).unwrap();
+        a.handle(&sealed, &a_local, &a_cfg).await.unwrap();
+
+        let notes = a.ordering_notes().await;
+        assert_eq!(notes.len(), 1, "one note per table, got {notes:?}");
+        assert_eq!(notes[0].table, "notes");
+        assert!(!notes[0].ordering_unavailable);
+        assert_eq!(
+            notes[0].representation_mismatch,
+            vec!["updated_at".to_string()],
+            "the disagreeing column must be named"
+        );
+    }
+
     /// Bind two gossip nodes with distinct instance ids on a test group. They
     /// share no path or DB identity, so convergence proves sync is scoped by
     /// group/key membership alone, never by file location.
@@ -761,21 +1192,46 @@ mod tests {
         key_a: Option<&str>,
         key_b: Option<&str>,
     ) -> (Gossip, Config, LocalDb, Gossip, Config, LocalDb) {
+        two_nodes_with(a_path, b_path, key_a, key_b, |_| {}).await
+    }
+
+    /// The port every test binds on.
+    ///
+    /// NOT [`DEFAULT_PORT`]: a test that binds the product's well-known port
+    /// fails whenever anything else on the host holds it -- a real smugglr
+    /// daemon, or an embedder using the same port for its own mesh -- and the
+    /// failure reads as a broken protocol rather than a busy socket.
+    const TEST_PORT: u16 = 39337;
+
+    /// Bind two gossip nodes. Keys are per node (they are what asymmetry tests
+    /// vary); `tweak` is applied to both, for settings a converging mesh must
+    /// share -- the apply policy and its ordering columns.
+    async fn two_nodes_with(
+        a_path: &str,
+        b_path: &str,
+        key_a: Option<&str>,
+        key_b: Option<&str>,
+        tweak: impl Fn(&mut BroadcastConfig),
+    ) -> (Gossip, Config, LocalDb, Gossip, Config, LocalDb) {
         let a_cfg = cfg(a_path);
         let b_cfg = cfg(b_path);
         let a_local = LocalDb::open(a_path).unwrap();
         let b_local = LocalDb::open(b_path).unwrap();
 
-        let bc_a = BroadcastConfig {
+        let mut bc_a = BroadcastConfig {
+            port: TEST_PORT,
             instance_id: Some("node-a".into()),
             secret: key_a.map(String::from),
             ..Default::default()
         };
-        let bc_b = BroadcastConfig {
+        let mut bc_b = BroadcastConfig {
+            port: TEST_PORT,
             instance_id: Some("node-b".into()),
             secret: key_b.map(String::from),
             ..Default::default()
         };
+        tweak(&mut bc_a);
+        tweak(&mut bc_b);
 
         let group = Ipv4Addr::new(239, 255, 99, 88);
         let a = Gossip::bind(&bc_a, group).await.unwrap();

--- a/crates/smugglr/src/broadcast.rs
+++ b/crates/smugglr/src/broadcast.rs
@@ -83,8 +83,23 @@ pub async fn run_broadcast(
             let mut recv_buf = vec![0u8; RECV_BUF];
             loop {
                 match gossip.recv_and_handle(&mut recv_buf, &local, &config).await {
-                    Ok(GossipEvent::Applied { table, rows }) if rows > 0 => {
-                        info!("Applied {} row(s) to '{}'", rows, table)
+                    // A rejected row is the conflict guard doing its job, not an
+                    // error -- but a run where every peer row is turned away is
+                    // indistinguishable from a run where none arrived unless the
+                    // count is said out loud.
+                    Ok(GossipEvent::Applied {
+                        table,
+                        rows,
+                        rejected,
+                    }) if rows > 0 || rejected > 0 => {
+                        if rejected > 0 {
+                            info!(
+                                "Applied {} row(s) to '{}' ({} turned away as not newer)",
+                                rows, table, rejected
+                            )
+                        } else {
+                            info!("Applied {} row(s) to '{}'", rows, table)
+                        }
                     }
                     Ok(GossipEvent::Served { table, rows }) if rows > 0 => {
                         debug!("Served {} row(s) of '{}'", rows, table)


### PR DESCRIPTION
## Summary

smugglr-core declares a conflict-resolution policy and implements it on the remote path, then
ignores it on the LAN path. `multicast::on_delta` applied every received row with a bare
`INSERT OR REPLACE`, so a stale peer row silently overwrote a newer local one -- one crate
resolving the same conflict two different ways depending on which transport you happened to use.
This makes the multicast apply honor a declared policy, scoped to `[broadcast]` so no existing
deployment changes behavior, with the resolution compiled into the write rather than performed
around it.

## Acceptance criteria mapping

### 1. The policy lives on `BroadcastConfig`, and must NOT be read from `[sync].conflict_resolution`

`BroadcastConfig` gains `conflict_resolution: ConflictResolution` with a serde default of
`RemoteWins`, which is what multicast has always done. The trap the issue names is real and
mechanical: `ConflictResolution::default()` is `LocalWins`, so a naive `config.sync.conflict_resolution`
read would have flipped every existing LAN deployment to never-accept-a-peer-row and shipped a
convergence break as a bugfix. `Gossip::bind` reads the policy from the same `BroadcastConfig` it
already takes port, identity, and key from, so there is no second source of truth.

The subtler hazard is that this struct has two default paths -- a hand-written `impl Default` and
per-field `#[serde(default)]` -- which can silently disagree, so a config that omits the key would
resolve differently from an embedder that constructs the struct. `impl Default` calls
`default_broadcast_conflict_resolution()` rather than restating the variant, and a test asserts the
two paths agree rather than trusting the convention.

Evidence: `multicast::tests::default_policy_is_remote_wins_not_the_sync_scoped_default` drives a
full digest/want/delta cycle with an unconfigured node and asserts the *older* peer row still wins,
plus asserts directly that `SyncConfig::default()` is `LocalWins` -- naming the value we must not
inherit. `broadcast::tests::omitted_conflict_keys_deserialize_to_the_struct_defaults` pins the two
default paths together.

### 2. The ordering signal is a column LIST evaluated with max, not a single `timestamp_column`

`ordering_columns: Vec<String>` on `BroadcastConfig`, empty-defaulting to
`[sync.timestamp_column]` so one entry degenerates to exactly the previous behavior. The reason it
cannot be a single column is legion's tombstone: it stamps `deleted_at` and leaves `updated_at`
alone, so under a single-column compare the delete is an exact tie, loses, and the row resurrects.

The max composition is the part that needed care. SQLite's scalar `max(a, b, c)` returns NULL if ANY
argument is NULL -- so the obvious `max(created_at, updated_at, deleted_at)` would evaluate to NULL
for every live row (`deleted_at IS NULL`) and lose every comparison, breaking precisely the case this
exists to serve. `ordering_max_expr` rotates the column list through `coalesce` so each position has
a non-NULL fallback, and the result is NULL only when every column is NULL.

Evidence: `local::tests::tombstone_setting_only_deleted_at_wins` asserts the tombstone is accepted
and then that a later live row with a lower max does not undo it;
`multicast::tests::newer_wins_propagates_a_deleted_at_only_tombstone` proves the same over the wire.
`local::tests::ordering_max_expr_tolerates_nulls_via_rotation` asserts the NULL-tolerance property
directly, and `ordering_max_expr_single_column_is_a_bare_reference` pins the degenerate case.

### 3. Apply is guarded in SQL, not read-modify-write, and lands on `LocalDb` rather than `DataSource`

The statement is `INSERT ... ON CONFLICT(<declared pk cols>) DO UPDATE SET ... WHERE <inc_max> IS
NOT NULL AND (<sto_max> IS NULL OR <inc_max> > <sto_max>)` -- one prepared statement executed once
per row inside one `unchecked_transaction`, which is the execution shape that was already there. The
predicate riding inside the write is what makes it atomic against a concurrent local writer; an
embedder-supplied per-row callback could not go into SQL and would force a read-then-write round
trip per row on the hot apply path.

Both NULL arms are load-bearing and symmetric: a row with no ordering value never displaces one that
has it, and never blocks one either. Because they are symmetric, exactly one side of any peer pair
accepts, so the exchange terminates rather than re-firing forever. `upsert_rows_guarded` is inherent
to `LocalDb`, so the `DataSource` trait is unchanged and plugin-SDK implementors are untouched. The
old `upsert_rows_inner` now delegates to the guarded builder with `UpsertGuard::Replace` rather than
keeping a second copy of the batch-write loop.

Evidence: `local::tests::newer_by_rejects_an_older_row_and_accepts_a_newer_one`,
`newer_by_keeps_the_local_row_on_an_exact_tie` (strict `>`, matching the remote path's tie rule),
`newer_by_handles_a_missing_ordering_value_on_either_side` (both NULL arms), and
`replace_still_overwrites_blindly` (the default path is byte-for-byte the old behavior).

### 4. `ON CONFLICT` needs a real conflict target; detect a table that lacks one and refuse or warn

**The premise is false, and I am reporting that rather than building what it asked for.** The issue
reasoned that `INSERT OR REPLACE` works on tables the guarded path cannot, so a silent fallback would
reinstate blind overwrite while the config claims `newer_wins`. But `upsert_rows_inner` calls
`table_info_inner`, which returns `Err(NoPrimaryKey)` when no column carries the pk flag
(`local.rs:183-185`), and `on_delta` already warns-and-drops on that `Err`. Such a table therefore
fails *today*, before `ON CONFLICT` is ever prepared, and the guarded path inherits the refusal for
free. The branch was unreachable, so it is not implemented.

The adjacent case that IS real is different and is handled: a table that has a primary key but none
of the configured ordering columns. There the guard cannot order, so the batch degrades to
`Replace` and sets `UpsertOutcome::ordering_unavailable`, which `on_delta` turns into a once-per-table
warning and a queryable `OrderingNote`. That is the actual "believes they are ordered and is not"
failure mode.

Evidence: `local.rs:183-185` for the pre-existing refusal;
`local::tests::newer_by_falls_back_to_replace_when_the_table_has_no_ordering_column` asserts both the
fallback and that the caller is told; `newer_by_uses_only_the_ordering_columns_the_table_actually_has`
asserts a partially-present list still orders rather than disabling itself.

### 5. Composite keys: the conflict target must be the declared PK columns, not the rendered `__pk`

The target is built from `TableInfo::primary_key`, which comes from `PRAGMA table_info`'s pk flag --
the table's actual constraint. multicast's `__pk` is a delimiter-escaped text join used as a lookup
key and is not a uniqueness constraint, so `ON CONFLICT` could not bind to it.

Evidence: `local::tests::newer_by_guards_a_composite_primary_key` builds a `PRIMARY KEY (p, q)` table
and asserts a stale row is rejected -- which only prepares at all if the conflict target matches a
real constraint, and the probe confirmed a PK-less table fails at prepare time with "ON CONFLICT
clause does not match any PRIMARY KEY or UNIQUE constraint".

### 6. Reuse `compare_ts` so both transports order identically; exposing it is part of the work

The intent is met; the mechanism named in the issue is not, and the difference matters enough to
state plainly. The LAN path cannot *call* `compare_ts`, because criterion 3 requires the comparison
to ride inside the SQL statement -- calling a Rust comparator would mean reading the stored row
first, which is the read-modify-write that criterion explicitly rejects. So the guarantee is pinned
by test instead of by shared code: `compare_ts` is now `pub(crate)` (not `pub` -- no external caller
wants it, and `pub` would freeze its contract as API), with a doc comment recording that the apply
path deliberately does not call it.

Where they agree is every pair the documented precondition admits -- both sides the same storage
class. `compare_ts` compares integers as `i64`, floats as `f64`, and same-class text lexically;
SQLite does the same within a class. Where they differ is the numeric-vs-text pair: `compare_ts`
returns `None` rather than inventing a winner, while SQLite's cross-class ordering is total and picks
TEXT. That divergence is deliberate and load-bearing -- see criterion 7.

Evidence: `local::tests::sql_guard_agrees_with_compare_ts_on_same_class_pairs` walks integer, float,
and ISO-text pairs in both directions plus an exact tie, asserting the SQL guard accepts exactly when
`compare_ts` returns `Greater`.
`local::tests::sql_guard_orders_a_mixed_representation_that_compare_ts_abstains_on` records the
divergence in both directions.

### 7. Name a terminal behavior for the no-signal cases (issue proposed a content-hash tiebreak)

Named, but the mechanism the issue proposed is not built, because the reason for it does not obtain
in a SQL-guarded apply. The issue's worry was `compare_ts` returning `None`, which `diff` routes to
`content_differs` -- benign in a one-shot sync, non-terminating in a converging mesh, since neither
side accepts and every heartbeat re-fires Want/Delta. SQL never abstains: its ordering across storage
classes is total, so on a mixed pair one node evaluates `INTEGER > TEXT` (false) and its peer
evaluates `TEXT > INTEGER` (true). Exactly one accepts and the mesh quiesces on its own.

A CAST-to-TEXT tiebreak would have *introduced* the hole it was meant to close: `CAST(999 AS TEXT)`
and `CAST('999' AS TEXT)` are equal, so neither side would accept and that pair would churn forever.
Native ordering handles it (integer loses).

What remains is not a convergence problem but an observability one, which is what legion actually
asked for: the winner is arbitrary rather than chronological, and "two nodes disagree on a timestamp
representation" is an operator-actionable fact. So it is warned once per table and recorded in
`OrderingNote`, readable via `Gossip::ordering_notes`. The other no-signal case -- a table with none
of the ordering columns -- is the `ordering_unavailable` fallback in criterion 4, also once per table.
The remaining non-terminating case is an exact same-instant tie, which is the accepted #536 behavior
on both transports, not a regression.

Evidence: `multicast::tests::representation_mismatch_is_recorded_once_per_table` asserts one note per
table naming the disagreeing column; `newer_wins_turns_away_a_stale_peer_row` drives both directions
and asserts the second converges, proving the exchange terminates.

### 8. Observability of a rejection (legion's explicit ask: logged once per table AND queryable)

A guard that turns rows away is indistinguishable from a quiet network unless it says so.
`GossipEvent::Applied` now carries `rejected` alongside `rows`, sourced from the statement's own
changed-row count rather than inferred, so a rejection cannot be miscounted as an apply. The CLI
receive loop surfaces it, and its log guard widened from `rows > 0` to `rows > 0 || rejected > 0` --
otherwise a cycle where every peer row was turned away would log nothing and look exactly like a
cycle where nothing arrived. Per-table anomalies are queryable via `Gossip::ordering_notes()` rather
than only reaching a log.

Evidence: `multicast::tests::newer_wins_turns_away_a_stale_peer_row` asserts
`Applied { rows: 0, rejected: 1 }`; `crates/smugglr/src/broadcast.rs` at the `GossipEvent::Applied`
arm; `local::tests::keep_local_inserts_new_rows_but_never_overwrites` asserts the applied/rejected
split on a mixed batch.

## Not done

- **Digest-side timestamps** -- advertising the ordering key alongside the content hash so a stale
  peer's rows are never Wanted at all. The issue already scoped this out as an optimization rather
  than correctness, and a guarded apply is sufficient without it. Not filed; say the word and I will.
- **#311 (deletes apply nowhere)** -- deliberately sequenced separately. It is a real defect, but it
  raises its own question ("does an incoming delete lose to a newer local row?") that would expand
  this diff past the one thing it is for. It does not gate legion, who never hard-delete.
- **A missing-conflict-target fallback** -- not built, because the premise is false. See criterion 4.
- **A content-hash tiebreak** -- not built, because the non-termination it was meant to prevent
  cannot occur in a SQL-guarded apply. See criterion 7.
- **`uuid_v7_wins` as a distinct LAN behavior** -- it maps to the same arm as `newer_wins`, since a
  same-PK collision carries the same UUID on both sides and the PK cannot break the tie. A separate
  arm would be a distinction with no behavior behind it. Documented at the match and on the config
  field.
- **Normalizing timestamp representations on ingest** -- legion raised it as the stronger fix, and I
  agree it would dissolve the mixed-representation case entirely rather than merely reporting it.
  It is a larger change that belongs with the v0.2 conflict work, and legion explicitly preferred
  this shipped narrow over delayed for it.
- **Incidental, in scope only because it blocked verification:** the multicast tests bound
  `DEFAULT_PORT` (31337) and failed on any host already holding it -- which is how they were failing
  here -- presenting as a broken protocol rather than a busy socket. They now bind a dedicated
  `TEST_PORT`. Confirmed pre-existing: the same five tests fail identically on unmodified `main`.

Closes #310
