### PR TITLE
chore(#314): 0.5.0 -- publishable inter-crate reqs, idempotent publish, migrate changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       # Inter-crate deps resolve by path locally, so a stale version req is
       # invisible to every other job here and only surfaces in the published
       # artifact, where it is immutable. This is the one check that reads

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: shellcheck install.sh
+      - run: shellcheck install.sh scripts/publish-crate.sh
+
+  versions:
+    name: Crate versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      # Inter-crate deps resolve by path locally, so a stale version req is
+      # invisible to every other job here and only surfaces in the published
+      # artifact, where it is immutable. This is the one check that reads
+      # what `cargo publish` would actually ship.
+      - run: python3 scripts/check-crate-versions.py
 
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,28 +109,32 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
+      # Dependency order: wire has no internal deps, sdk and core need
+      # wire, http-sql needs core + sdk, the CLI needs core. Each step is
+      # idempotent (see scripts/publish-crate.sh), so a failure partway
+      # through can be re-run without the earlier crates killing the job.
       - name: Publish smugglr-wire
-        run: cargo publish -p smugglr-wire
+        run: ./scripts/publish-crate.sh smugglr-wire
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Publish smugglr-plugin-sdk
-        run: cargo publish -p smugglr-plugin-sdk
+        run: ./scripts/publish-crate.sh smugglr-plugin-sdk
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Publish smugglr-core
-        run: cargo publish -p smugglr-core
+        run: ./scripts/publish-crate.sh smugglr-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Publish smugglr-http-sql
-        run: cargo publish -p smugglr-http-sql
+        run: ./scripts/publish-crate.sh smugglr-http-sql
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Publish smugglr (CLI)
-        run: cargo publish -p smugglr
+        run: ./scripts/publish-crate.sh smugglr
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.5.0 (2026-08-12)
+
+`smugglr migrate` lands: envelope-based, self-reversing schema migrations for the SQLite family, built as seven pieces that each hold on their own -- a manifest and structured op enum, a rails-style generator, a tamper-evident ledger, a forward apply engine, faithful reverse/rollback, a destructive-op lint, and a first-run primary-key compatibility check. Alongside it, one silent sync bug is fixed (multicast applied remote rows without consulting the conflict policy the crate already declared), blob columns are canonicalized in the content hash, and the release pipeline is hardened so a single crate can no longer take the whole publish down.
+
+**Note for crates.io consumers.** 0.4.3 was tagged but never published -- its `publish-crates` job failed on the first step and none of the five crates moved. Upgrading a crate dependency from 0.4.2 lands both releases at once, including 0.4.3's internal sweep. One item there is a breaking signature change: `Multicast::recv_and_handle` takes a caller-supplied `&mut [u8]` buffer as its first argument (#211). npm consumers are unaffected -- 0.4.3 published normally there.
+
+### Added
+
+- **`smugglr migrate`** -- schema migrations that cross the same boundary sync does, with the globally-unique-primary-key precondition the engine already assumes.
+  - **Migration manifest and structured `Op` enum**, with a native envelope format instead of raw SQL strings, so a migration is inspectable before it is applied. (#271)
+  - **Rails-style generator** -- `smugglr migrate generate` scaffolds a timestamped migration from the CLI. (#270)
+  - **Migration ledger** -- version-gated, success-gated, and tamper-evident, so a partially applied or edited-after-the-fact migration is detected rather than replayed. (#272)
+  - **Forward apply engine** with idempotent per-op DDL and pure remote generators, so re-running an interrupted apply converges instead of double-applying. (#273)
+  - **Reverse/rollback** with faithful verbatim-DDL reverse and a delta-scoped pre-image, so a rollback restores what was actually there rather than a reconstruction of it. (#274)
+  - **Destructive-op lint** -- two-axis op classification with a pre-image gate, so a destructive migration must declare that it is one. (#275)
+  - **First-run primary-key compatibility check**, warning in 0.5.0, for tables whose keys do not satisfy the migrate precondition. (#268)
+
+### Fixed
+
+- **Multicast apply is ordering-aware.** smugglr-core resolved same-primary-key conflicts two different ways depending on transport, and the LAN one was blind: the remote path honors `ConflictResolution` and `timestamp_column`, while the multicast path read `timestamp_column` only to build the digest, discarded it, and applied with a bare `INSERT OR REPLACE`. A stale peer row silently overwrote a newer local one. Resolution now rides inside the write as a single atomic `ON CONFLICT ... DO UPDATE ... WHERE` per row, with no read-modify-write. Two deliberate choices: the policy lands on `BroadcastConfig` and is **not** inherited from `[sync].conflict_resolution` -- that field defaults to `LocalWins` while multicast has always behaved as `RemoteWins`, so inheriting it would flip every existing deployment to never accepting a peer row, a convergence break shipped as a bugfix. And the ordering signal is a column *list* reduced with max, not a single column, so a tombstone that stamps `deleted_at` without bumping `updated_at` is not a tie that loses the delete. A single-entry list degenerates to the old single-column behavior. (#310)
+- **Blob columns fold to one canonical encoding in the content hash.** The native rusqlite path renders a blob as lowercase hex; the JSON SQL backends (Turso, rqlite, D1, and the wasm executors) commonly render standard base64. Two peers folding different renderings of the *same bytes* never converge -- the row reads `content_differs` on every sync, forever, with no error to point at. The content hash now pins one canonical form (lowercase hex), and a backend that renders otherwise declares its `BlobEncoding` and canonicalizes before hashing. Only explicitly-declared `BLOB` columns are canonicalized: a column with an empty declared type has BLOB affinity in SQLite but holds arbitrary dynamically-typed values, and base64-decoding a genuine text value there would corrupt it. Native-only deployments already emitted the canonical form and see no hash change. (#292, residual of #202)
+
+### Changed
+
+- **The release pipeline is idempotent and diagnostic.** `publish-crates` ran five sequential `cargo publish` steps with no guard, so any failure partway left the earlier crates published and the run unrepeatable -- exactly how 0.4.3 got stuck. Each step now skips a crate version already on the index and treats a lost race as success (`scripts/publish-crate.sh`). A new CI job asserts every inter-crate version req equals the workspace version, which is the one thing local builds structurally cannot catch: they resolve those deps by path and never read the version string that `cargo publish` actually ships (`scripts/check-crate-versions.py`). The test matrix no longer cancels its siblings on the first red, so a single-platform failure still returns a complete run.
+- **`smugglr-wasm` is marked `publish = false`.** It ships to npm via wasm-pack and its `smugglr-core` dep is path-only, which `cargo publish` cannot express -- previously that was true but undeclared.
+
+### Docs
+
+- **Migration design and sequencing** -- drift-audit corrections folded into the design and sequencing docs (#304), and the D1 atomicity citation in decision 6 corrected after a `SPEC.md` S4.2 misread (#307).
+
 ## 0.4.3 (2026-07-17)
 
 The last 0.4.x release before the 0.5.0 `smugglr migrate` work. One real correctness fix in the sync path -- composite primary keys with a `|` in a value no longer collide -- plus a numeric float-timestamp ordering fix, a large internal structural-debt sweep from the code audit, and the design groundwork for `smugglr migrate` landed as a doc.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,7 +1756,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smugglr"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "clap",
  "indicatif",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-core"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-http-sql"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "hex",
  "reqwest",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-plugin-sdk"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-wasm"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "hex",
  "js-sys",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "smugglr-wire"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/crates/smugglr-core/Cargo.toml
+++ b/crates/smugglr-core/Cargo.toml
@@ -31,7 +31,7 @@ native = [
 [dependencies]
 # Canonical wire types (TableInfo/ColumnInfo/RowMeta), shared with
 # smugglr-plugin-sdk. serde-only, no tokio -- safe on the wasm32 path. See #228.
-smugglr-wire = { path = "../smugglr-wire", version = "0.4.2" }
+smugglr-wire = { path = "../smugglr-wire", version = "0.5.0" }
 
 # Serialization (always needed)
 serde = { version = "1", features = ["derive"] }

--- a/crates/smugglr-plugin-sdk/Cargo.toml
+++ b/crates/smugglr-plugin-sdk/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["database", "development-tools"]
 [dependencies]
 # Canonical wire types (TableInfo/ColumnInfo/RowMeta), shared with
 # smugglr-core. See #228.
-smugglr-wire = { path = "../smugglr-wire", version = "0.4.2" }
+smugglr-wire = { path = "../smugglr-wire", version = "0.5.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/smugglr-wasm/Cargo.toml
+++ b/crates/smugglr-wasm/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+# Ships to npm via wasm-pack, never to crates.io. Its smugglr-core dep is
+# path-only, which `cargo publish` cannot express -- so declare the intent
+# here rather than discovering it at publish time.
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/smugglr/Cargo.toml
+++ b/crates/smugglr/Cargo.toml
@@ -22,7 +22,7 @@ name = "smugglr"
 path = "src/main.rs"
 
 [dependencies]
-smugglr-core = { path = "../smugglr-core", version = "0.4.2" }
+smugglr-core = { path = "../smugglr-core", version = "0.5.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/packages/nanostores-plugin/package.json
+++ b/packages/nanostores-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smugglr/nanostores",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Nanostores adapter that auto-persists atoms and maps to a smugglr-managed SQLite table.",
   "type": "module",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
   "author": "Sean Silvius",
   "peerDependencies": {
     "nanostores": "^1.0.0",
-    "smugglr": "^0.4.0"
+    "smugglr": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/packages/smugglr/package.json
+++ b/packages/smugglr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smugglr",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Content-hashed delta sync for SQLite, in the browser",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/zustand-plugin/package.json
+++ b/packages/zustand-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smugglr/zustand",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Zustand middleware that auto-persists store slices to a smugglr-managed SQLite table.",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
   },
   "author": "Sean Silvius",
   "peerDependencies": {
-    "smugglr": "^0.4.0",
+    "smugglr": "^0.5.0",
     "zustand": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {

--- a/plugins/smugglr-http-sql/Cargo.toml
+++ b/plugins/smugglr-http-sql/Cargo.toml
@@ -18,8 +18,8 @@ name = "smugglr-http-sql"
 path = "src/main.rs"
 
 [dependencies]
-smugglr-core = { path = "../../crates/smugglr-core", version = "0.4.2", default-features = false }
-smugglr-plugin-sdk = { path = "../../crates/smugglr-plugin-sdk", version = "0.4.2" }
+smugglr-core = { path = "../../crates/smugglr-core", version = "0.5.0", default-features = false }
+smugglr-plugin-sdk = { path = "../../crates/smugglr-plugin-sdk", version = "0.5.0" }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/scripts/check-crate-versions.py
+++ b/scripts/check-crate-versions.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Assert every inter-crate dependency req equals the workspace version.
+
+Workspace crates depend on each other with both a path and a version:
+
+    smugglr-core = { path = "../smugglr-core", version = "0.4.2" }
+
+Local builds and CI resolve those deps by PATH and never read the version
+string, so it can rot for months with every check green. `cargo publish`
+strips the path and ships the registry req -- it is the first and only
+reader, and by then the artifact is immutable.
+
+The failure is silent rather than loud. A req naming a version that does
+not exist would fail resolution and stop the release. A req naming a
+version that DOES exist resolves fine -- to the wrong crate. Publishing
+smugglr 0.5.0 while its req still reads "0.4.2" ships a 0.5.0 CLI hard-
+depending on a four-versions-stale engine, with a green pipeline start to
+finish.
+
+So: every inter-crate req moves in the same commit as the workspace
+version bump. That is the invariant this script enforces.
+
+Reads `cargo metadata` rather than parsing manifests, so it sees the same
+normalized reqs cargo itself resolves ("0.5.0" -> "^0.5.0").
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+# Deps whose reqs must track the workspace version. Third-party deps are
+# none of this script's business.
+INTERNAL_PREFIX = "smugglr"
+
+
+def workspace_version(meta: dict) -> str:
+    """The single version every workspace member shares.
+
+    Every member inherits `version.workspace = true`, so any member's
+    version is the workspace version -- but assert that rather than
+    trusting it, because a member that opts out is exactly the kind of
+    drift this script exists to catch.
+    """
+    members = {p["name"]: p["version"] for p in meta["packages"]}
+    versions = set(members.values())
+    if len(versions) != 1:
+        detail = ", ".join(f"{n} {v}" for n, v in sorted(members.items()))
+        raise SystemExit(
+            "workspace members do not share one version, so there is no "
+            f"single version to check reqs against: {detail}"
+        )
+    return versions.pop()
+
+
+def main() -> int:
+    proc = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr, file=sys.stderr)
+        raise SystemExit("cargo metadata failed")
+
+    meta = json.loads(proc.stdout)
+    expected_version = workspace_version(meta)
+    expected_req = f"^{expected_version}"
+
+    failures: list[str] = []
+    checked = 0
+
+    for pkg in sorted(meta["packages"], key=lambda p: p["name"]):
+        # `publish = false` crates never reach the registry, so their reqs
+        # are never read by anyone. cargo metadata reports the field as []
+        # when publishing is disabled and null when it is allowed.
+        if pkg.get("publish") == []:
+            continue
+
+        for dep in pkg["dependencies"]:
+            if not dep["name"].startswith(INTERNAL_PREFIX):
+                continue
+
+            # A path-only dep ships no version req at all, which means
+            # `cargo publish` cannot express the dependency and refuses.
+            # Report it here rather than at publish time.
+            if dep["req"] == "*":
+                failures.append(
+                    f"{pkg['name']} -> {dep['name']}: no version req "
+                    f"(path-only deps are unpublishable; add version = "
+                    f'"{expected_version}")'
+                )
+                continue
+
+            checked += 1
+            if dep["req"] != expected_req:
+                failures.append(
+                    f"{pkg['name']} -> {dep['name']}: req {dep['req']} "
+                    f"!= workspace version {expected_version}"
+                )
+
+    if failures:
+        print(
+            f"inter-crate version reqs disagree with the workspace version "
+            f"({expected_version}):\n",
+            file=sys.stderr,
+        )
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        print(
+            "\nThese reqs are what `cargo publish` ships once the path is "
+            "stripped. Local builds resolve by path and cannot catch this.\n"
+            "Bump every inter-crate req in the same commit as "
+            "[workspace.package].version.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"ok: {checked} inter-crate reqs all pin {expected_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publish-crate.sh
+++ b/scripts/publish-crate.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Publish one workspace crate to crates.io, idempotently.
+#
+# The release job publishes five crates in sequence with no guard, so any
+# failure partway leaves the earlier crates published and the run
+# unrepeatable: re-running hits "crate version already exists" on crate 1
+# and dies before reaching the crate that actually failed. That is how
+# v0.4.3 got stuck -- one brand-new crate took down four that were ready.
+#
+# publish-npm already does the view-then-publish dance. This is the cargo
+# equivalent.
+#
+# Bias: a false MISS (we think it is unpublished when it is not) is safe --
+# we attempt the publish and treat "already exists" as success. A false HIT
+# is not safe: it would silently skip a crate that never shipped. Sparse
+# index propagation lags a successful publish by seconds, so the guard is
+# written to fail toward attempting.
+
+set -euo pipefail
+
+crate="${1:?usage: publish-crate.sh <crate-name>}"
+
+version="$(cargo metadata --format-version 1 --no-deps \
+  | python3 -c "import json,sys; m=json.load(sys.stdin); print(next(p['version'] for p in m['packages'] if p['name']=='$crate'))")"
+
+# crates.io sparse index path: 1/x, 2/xy, 3/x/xyz, else xx/yy/name
+name_len="${#crate}"
+case "$name_len" in
+  1) index_path="1/$crate" ;;
+  2) index_path="2/$crate" ;;
+  3) index_path="3/${crate:0:1}/$crate" ;;
+  *) index_path="${crate:0:2}/${crate:2:2}/$crate" ;;
+esac
+
+echo "checking index for $crate@$version"
+
+already_published=no
+if body="$(curl -sf --max-time 30 "https://index.crates.io/$index_path")"; then
+  if printf '%s' "$body" | python3 -c "
+import json, sys
+target = '$version'
+for line in sys.stdin:
+    line = line.strip()
+    if line and json.loads(line)['vers'] == target:
+        raise SystemExit(0)
+raise SystemExit(1)
+"; then
+    already_published=yes
+  fi
+else
+  # 404 means the crate has never been published (first release of a new
+  # crate); any other curl failure is a transient we treat the same way,
+  # because attempting is the safe direction.
+  echo "index lookup did not resolve; assuming not published"
+fi
+
+if [ "$already_published" = yes ]; then
+  echo "$crate@$version already on crates.io, skipping"
+  exit 0
+fi
+
+echo "publishing $crate@$version"
+if ! output="$(cargo publish -p "$crate" 2>&1)"; then
+  echo "$output"
+  # Lost a race with the index, or the guard read a stale index. The
+  # end state is the one we wanted, so do not fail the run.
+  if printf '%s' "$output" | grep -q "already exists"; then
+    echo "$crate@$version was already published; treating as success"
+    exit 0
+  fi
+  exit 1
+fi
+echo "$output"

--- a/scripts/publish-crate.sh
+++ b/scripts/publish-crate.sh
@@ -21,7 +21,10 @@ set -euo pipefail
 crate="${1:?usage: publish-crate.sh <crate-name>}"
 
 version="$(cargo metadata --format-version 1 --no-deps \
-  | python3 -c "import json,sys; m=json.load(sys.stdin); print(next(p['version'] for p in m['packages'] if p['name']=='$crate'))")"
+  | python3 -c 'import json, sys
+meta = json.load(sys.stdin)
+name = sys.argv[1]
+print(next(p["version"] for p in meta["packages"] if p["name"] == name))' "$crate")"
 
 # crates.io sparse index path: 1/x, 2/xy, 3/x/xyz, else xx/yy/name
 name_len="${#crate}"
@@ -36,15 +39,13 @@ echo "checking index for $crate@$version"
 
 already_published=no
 if body="$(curl -sf --max-time 30 "https://index.crates.io/$index_path")"; then
-  if printf '%s' "$body" | python3 -c "
-import json, sys
-target = '$version'
+  if printf '%s' "$body" | python3 -c 'import json, sys
+target = sys.argv[1]
 for line in sys.stdin:
     line = line.strip()
-    if line and json.loads(line)['vers'] == target:
+    if line and json.loads(line)["vers"] == target:
         raise SystemExit(0)
-raise SystemExit(1)
-"; then
+raise SystemExit(1)' "$version"; then
     already_published=yes
   fi
 else


### PR DESCRIPTION
## Summary

Bumps the workspace to 0.5.0 for the `smugglr migrate` release and fixes the publish path that made v0.4.3 a phantom -- tagged in git, resolvable nowhere. Two mechanisms change. Every inter-crate version req moves to 0.5.0 in the same commit as the workspace bump, because those reqs cannot be correct in any other commit, and a CI job now enforces that. Each crate publish step becomes idempotent, so one crate can no longer take the other four down with it.

The defect this closes is not a typo, it is a blind spot. Workspace crates depend on each other with both a `path` and a `version`. Every local build and every CI job resolves those deps by path and never reads the version string; `cargo publish` strips the path and ships the registry req, and is the first and only reader. At a patch bump a stale `0.4.2` req is caret-satisfied and genuinely harmless -- which is exactly why it survived. At a minor bump the caret closes, and because 0.4.2 still exists on the index the req resolves anyway, to the wrong crate. A green pipeline publishing a 0.5.0 CLI pinned to a four-versions-stale engine.

## Acceptance criteria mapping

### 1. `[workspace.package].version` is 0.5.0 and every inter-crate version req equals it

The workspace anchor moves once (`Cargo.toml:20`) and all five internal reqs move with it in the same commit: `smugglr -> smugglr-core`, `smugglr-core -> smugglr-wire`, `smugglr-plugin-sdk -> smugglr-wire`, and both of `smugglr-http-sql`'s. They are one commit rather than two on purpose -- an intermediate state pinning `0.4.3` would name a version that does not exist on the index and would be unpublishable, so the reqs are only correct at the instant the bump makes 0.5.0 real. Each dep keeps both `path` and `version`; dropping either changes meaning, since path-only cannot be published and version-only stops resolving locally.

Evidence: `Cargo.toml:20`, `crates/smugglr/Cargo.toml:25`, `crates/smugglr-core/Cargo.toml:34`, `crates/smugglr-plugin-sdk/Cargo.toml:19`, `plugins/smugglr-http-sql/Cargo.toml:21-22`. Confirmed end to end by reading the manifest inside the packaged artifact: before the change `tar -xzOf target/package/smugglr-0.4.3.crate` showed `smugglr-core -> {'version': '0.4.2'}` with the path stripped; `cargo package -p smugglr-wire` now emits 0.5.0.

### 2. A check that fails when they disagree runs in CI, and was observed failing before the fix

`scripts/check-crate-versions.py` reads `cargo metadata --no-deps` rather than parsing manifests, so it compares the reqs cargo itself normalizes (`"0.5.0"` -> `"^0.5.0"`) instead of reimplementing semver. It derives the expected version by asserting all workspace members share one, so a member that opts out of `version.workspace` is caught rather than silently becoming the baseline. A new `versions` job runs it on every PR.

It was written against the unfixed tree and watched to fail first -- a check never seen red is a check nobody has tested. That red run also surfaced a sixth site none of the release checklists counted: `smugglr-wasm`'s `smugglr-core` dep is path-only and therefore unpublishable, and the crate had no `publish = false` to say it never goes to crates.io. It does now, and the script skips on that declared signal rather than a hardcoded crate name.

Evidence: `scripts/check-crate-versions.py`, `.github/workflows/ci.yml:57-67`, `crates/smugglr-wasm/Cargo.toml:10-13`. Observed output on the pre-fix tree: six failures including `smugglr -> smugglr-core: req ^0.4.2 != workspace version 0.4.3`. Post-fix: `ok: 5 inter-crate reqs all pin 0.5.0`.

### 3. Each crate publish step skips a name@version already on the index and treats a lost race as success

`publish-crates` previously ran five bare sequential `cargo publish` steps, so a failure partway left the earlier crates published and the run unrepeatable -- re-running died on "already exists" at step 1 before reaching the crate that actually failed. That is precisely how v0.4.3 died: `smugglr-wire` had never existed on crates.io, Trusted Publishing is configured per-crate and cannot cover a crate with no page, step 1 failed, and four ready crates never ran.

`scripts/publish-crate.sh` queries the sparse index for `name@version` and skips if present. Its failure direction is deliberately asymmetric: an unreachable or 404 index falls through to attempting the publish, and a `cargo publish` that fails with "already exists" exits 0. A false miss costs a wasted attempt the publish itself adjudicates; a false hit would silently skip a crate that never shipped. Every other non-zero exit re-prints cargo's output and fails.

The five steps are intentionally not collapsed into a matrix: they are order-dependent (wire, then sdk and core, then http-sql and the CLI), and matrix entries run concurrently, which would race the dependency order.

Evidence: `scripts/publish-crate.sh`, `.github/workflows/release.yml:112-137`. Tested against the live index: correctly reports `smugglr-wire 0.4.3` as already published (skip) and `0.5.0` as not (publish). `publish-npm` is untouched -- the only release.yml changes are five `run:` lines and a comment, all inside `publish-crates`.

### 4. All three npm packages at 0.5.0, both bridge peerDeps at `^0.5.0`

`smugglr`, `@smugglr/zustand`, and `@smugglr/nanostores` move together, and the two bridges' `peerDependencies.smugglr` goes `^0.4.0` -> `^0.5.0`. The peer bump is required, not cosmetic: both bridges runtime-import `createPersistBinding` from `smugglr` (#227), which no 0.4.x published to npm before 0.4.3 provides, so a `^0.4.0` peer admits versions that break at import.

I checked for a seventh site holding a stale range and there is none -- the bridges' only other reference to `smugglr` is a `link:../smugglr` devDependency, which carries no version, and `packages/smugglr` has no `bin` or postinstall building a version-derived download URL.

Evidence: `packages/smugglr/package.json:3`, `packages/zustand-plugin/package.json:3,33`, `packages/nanostores-plugin/package.json:3,34`. Verified under the pnpm major CI actually pins (10, via `pnpm/action-setup@v4`) that `pnpm install --frozen-lockfile` still accepts all three manifests after the peer change -- exit 0 for each.

### 5. CHANGELOG 0.5.0 entry, dated to the tag day

The entry covers the seven migrate pieces, the two fixes, and the pipeline changes, and it states the one thing a crates.io consumer cannot discover for themselves: 0.4.3 was tagged but never published, so upgrading a crate dep from 0.4.2 lands both releases at once -- including the breaking `Multicast::recv_and_handle` signature change from #211, which now takes a caller-supplied `&mut [u8]`. npm consumers are unaffected; 0.4.3 published normally there.

Two entries were rewritten during review after checking them against the source instead of against my own notes. The blob entry had claimed every blob table re-hashes -- false, the native path already emitted the canonical lowercase hex, so native-only deployments see no change. The #310 entry had claimed the guard achieves parity with `compare_ts`, which is the exact claim that branch's own second commit exists to refuse.

Evidence: `CHANGELOG.md:3-33`. Dated 2026-08-12, matching the intended tag day; if the tag slips to another date this line must move with it, since the published artifact is immutable.

### 6. `cargo check --workspace` clean; shellcheck clean on any new script

Nothing in this change touches Rust source, so the build criterion is really asking whether the manifest edits left the workspace resolvable -- a mistyped req or a malformed `publish` key breaks resolution before compilation, and that is what `cargo check --workspace` proves is not the case here. The shellcheck half matters more than it looks: `publish-crate.sh` runs only during a release, on a runner, when a mistake is expensive and hard to iterate on, so static analysis is most of the feedback it will ever get before it matters. Adding it to the existing job rather than a new one means it cannot be forgotten as the script grows.

Evidence: `cargo check --workspace` exits 0 on HEAD. `shellcheck scripts/publish-crate.sh` is clean, and the new script was added to the existing `shellcheck` job's argument list (`.github/workflows/ci.yml:54`) rather than given a second job, so it stays linted. Both workflow files parse as YAML with the expected job sets.

## Not done

**The tag.** `legion push` refuses main and has no force path; tagging and the publish it triggers stay with the operator, as they always have.

**The one-time crates.io actions**, which were the actual blocker and are already complete: `smugglr-wire` was hand-published at 0.4.3 to claim the name, and the Trusted Publisher was configured. The name is confirmed live on the index. The Trusted Publisher setting is not exposed anywhere readable from a checkout, so it stays unverified until the tag run exercises it -- worth watching as the first thing that can fail.

**Pre-publish verification of the dependent crates.** `cargo package -p smugglr` now fails locally, because it resolves `smugglr-core` 0.5.0 from a registry where it does not exist yet. That is inherent to publishing a workspace and is why step order in `release.yml` matters -- core ships before the CLI, so the req resolves at publish time. Only the leaf crate (`smugglr-wire`) can be packaged standalone before a release.

**Two CI changes not in the issue**, both small and both about this pipeline being trustworthy rather than about the release contents: `fail-fast: false` on the test matrix, so a single-platform red still returns a complete run instead of cancelling its siblings, and a registry cache on the new `versions` job, so the gate cannot go red for a network reason unrelated to what it checks.

Closes #314
