### PR TITLE
docs(#309): state d1_statements atomic-batch precondition

### DIFF
--- a/crates/smugglr-core/src/migrate/apply.rs
+++ b/crates/smugglr-core/src/migrate/apply.rs
@@ -238,9 +238,13 @@ impl RemoteTarget {
 /// pragma is here to prevent. The failure is in the caller's transaction scope,
 /// not in this SQL, which is why it cannot be detected by reading the output.
 ///
-/// Contrast [`rqlite_statements`], which frames its own ops in `BEGIN`/`COMMIT`
-/// and therefore carries no such precondition; the framing is omitted here only
-/// because D1 rejects `BEGIN`.
+/// Contrast [`rqlite_statements`], which supplies its own `BEGIN`/`COMMIT`. It
+/// still expects its statements to travel together -- what differs is the
+/// failure mode when they do not. A split there is loud: an unbalanced `BEGIN`
+/// or a stray `COMMIT` fails where it is sent. A split here is silent, because
+/// every statement is individually valid and only the deferral quietly stops
+/// meaning anything. That is why this one needs saying and that one does not.
+/// The explicit framing is omitted here only because D1 rejects `BEGIN`.
 ///
 /// This crate cannot enforce the boundary: [`apply_remote`] has no transport in
 /// 0.5.0, so callers use these generators directly and own the batch boundary

--- a/crates/smugglr-core/src/migrate/apply.rs
+++ b/crates/smugglr-core/src/migrate/apply.rs
@@ -223,6 +223,28 @@ impl RemoteTarget {
 /// this lowers to one batch. Cross-table DDL wants `defer_foreign_keys` so an
 /// out-of-order reference does not trip mid batch. The first statement enables
 /// it; the rest are the ops in order.
+///
+/// # Precondition: execute these as one atomic batch
+///
+/// The returned slice is sound **only** when the caller executes it inside a
+/// single enclosing transaction -- for D1, one `db.batch()` call.
+///
+/// `PRAGMA defer_foreign_keys` defers enforcement until the *outermost*
+/// transaction commits. Under autocommit -- which is exactly what a non-atomic
+/// batch is, one implicit transaction per statement -- every statement commits
+/// at its own end, enforcement fires there, and statement 0 buys nothing. So
+/// splitting this slice across requests, or handing it to a driver that batches
+/// non-atomically, silently reinstates the mid-batch foreign-key failure the
+/// pragma is here to prevent. The failure is in the caller's transaction scope,
+/// not in this SQL, which is why it cannot be detected by reading the output.
+///
+/// Contrast [`rqlite_statements`], which frames its own ops in `BEGIN`/`COMMIT`
+/// and therefore carries no such precondition; the framing is omitted here only
+/// because D1 rejects `BEGIN`.
+///
+/// This crate cannot enforce the boundary: [`apply_remote`] has no transport in
+/// 0.5.0, so callers use these generators directly and own the batch boundary
+/// themselves.
 pub fn d1_statements(ops: &[ClassifiedOp]) -> Vec<String> {
     let mut out = Vec::with_capacity(ops.len() + 1);
     out.push("PRAGMA defer_foreign_keys = ON".to_string());
@@ -258,7 +280,10 @@ pub fn rqlite_statements(ops: &[ClassifiedOp]) -> Vec<String> {
 /// [`MigrateError::RemoteTransportUnsupported`], deferred to #291. The statement
 /// generators above are the usable half today. Callers that only need the SQL
 /// should call `d1_statements` / `turso_statements` / `rqlite_statements`
-/// directly rather than routing through this.
+/// directly rather than routing through this -- and must then honor each
+/// generator's own transaction contract, which this function would otherwise
+/// have owned. In particular [`d1_statements`] is sound only as one atomic
+/// batch; see its precondition.
 pub fn apply_remote(target: RemoteTarget, _ops: &[ClassifiedOp]) -> Result<(), MigrateError> {
     Err(MigrateError::RemoteTransportUnsupported(
         target.name().to_string(),


### PR DESCRIPTION
## Summary

`d1_statements` emits `PRAGMA defer_foreign_keys = ON` as statement 0, and its doc-comment
promised that this is why "an out-of-order reference does not trip mid batch." That promise
holds only when statements 1..n execute inside one enclosing transaction. `PRAGMA
defer_foreign_keys` defers enforcement until the *outermost* transaction commits, so under
autocommit -- which is exactly what a non-atomic batch is, one implicit transaction per
statement -- every statement commits at its own end, enforcement fires there, and statement 0
buys nothing.

The generated SQL is correct when sent as an atomic batch (D1's `db.batch()`), which is
evidently the intended contract: `rqlite_statements` in the same file wraps its ops in
`BEGIN`/`COMMIT`, so explicit framing was a known tool and was omitted for D1 only because D1
rejects `BEGIN`. This is therefore an unstated precondition, not broken code, and the fix is
to state it. Docs only -- no behavior change.

Note on structure: #309 has no formal "Acceptance criteria" section; it is a defect report.
The entries below map the three requirements its Summary and "This is an unstated
precondition, not broken code" section actually state.

## Acceptance criteria mapping

### 1. The atomic-batch precondition is stated where a caller will hit it

A `# Precondition: execute these as one atomic batch` section now sits on `d1_statements`
itself, so it appears in rustdoc directly above the signature a caller is reading. It states
the mechanism rather than just the rule -- that the pragma defers to the outermost transaction
and that autocommit is one implicit transaction per statement -- because a caller who knows
only "send it atomically" cannot tell which of their drivers qualify, whereas one who knows
*why* can. It also names the consequence: splitting the slice across requests silently
reinstates the mid-batch foreign-key failure the pragma exists to prevent.

Evidence: `crates/smugglr-core/src/migrate/apply.rs`, the `# Precondition` block on
`fn d1_statements` (immediately above the `out.push("PRAGMA defer_foreign_keys = ON")` at
line 250 that it describes).

### 2. The precondition is stated at the point that sends callers to the generators

The issue notes the generators have no production caller today; the documented route to them
is `apply_remote`, whose doc-comment tells callers that remote transport is unsupported in
0.5.0 and that they should call `d1_statements` / `turso_statements` / `rqlite_statements`
directly instead. That redirect was where a caller silently inherited a transaction contract
`apply_remote` would otherwise have owned, so it now says so and points at the precondition.
Deliberately a pointer, not a second copy: two independent statements of one transaction
contract drift, and this is the contract that was already ambiguous.

Evidence: `crates/smugglr-core/src/migrate/apply.rs`, the closing clauses of `fn apply_remote`'s
doc-comment ("must then honor each generator's own transaction contract ... In particular
`d1_statements` is sound only as one atomic batch").

### 3. No behavior change, and the existing shape assertion still holds

Nothing executable changed: `d1_statements` still returns the pragma followed by
`ops.iter().map(statement_for)` in order, so the SQL on the wire is byte-identical. The
pre-existing test `d1_prepends_defer_foreign_keys` continues to pin statement 0's content and
position, which is the assertion the doc now explains rather than replaces. Full gate run
clean on this HEAD: `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`,
and `cargo test -p smugglr-core` (411 passed, 0 failed). Intra-doc links were checked to
resolve -- `cargo doc` emits zero warnings naming `apply.rs`.

Evidence: `crates/smugglr-core/src/migrate/apply.rs:1464`
(`fn d1_prepends_defer_foreign_keys`, asserting `s[0] == "PRAGMA defer_foreign_keys = ON"`).

## Not done

I did not make the precondition type-enforced. The strongest version of this fix wraps the
return in an `AtomicBatch` newtype so the contract cannot be ignored by a caller who does not
read docs. I left it out on purpose: it changes the public signature of `d1_statements`, and
for consistency `turso_statements` and `rqlite_statements` too, immediately before a release
that is waiting on a tag -- and #291, which wires the host-to-target transport, is the change
that will actually have a production caller to enforce it against. Settling the wording now
and the type later is the sequencing the issue itself asks for ("Settle it before #291 wires
the transport").

I also did not touch `turso_statements` or `rqlite_statements`. Neither makes a false promise:
`rqlite_statements` supplies its own `BEGIN`/`COMMIT` framing, and `turso_statements` emits no
pragma and already states that transaction framing is the embedded-replica connection's
concern. `docs/plans/migration.md` was left alone for the same reason -- its D1 row already
names the batch API as the transaction unit, which is consistent with this precondition
rather than contradicted by it.

---

## Review provenance -- read this before merging

**Independently reviewed.** The Agent tool was authorized partway through this batch, after an
earlier author-only pass was judged insufficient. The `legion-review` gate on this PR now records
a genuine subagent review rather than the author's own verdict.

- `legion-simplify` and `legion-pr-write` remain provenance `validated`: the tool mechanically
  checked the articulation's shape -- per-file coverage, non-boilerplate substance, a locator per
  entry, one mapping entry per acceptance criterion. It still does not and cannot check whether
  the reasoning is correct.
- `legion-review` was executed by an independent subagent that did not write the code, with its
  own verification (it re-ran the relevant tooling and traced claims to implementing code rather
  than reading this PR body). Findings it raised were fixed before this record was made; the
  gate's `details-json` lists them.
- `legion-verify` did not run. It requires a kanban card and none exists for this work. That was a
  deliberate call: verify consumes per-criterion verdicts written by the author, so running it
  here would have re-certified my own judgement rather than adding a second party.

An earlier revision of this section said this PR was author-reviewed only. That was accurate when
written and is superseded by the above.

Closes #309
