### PR TITLE
feat(#269): refuse a duplicate __pk instead of overwriting one row with the other

### DIFF
--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -1458,29 +1458,61 @@ converge_columns = ["email", "phone_*"]
         );
     }
 
+    /// Both spellings parse. This pins the serde surface only -- it says nothing
+    /// about the error message; that cross-check is the test below.
     #[test]
-    fn duplicate_pk_parses_the_warn_escape_hatch() {
-        let config: Config = toml::from_str(
-            "local_db = \"game.db\"\n\
-             [sync]\n\
-             duplicate_pk = \"warn\"\n",
-        )
-        .unwrap();
-        assert_eq!(config.sync.duplicate_pk, DuplicatePkPolicy::Warn);
+    fn duplicate_pk_parses_both_spellings() {
+        let parse = |v: &str| -> DuplicatePkPolicy {
+            let config: Config = toml::from_str(&format!(
+                "local_db = \"game.db\"\n[sync]\nduplicate_pk = \"{v}\"\n"
+            ))
+            .unwrap();
+            config.sync.duplicate_pk
+        };
+        assert_eq!(parse("warn"), DuplicatePkPolicy::Warn);
+        assert_eq!(parse("refuse"), DuplicatePkPolicy::Refuse);
     }
 
+    /// The remedy the refusal prints must be a config the parser accepts.
+    ///
+    /// `SyncError::DuplicatePrimaryKey` hardcodes `set [sync] duplicate_pk =
+    /// "warn"` in its message. That string is the operator's only instruction
+    /// for getting unstuck, and nothing structural ties it to the serde
+    /// spelling -- rename the variant or change `rename_all` and the message
+    /// keeps confidently printing an incantation that no longer parses. So this
+    /// lifts the value straight out of the rendered message and feeds it to the
+    /// TOML parser, rather than asserting the two look alike by eye.
     #[test]
-    fn duplicate_pk_refuse_is_spelled_the_way_the_error_message_says() {
-        // The refusal message tells operators to set duplicate_pk = "refuse" /
-        // "warn"; if the serde spelling ever drifts from the message, the
-        // documented remedy stops working.
-        let config: Config = toml::from_str(
-            "local_db = \"game.db\"\n\
-             [sync]\n\
-             duplicate_pk = \"refuse\"\n",
-        )
-        .unwrap();
-        assert_eq!(config.sync.duplicate_pk, DuplicatePkPolicy::Refuse);
+    fn the_remedy_the_refusal_prints_is_a_config_that_actually_parses() {
+        let rendered = SyncError::DuplicatePrimaryKey {
+            table: "items".into(),
+            pk: "1".into(),
+            first_hash: "aaaa".into(),
+            second_hash: "bbbb".into(),
+        }
+        .to_string();
+
+        // Pull the value out of `duplicate_pk = "<value>"` as the message prints it.
+        let marker = "duplicate_pk = \"";
+        let start = rendered
+            .find(marker)
+            .expect("the refusal must tell the operator which key to set")
+            + marker.len();
+        let value = &rendered[start..][..rendered[start..]
+            .find('"')
+            .expect("the remedy value must be quoted")];
+
+        let config: Config = toml::from_str(&format!(
+            "local_db = \"game.db\"\n[sync]\nduplicate_pk = \"{value}\"\n"
+        ))
+        .unwrap_or_else(|e| {
+            panic!("the refusal prints duplicate_pk = \"{value}\", which does not parse: {e}")
+        });
+        assert_eq!(
+            config.sync.duplicate_pk,
+            DuplicatePkPolicy::Warn,
+            "the refusal offers `warn` as the escape hatch, so its printed value must mean Warn"
+        );
     }
 
     // The hash-exclusion union is the invariant every hash producer depends on:

--- a/crates/smugglr-core/src/config.rs
+++ b/crates/smugglr-core/src/config.rs
@@ -192,6 +192,20 @@ pub struct SyncConfig {
     #[serde(default)]
     pub conflict_resolution: ConflictResolution,
 
+    /// What to do when two rows in one table render the same `__pk` (#269).
+    ///
+    /// Defaults to [`DuplicatePkPolicy::Refuse`]. This is distinct from
+    /// [`SyncConfig::conflict_resolution`], which decides between a local and a
+    /// remote row that legitimately share a key: this field is about two rows
+    /// **in the same table on the same node** colliding, which no resolution
+    /// policy can fix because there is no second side to prefer.
+    ///
+    /// Scope: consulted by the diff/sync metadata builders. The multicast
+    /// `on_delta` apply path does not build metadata, so a duplicate arriving
+    /// as a Delta is not covered by this field (#278).
+    #[serde(default)]
+    pub duplicate_pk: DuplicatePkPolicy,
+
     /// Retry policy for transient failures. Flattened into the `[sync]` table,
     /// so the TOML keys stay `max_retries`, `initial_retry_delay_ms`,
     /// `max_retry_delay_ms`, and `backoff_multiplier`. These are the raw
@@ -226,6 +240,7 @@ impl Default for SyncConfig {
             converge_columns: Vec::new(),
             timestamp_column: default_timestamp_column(),
             conflict_resolution: ConflictResolution::default(),
+            duplicate_pk: DuplicatePkPolicy::default(),
             retry: RetryConfig::default(),
             batch_size: default_batch_size(),
             max_statement_bytes: default_max_statement_bytes(),
@@ -439,6 +454,79 @@ fn default_exclude_tables() -> Vec<String> {
 
 fn default_timestamp_column() -> String {
     "updated_at".to_string()
+}
+
+/// What to do when two rows in one table render the same `__pk` text.
+///
+/// # Why this is a refusal and not a warning (#269)
+///
+/// smugglr's identity **is** the primary key -- every path matches rows by the
+/// rendered `__pk`, so the metadata map is keyed by it. Two rows rendering the
+/// same key means the map can only hold one of them: the second silently
+/// evicts the first, and from that moment the evicted row is invisible to the
+/// diff. It is never compared, never transferred, and -- because the
+/// destination is reconciled against a metadata map that does not mention it --
+/// it reads as a row that should not exist.
+///
+/// Under the globally-unique-PK precondition this is not a benign event. A
+/// duplicate `__pk` means two nodes minted the same key for different logical
+/// rows, which is exactly the cross-node data loss the precondition exists to
+/// prevent. Overwriting one with the other **is** the data loss, so the default
+/// is to stop before any row is written rather than to log and continue.
+///
+/// This is the runtime half of the precondition. The structural half (#268)
+/// checks the *declared* primary-key shape at first run; only runtime can see
+/// that actual *values* collide.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DuplicatePkPolicy {
+    /// Stop the sync and return [`SyncError::DuplicatePrimaryKey`], naming the
+    /// colliding key, the table, and both rows' content hashes. Nothing is
+    /// upserted -- the refusal happens while metadata is still being built,
+    /// before the diff runs and before any write is issued.
+    #[default]
+    Refuse,
+    /// Log the collision and keep the pre-#269 behavior: the later row
+    /// overwrites the earlier one in the metadata map and the sync continues.
+    /// The escape hatch for a deployment that cannot fix its keys immediately;
+    /// it does not make the collision safe, it only defers the failure.
+    Warn,
+}
+
+impl DuplicatePkPolicy {
+    /// Decide what a duplicate rendered `__pk` means for this policy.
+    ///
+    /// Returns `Err` under [`DuplicatePkPolicy::Refuse`], and
+    /// `Ok(Some(message))` under [`DuplicatePkPolicy::Warn`] -- the caller
+    /// emits that message on its own sink (`tracing::warn`, `console.warn`, or
+    /// `eprintln`, depending on transport). Both strings are built here so the
+    /// native, wasm, and http-sql builders cannot drift on what a collision
+    /// says, which is the failure mode #231 already hit once on this exact
+    /// code path.
+    ///
+    /// `first_hash` is the content hash of the row already in the map,
+    /// `second_hash` the one that would evict it.
+    pub fn check(
+        self,
+        table: &str,
+        pk: &str,
+        first_hash: &str,
+        second_hash: &str,
+    ) -> Result<Option<String>> {
+        match self {
+            Self::Refuse => Err(SyncError::DuplicatePrimaryKey {
+                table: table.to_string(),
+                pk: pk.to_string(),
+                first_hash: first_hash.to_string(),
+                second_hash: second_hash.to_string(),
+            }),
+            Self::Warn => Ok(Some(format!(
+                "duplicate primary key {pk} in {table} -- a row was overwritten in change \
+                 metadata (kept hash {second_hash}, lost hash {first_hash}). The lost row is \
+                 invisible to this sync. Set [sync] duplicate_pk = \"refuse\" to stop instead."
+            ))),
+        }
+    }
 }
 
 /// How a same-primary-key collision resolves.
@@ -1350,6 +1438,49 @@ converge_columns = ["email", "phone_*"]
             config.sync.hash_excluded_columns(),
             std::borrow::Cow::Borrowed(_)
         ));
+    }
+
+    // #269: absent from the config, duplicate_pk defaults to REFUSE. This is the
+    // shipped-behavior change -- an existing config that never mentioned the key
+    // now refuses a collision it previously overwrote-and-warned through -- so
+    // the default is pinned here rather than left to the derive.
+    #[test]
+    fn duplicate_pk_defaults_to_refuse() {
+        let config: Config = toml::from_str("local_db = \"game.db\"\n").unwrap();
+        assert_eq!(config.sync.duplicate_pk, DuplicatePkPolicy::Refuse);
+        // The Default impl and serde's default must agree; a field added to the
+        // struct without a matching Default arm does not compile, but a
+        // MISMATCHED arm would, and would make behavior depend on how the config
+        // was constructed.
+        assert_eq!(
+            SyncConfig::default().duplicate_pk,
+            DuplicatePkPolicy::Refuse
+        );
+    }
+
+    #[test]
+    fn duplicate_pk_parses_the_warn_escape_hatch() {
+        let config: Config = toml::from_str(
+            "local_db = \"game.db\"\n\
+             [sync]\n\
+             duplicate_pk = \"warn\"\n",
+        )
+        .unwrap();
+        assert_eq!(config.sync.duplicate_pk, DuplicatePkPolicy::Warn);
+    }
+
+    #[test]
+    fn duplicate_pk_refuse_is_spelled_the_way_the_error_message_says() {
+        // The refusal message tells operators to set duplicate_pk = "refuse" /
+        // "warn"; if the serde spelling ever drifts from the message, the
+        // documented remedy stops working.
+        let config: Config = toml::from_str(
+            "local_db = \"game.db\"\n\
+             [sync]\n\
+             duplicate_pk = \"refuse\"\n",
+        )
+        .unwrap();
+        assert_eq!(config.sync.duplicate_pk, DuplicatePkPolicy::Refuse);
     }
 
     // The hash-exclusion union is the invariant every hash producer depends on:

--- a/crates/smugglr-core/src/daemon.rs
+++ b/crates/smugglr-core/src/daemon.rs
@@ -265,6 +265,7 @@ fn _assert_every_variant_is_enumerated_in_retry_verdict_test(err: &SyncError) {
         SyncError::Plugin(_) => {}
         SyncError::Migrate(_) => {}
         SyncError::LedgerTampered(_) => {}
+        SyncError::DuplicatePrimaryKey { .. } => {}
     }
     // No `_` arm above: a new SyncError variant must be added to the match
     // (and to the enumeration test) or this file fails to compile.
@@ -618,6 +619,18 @@ database = "backup.db""#
             (
                 "LedgerTampered",
                 SyncError::LedgerTampered("broken chain".into()),
+                false,
+            ),
+            // Never retryable: re-running the sync re-reads the same two rows
+            // and collides again. Only the operator re-keying a row clears it.
+            (
+                "DuplicatePrimaryKey",
+                SyncError::DuplicatePrimaryKey {
+                    table: "items".into(),
+                    pk: "dup".into(),
+                    first_hash: "aaaa".into(),
+                    second_hash: "bbbb".into(),
+                },
                 false,
             ),
         ];

--- a/crates/smugglr-core/src/error.rs
+++ b/crates/smugglr-core/src/error.rs
@@ -108,6 +108,31 @@ pub enum SyncError {
     #[error("Migrate error: {0}")]
     Migrate(#[from] crate::migrate::MigrateError),
 
+    /// Two rows in one table render the same `__pk` text (#269).
+    ///
+    /// smugglr keys every sync path by the rendered primary key, so a metadata
+    /// map can hold only one of them -- the second evicts the first, and the
+    /// evicted row becomes invisible to the diff. Under the globally-unique-PK
+    /// precondition that means two nodes minted the same key for different
+    /// logical rows, so the sync refuses before any row is upserted rather than
+    /// silently overwriting one with the other. Governed by
+    /// [`crate::config::SyncConfig::duplicate_pk`]; carries both content hashes
+    /// so the operator can identify which two rows collided.
+    #[error(
+        "duplicate primary key '{pk}' in table '{table}': two rows render the same __pk \
+         (content hashes {first_hash} and {second_hash}). smugglr matches rows by primary \
+         key, so continuing would silently drop one of them -- the cross-node data loss \
+         that globally-unique primary keys exist to prevent. No rows were written. Give \
+         the two rows distinct primary keys, or set [sync] duplicate_pk = \"warn\" to \
+         restore the previous overwrite-and-continue behavior."
+    )]
+    DuplicatePrimaryKey {
+        table: String,
+        pk: String,
+        first_hash: String,
+        second_hash: String,
+    },
+
     /// The migration ledger's chain-hash is broken -- an out-of-band
     /// `UPDATE`/`DELETE` altered or removed a `_smugglr_migrations` row. This is
     /// the resurrected `_journal.json` hand-edit failure the ledger exists to
@@ -183,6 +208,12 @@ impl SyncError {
             // failure) need a human decision -- classify as conflict (4), the
             // same bucket the sequencing doc reserves for the migrate bridge.
             SyncError::ConcurrentWrite | SyncError::Migrate(_) | SyncError::LedgerTampered(_) => 4,
+
+            // A duplicate `__pk` is data the operator must reconcile -- smugglr
+            // cannot pick a winner without discarding a row -- so it shares the
+            // conflict bucket (4) rather than reading as a config error. The
+            // remedy is to re-key the rows, not to edit smugglr.toml.
+            SyncError::DuplicatePrimaryKey { .. } => 4,
 
             SyncError::TableNotFound(_)
             | SyncError::RelayNotFound(_)
@@ -376,6 +407,25 @@ mod tests {
             .exit_code(),
             5
         );
+    }
+
+    #[test]
+    fn test_exit_code_duplicate_primary_key() {
+        // #269: a duplicate __pk needs a human to re-key a row -- smugglr cannot
+        // pick a winner without discarding data -- so it shares the conflict
+        // bucket (4). Pinned because exit_code() has a `_ => 1` arm: without an
+        // explicit case the variant would silently read as general/unknown.
+        let err = SyncError::DuplicatePrimaryKey {
+            table: "items".into(),
+            pk: "1".into(),
+            first_hash: "aaaa".into(),
+            second_hash: "bbbb".into(),
+        };
+        assert_eq!(err.exit_code(), 4);
+        // Re-running collides again on the same two rows, so retrying is never
+        // productive. `is_retryable` has a `_ => false` arm; pin the verdict so a
+        // future refactor cannot flip it into the retry loop.
+        assert!(!err.is_retryable());
     }
 
     #[test]

--- a/crates/smugglr-core/src/local.rs
+++ b/crates/smugglr-core/src/local.rs
@@ -1,5 +1,6 @@
 //! Local SQLite database operations
 
+use crate::config::DuplicatePkPolicy;
 use crate::datasource::{ColumnInfo, DataSource, RowMeta, TableInfo};
 use crate::error::{Result, SyncError};
 use crate::table::TableSchema;
@@ -13,11 +14,30 @@ use tracing::{debug, info, warn};
 /// Wrapper for local SQLite database
 pub struct LocalDb {
     conn: Mutex<Connection>,
+    /// What a duplicate rendered `__pk` means when building row metadata.
+    ///
+    /// A field rather than a [`DataSource::get_row_metadata`] parameter: that
+    /// method is also the plugin-SDK wire contract (`table`, `timestamp_column`,
+    /// `exclude_columns` are decoded from a JSON-RPC request), so widening it
+    /// would be a plugin protocol change for every implementor. Defaults to
+    /// [`DuplicatePkPolicy::Refuse`] so a `LocalDb` opened without config is
+    /// safe by default; the CLI overrides it from `[sync].duplicate_pk` via
+    /// [`LocalDb::with_duplicate_pk`].
+    duplicate_pk: DuplicatePkPolicy,
 }
 
 impl LocalDb {
     pub(crate) fn conn(&self) -> MutexGuard<'_, Connection> {
         self.conn.lock().expect("mutex poisoned")
+    }
+
+    /// Set the duplicate-`__pk` policy from `[sync].duplicate_pk`.
+    ///
+    /// Chainable at the open site so `open`/`open_readonly` keep their
+    /// signatures and every caller that does not care keeps the safe default.
+    pub fn with_duplicate_pk(mut self, policy: DuplicatePkPolicy) -> Self {
+        self.duplicate_pk = policy;
+        self
     }
 
     /// Open a local SQLite database
@@ -29,6 +49,7 @@ impl LocalDb {
 
         Ok(Self {
             conn: Mutex::new(conn),
+            duplicate_pk: DuplicatePkPolicy::default(),
         })
     }
 
@@ -41,6 +62,7 @@ impl LocalDb {
 
         Ok(Self {
             conn: Mutex::new(conn),
+            duplicate_pk: DuplicatePkPolicy::default(),
         })
     }
 
@@ -113,7 +135,13 @@ impl DataSource for LocalDb {
         exclude_columns: &[String],
     ) -> Result<HashMap<String, RowMeta>> {
         let conn = self.conn();
-        get_row_metadata_inner(&conn, table, timestamp_column, exclude_columns)
+        get_row_metadata_inner(
+            &conn,
+            table,
+            timestamp_column,
+            exclude_columns,
+            self.duplicate_pk,
+        )
     }
 
     async fn get_rows(
@@ -196,6 +224,7 @@ fn get_row_metadata_inner(
     table: &str,
     timestamp_column: &str,
     exclude_columns: &[String],
+    duplicate_pk: DuplicatePkPolicy,
 ) -> Result<HashMap<String, RowMeta>> {
     let info = table_info_inner(conn, table)?;
     let pk_cols = &info.primary_key;
@@ -222,7 +251,7 @@ fn get_row_metadata_inner(
     debug!("Executing: {}", sql);
 
     let mut stmt = conn.prepare(&sql)?;
-    let mut result = HashMap::new();
+    let mut result: HashMap<String, RowMeta> = HashMap::new();
 
     let mut rows = stmt.query([])?;
     while let Some(row) = rows.next()? {
@@ -260,21 +289,27 @@ fn get_row_metadata_inner(
             None
         };
 
-        if let Some(prev) = result.insert(
+        // Two rows rendering the same PK text means the PK is not unique as
+        // encoded, so the map can keep only one of them. Checked BEFORE the
+        // insert, not after: under `Refuse` this returns while the metadata map
+        // is still being built, which is upstream of the diff and of every
+        // write, so no row is upserted (#269).
+        if let Some(prev) = result.get(&pk_value) {
+            if let Some(message) =
+                duplicate_pk.check(table, &pk_value, &prev.content_hash, &content_hash)?
+            {
+                warn!("{}", message);
+            }
+        }
+
+        result.insert(
             pk_value.clone(),
             RowMeta {
                 pk_value: pk_value.clone(),
                 updated_at,
                 content_hash,
             },
-        ) {
-            // Two rows rendering to the same PK text means the PK is not unique
-            // as encoded -- the metadata map silently lost `prev`. Surface it.
-            warn!(
-                "duplicate primary key {} in {} -- a row was overwritten in change metadata (prev hash {})",
-                pk_value, table, prev.content_hash
-            );
-        }
+        );
     }
 
     debug!("Got {} rows from {}", result.len(), table);
@@ -654,6 +689,137 @@ mod tests {
 
     /// A table shaped like legion's: an ordering key that is the max over three
     /// columns, one of which (`deleted_at`) is NULL on every live row.
+    /// A table holding two DISTINCT rows whose `__pk` renders identically.
+    ///
+    /// The column is declared `BLOB`, so it has SQLite affinity NONE and stores
+    /// each value in the storage class it arrives as. The integer `1` and the
+    /// text `'1'` are different values to the primary-key unique index (SQLite
+    /// orders INTEGER before TEXT, so they never compare equal), which is why
+    /// SQLite accepts both -- but `pk_text_expr` renders a single-column PK as
+    /// `CAST(col AS TEXT)`, and both cast to `"1"`.
+    ///
+    /// This is the real cross-node shape, not a contrivance: node A minted the
+    /// key as a number and node B minted the same key as a string, so the two
+    /// nodes hold different logical rows under one `__pk`. Composite PKs cannot
+    /// reach this state -- `pk_text_expr` escapes the delimiter and is injective.
+    fn colliding_pk_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE items (
+                 id BLOB PRIMARY KEY,
+                 name TEXT,
+                 updated_at TEXT
+             );
+             INSERT INTO items VALUES (1, 'alice', '2026-01-01');
+             INSERT INTO items VALUES ('1', 'bob', '2026-01-02');",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn duplicate_pk_refuses_by_default() {
+        // #269: the default policy stops the sync. Before this, the second row
+        // silently evicted the first from the metadata map and the sync
+        // continued -- the evicted row then read as a row to delete.
+        let conn = colliding_pk_conn();
+
+        let err =
+            get_row_metadata_inner(&conn, "items", "updated_at", &[], DuplicatePkPolicy::Refuse)
+                .expect_err("two rows rendering __pk '1' must refuse under the default policy");
+
+        match err {
+            SyncError::DuplicatePrimaryKey {
+                table,
+                pk,
+                first_hash,
+                second_hash,
+            } => {
+                assert_eq!(table, "items");
+                assert_eq!(pk, "1");
+                // Both hashes must be present and distinct: they are what lets an
+                // operator tell WHICH two rows collided. Reporting one (or the
+                // same one twice) would name the collision without locating it.
+                assert_ne!(
+                    first_hash, second_hash,
+                    "the two colliding rows differ, so their content hashes must differ"
+                );
+                assert!(!first_hash.is_empty() && !second_hash.is_empty());
+            }
+            other => panic!("expected DuplicatePrimaryKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_pk_refusal_names_both_rows_in_its_message() {
+        // The rendered message is the whole remedy surface -- an operator with
+        // only "duplicate primary key" cannot find the two rows. Pin that the
+        // table, the key, and both hashes reach the text a user actually sees.
+        let conn = colliding_pk_conn();
+        let err =
+            get_row_metadata_inner(&conn, "items", "updated_at", &[], DuplicatePkPolicy::Refuse)
+                .expect_err("must refuse");
+        let (first, second) = match &err {
+            SyncError::DuplicatePrimaryKey {
+                first_hash,
+                second_hash,
+                ..
+            } => (first_hash.clone(), second_hash.clone()),
+            other => panic!("expected DuplicatePrimaryKey, got {other:?}"),
+        };
+
+        let msg = err.to_string();
+        assert!(msg.contains("items"), "message must name the table: {msg}");
+        assert!(msg.contains('1'), "message must name the key: {msg}");
+        assert!(
+            msg.contains(&first),
+            "message must carry both hashes: {msg}"
+        );
+        assert!(
+            msg.contains(&second),
+            "message must carry both hashes: {msg}"
+        );
+    }
+
+    #[test]
+    fn duplicate_pk_warn_policy_keeps_the_previous_behavior() {
+        // The escape hatch: `warn` restores pre-#269 overwrite-and-continue, so
+        // a deployment that cannot re-key immediately is not hard-stopped. The
+        // map keeps ONE entry for the colliding key -- that is the data loss the
+        // default now refuses, made explicit here so nobody reads `warn` as safe.
+        let conn = colliding_pk_conn();
+
+        let meta =
+            get_row_metadata_inner(&conn, "items", "updated_at", &[], DuplicatePkPolicy::Warn)
+                .expect("warn policy must not stop the sync");
+
+        assert_eq!(
+            meta.len(),
+            1,
+            "warn keeps the old behavior: the colliding rows collapse onto one entry"
+        );
+        assert!(meta.contains_key("1"));
+    }
+
+    #[test]
+    fn distinct_pks_are_unaffected_by_the_refusal() {
+        // Guard against over-refusing: the default policy must be invisible to
+        // every table whose keys are actually unique, which is all of them.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT, updated_at TEXT);
+             INSERT INTO items VALUES ('a', 'alice', '2026-01-01');
+             INSERT INTO items VALUES ('b', 'bob', '2026-01-02');",
+        )
+        .unwrap();
+
+        let meta =
+            get_row_metadata_inner(&conn, "items", "updated_at", &[], DuplicatePkPolicy::Refuse)
+                .expect("unique keys must not refuse");
+
+        assert_eq!(meta.len(), 2);
+    }
+
     fn ordered_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
@@ -1070,14 +1236,28 @@ mod tests {
             [],
         )
         .unwrap();
-        let before = get_row_metadata_inner(&conn, "rows_t", "updated_at", &[]).unwrap();
+        let before = get_row_metadata_inner(
+            &conn,
+            "rows_t",
+            "updated_at",
+            &[],
+            DuplicatePkPolicy::default(),
+        )
+        .unwrap();
 
         conn.execute(
             "UPDATE rows_t SET deleted_at = '2026-06-01' WHERE id = 'a'",
             [],
         )
         .unwrap();
-        let after = get_row_metadata_inner(&conn, "rows_t", "updated_at", &[]).unwrap();
+        let after = get_row_metadata_inner(
+            &conn,
+            "rows_t",
+            "updated_at",
+            &[],
+            DuplicatePkPolicy::default(),
+        )
+        .unwrap();
 
         assert_ne!(
             before["a"].content_hash, after["a"].content_hash,

--- a/crates/smugglr-core/src/multicast.rs
+++ b/crates/smugglr-core/src/multicast.rs
@@ -642,6 +642,18 @@ impl Gossip {
 
         let local_hashes = match self.row_hashes(local, config, &d.table).await {
             Ok(h) => h,
+            // A duplicate `__pk` is a refusal, not a missing view, and the two
+            // must not share an arm. Treating it as empty would Want every row
+            // the peer advertises and apply them through `on_delta`, which
+            // bypasses the duplicate-`__pk` guard entirely (#269) and is not
+            // itself guarded until #278 -- so swallowing here would turn a
+            // refusal into a full-table pull down the one unguarded path, on
+            // the transport where cross-node key collisions actually originate.
+            // Propagate instead: `recv_and_handle`'s caller logs it at `warn`,
+            // matching how the emission side already reports (`digest_bodies`
+            // propagates with `?`), so a node stops pulling rather than
+            // silently stops advertising while still pulling.
+            Err(e @ SyncError::DuplicatePrimaryKey { .. }) => return Err(e),
             // No local view (e.g. the table is absent on a late joiner) -> treat
             // as empty so we want everything the peer advertises.
             Err(e) => {
@@ -1537,6 +1549,119 @@ mod tests {
             Some("Alice2"),
             "divergent row resolves last-received-wins"
         );
+    }
+
+    /// Seed a table holding two DISTINCT rows whose `__pk` renders identically.
+    ///
+    /// The PK column is declared `BLOB`, so it has SQLite affinity NONE and
+    /// keeps each value in the storage class it arrived as. Integer `1` and
+    /// text `'1'` are different values to the PK unique index (SQLite orders
+    /// INTEGER before TEXT, so they never compare equal), which is why both
+    /// insert -- but `pk_text_expr` renders a single-column PK as
+    /// `CAST(col AS TEXT)` and both render `"1"`. That is the real cross-node
+    /// shape: one node minted the key as a number, another as a string.
+    fn seed_colliding_pk(path: &str) {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE users (id BLOB PRIMARY KEY, name TEXT, updated_at TEXT);
+             INSERT INTO users VALUES (1, 'MintedAsInt', '2026-01-01T00:00:00Z');
+             INSERT INTO users VALUES ('1', 'MintedAsText', '2026-01-02T00:00:00Z');",
+        )
+        .unwrap();
+    }
+
+    /// A node whose own table has a duplicate `__pk` must not answer a peer's
+    /// digest by pulling that peer's rows.
+    ///
+    /// The regression this pins is specific and was introduced by #269 itself.
+    /// `on_digest` used to funnel EVERY `row_hashes` error into one arm written
+    /// for "table absent on a late joiner", which treats the local view as
+    /// empty so the node wants everything advertised. Once #269 made
+    /// `row_hashes` able to fail for a second reason with opposite meaning, a
+    /// node with colliding keys read its own table as empty on every received
+    /// digest, requested every peer row, and applied them through `on_delta` --
+    /// the one path that bypasses the duplicate-`__pk` guard (#278, deferred).
+    /// A refusal became a silent full-table pull down the unguarded path.
+    ///
+    /// The assertion is on the emitted Want payload rather than on the event or
+    /// on the call returning `Err`, because the whole defect is that the wrong
+    /// thing happened while every status reported fine: pre-fix this returns
+    /// `Ok` with a `GossipEvent::Digest` and a Want naming both of A's rows.
+    #[tokio::test]
+    async fn duplicate_pk_node_does_not_pull_peer_rows_on_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+
+        // A is a healthy peer advertising two rows; B's own table collides.
+        seed(&a_path, &[("1", "Alice"), ("2", "Bob")]);
+        seed_colliding_pk(&b_path);
+        let (a, a_cfg, a_local, b, b_cfg, b_local) = two_nodes(&a_path, &b_path).await;
+
+        let digest = only(a.digest_bodies(&a_local, &a_cfg).await.unwrap());
+        let sealed = a.seal(digest).unwrap();
+        let result = b.handle(&sealed, &b_local, &b_cfg).await;
+
+        // Whatever shape the outcome takes, no Want may leave B: it cannot know
+        // which of its rows are missing while its own key space is ambiguous.
+        let bodies = match &result {
+            Ok((_, out)) => out.clone(),
+            Err(_) => Vec::new(),
+        };
+        let wanted: Vec<String> = bodies
+            .iter()
+            .flat_map(|body| match body {
+                Body::Want(w) => w.pks.clone(),
+                _ => Vec::new(),
+            })
+            .collect();
+        assert!(
+            wanted.is_empty(),
+            "a node with a duplicate __pk must not request peer rows -- those \
+             would apply through on_delta, which bypasses the guard; wanted {wanted:?}"
+        );
+
+        // And the refusal must be visible rather than absorbed: the daemon's
+        // recv loop logs this at `warn`, so an operator sees the collision named.
+        match result {
+            Err(SyncError::DuplicatePrimaryKey { table, pk, .. }) => {
+                assert_eq!(table, "users");
+                assert_eq!(pk, "1");
+            }
+            Err(other) => panic!("expected DuplicatePrimaryKey, got {other:?}"),
+            Ok((ev, _)) => panic!("expected the refusal to surface, got event {ev:?}"),
+        }
+    }
+
+    /// The benign cause keeps its old behavior: a late joiner missing the table
+    /// still treats its local view as empty and wants everything. Guards the
+    /// narrowing above from being over-read as "any row_hashes error refuses",
+    /// which would break late-joiner convergence entirely.
+    #[tokio::test]
+    async fn missing_table_still_wants_everything_on_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_path = dir.path().join("a.db").to_str().unwrap().to_string();
+        let b_path = dir.path().join("b.db").to_str().unwrap().to_string();
+
+        seed(&a_path, &[("1", "Alice"), ("2", "Bob")]);
+        // B has a database but not the advertised table at all.
+        rusqlite::Connection::open(&b_path)
+            .unwrap()
+            .execute_batch("CREATE TABLE unrelated (id TEXT PRIMARY KEY);")
+            .unwrap();
+        let (a, a_cfg, a_local, b, b_cfg, b_local) = two_nodes(&a_path, &b_path).await;
+
+        let digest = only(a.digest_bodies(&a_local, &a_cfg).await.unwrap());
+        let (ev, out) = route(&a, digest, &b, &b_local, &b_cfg).await;
+
+        assert!(
+            matches!(ev, GossipEvent::Digest { wanted: 2, .. }),
+            "a late joiner must still want every advertised row, got {ev:?}"
+        );
+        match only(out) {
+            Body::Want(w) => assert_eq!(w.pks.len(), 2),
+            other => panic!("expected a Want, got {other:?}"),
+        }
     }
 
     // Convergence over the ENCRYPTED wire: the same shared key on both nodes.

--- a/crates/smugglr-core/src/stash.rs
+++ b/crates/smugglr-core/src/stash.rs
@@ -4,7 +4,7 @@
 //! The `retrieve` command downloads the relay and syncs it with the local database.
 //! Both use the existing diff engine since both sides are SQLite.
 
-use crate::config::{ConflictResolution, StashConfig};
+use crate::config::{StashConfig, SyncConfig};
 use crate::datasource::DataSource;
 use crate::diff::diff_table;
 use crate::error::{Result, SyncError};
@@ -230,17 +230,20 @@ async fn sync_table<S: DataSource, D: DataSource>(
     source: &S,
     dest: &D,
     table: &str,
-    timestamp_column: &str,
-    conflict_resolution: ConflictResolution,
+    sync: &SyncConfig,
     dry_run: bool,
     label: &str,
     set_count: impl FnOnce(&mut SyncResult, usize),
 ) -> Result<SyncResult> {
-    // Stash operations use empty exclusion lists; column exclusion -- both the
-    // stripped kind and the converge kind -- is applied by the higher-level sync
-    // engine that owns the SyncConfig.
-    let diff = diff_table(source, dest, table, timestamp_column, &[], &[]).await?;
-    diff.warn_unresolved_conflicts(conflict_resolution);
+    // Stash operations still pass EMPTY exclusion lists. The `SyncConfig` is now
+    // in scope, so this is a deliberate hold rather than a plumbing limit:
+    // honoring `exclude_columns` here needs the transfer side sorted out first,
+    // because the apply path binds NULL for an absent column inside
+    // `INSERT OR REPLACE` -- stripping a column on this path would null the
+    // destination's value rather than leave it stale. That is #322's call, not
+    // a line to flip here.
+    let diff = diff_table(source, dest, table, &sync.timestamp_column, &[], &[]).await?;
+    diff.warn_unresolved_conflicts(sync.conflict_resolution);
 
     let (stats, detail) = if dry_run {
         (
@@ -261,7 +264,7 @@ async fn sync_table<S: DataSource, D: DataSource>(
     result.diff_detail = detail;
 
     // Both stash and retrieve use "push" semantics: source-only + source-newer rows go to dest.
-    let rows_to_sync = diff.rows_to_push(conflict_resolution);
+    let rows_to_sync = diff.rows_to_push(sync.conflict_resolution);
 
     if rows_to_sync.is_empty() {
         info!("No changes to sync for table: {}", table);
@@ -400,19 +403,26 @@ fn init_relay_schema(source: &LocalDb, relay_path: &Path) -> Result<()> {
 }
 
 /// Execute the `stash` command: upload local state to S3 relay.
+///
+/// Takes `&SyncConfig` rather than the individual settings it needs. Three of
+/// them (`timestamp_column`, `conflict_resolution`, `exclude_tables`) were
+/// already being pulled apart from that one struct at the call site and passed
+/// back in as scalars, and each new setting this path had to honor widened the
+/// parameter list by one -- which is how it reached seven. Passing the struct
+/// means a setting added to `[sync]` reaches the relay path without another
+/// signature change. `table_filter` and `dry_run` stay separate because they
+/// are per-invocation CLI arguments, not config.
 pub async fn stash(
     config: &StashConfig,
+    sync: &SyncConfig,
     local_db_path: &str,
-    timestamp_column: &str,
-    conflict_resolution: ConflictResolution,
     table_filter: Option<String>,
     dry_run: bool,
-    exclude_tables: &[String],
 ) -> Result<Vec<SyncResult>> {
     let (store, obj_path) = build_store(config)?;
 
     // Open local database (read-only -- we only read from it)
-    let local = LocalDb::open_readonly(local_db_path)?;
+    let local = LocalDb::open_readonly(local_db_path)?.with_duplicate_pk(sync.duplicate_pk);
 
     // Download existing relay (or create new one).
     // IMPORTANT: temp_file must live until end of function -- dropping it deletes the file.
@@ -422,26 +432,23 @@ pub async fn stash(
     // Initialize relay schema from local (creates missing tables)
     init_relay_schema(&local, &relay_path)?;
 
-    // Open relay as writable LocalDb
-    let relay = LocalDb::open(&relay_path)?;
+    // Open relay as writable LocalDb. The relay carries the same policy as the
+    // local side: the diff builds metadata for BOTH, so a relay opened under the
+    // default while the local side honors `warn` would refuse a collision the
+    // local side tolerates, and the knob would read as half-applied.
+    let relay = LocalDb::open(&relay_path)?.with_duplicate_pk(sync.duplicate_pk);
 
     // Determine tables to sync
     let filter_vec: Option<Vec<String>> = table_filter.map(|t| vec![t]);
-    let tables = get_stash_tables(&local, &relay, filter_vec.as_deref(), exclude_tables).await?;
+    let tables =
+        get_stash_tables(&local, &relay, filter_vec.as_deref(), &sync.exclude_tables).await?;
 
     let mut results = Vec::new();
 
     for table in &tables {
-        let result = sync_table(
-            &local,
-            &relay,
-            table,
-            timestamp_column,
-            conflict_resolution,
-            dry_run,
-            "stash",
-            |r, n| r.rows_pushed = n,
-        )
+        let result = sync_table(&local, &relay, table, sync, dry_run, "stash", |r, n| {
+            r.rows_pushed = n
+        })
         .await?;
         results.push(result);
     }
@@ -462,14 +469,14 @@ pub async fn stash(
 }
 
 /// Execute the `retrieve` command: download and sync from S3 relay.
+///
+/// Takes `&SyncConfig` for the same reason as [`stash`] -- see its note.
 pub async fn retrieve(
     config: &StashConfig,
+    sync: &SyncConfig,
     local_db_path: &str,
-    timestamp_column: &str,
-    conflict_resolution: ConflictResolution,
     table_filter: Option<String>,
     dry_run: bool,
-    exclude_tables: &[String],
 ) -> Result<Vec<SyncResult>> {
     let (store, obj_path) = build_store(config)?;
 
@@ -478,29 +485,24 @@ pub async fn retrieve(
     let (temp_file, _etag) = download_relay(store.as_ref(), &obj_path, false).await?;
     let relay_path = temp_file.path().to_path_buf();
 
-    // Open relay as read-only
-    let relay = LocalDb::open_readonly(&relay_path)?;
+    // Open relay as read-only. Both sides carry the same policy -- see the note
+    // on the relay open in `stash`.
+    let relay = LocalDb::open_readonly(&relay_path)?.with_duplicate_pk(sync.duplicate_pk);
 
     // Open local database as writable
-    let local = LocalDb::open(local_db_path)?;
+    let local = LocalDb::open(local_db_path)?.with_duplicate_pk(sync.duplicate_pk);
 
     // Determine tables to sync (relay is source, local is dest)
     let filter_vec: Option<Vec<String>> = table_filter.map(|t| vec![t]);
-    let tables = get_stash_tables(&relay, &local, filter_vec.as_deref(), exclude_tables).await?;
+    let tables =
+        get_stash_tables(&relay, &local, filter_vec.as_deref(), &sync.exclude_tables).await?;
 
     let mut results = Vec::new();
 
     for table in &tables {
-        let result = sync_table(
-            &relay,
-            &local,
-            table,
-            timestamp_column,
-            conflict_resolution,
-            dry_run,
-            "retrieve",
-            |r, n| r.rows_pulled = n,
-        )
+        let result = sync_table(&relay, &local, table, sync, dry_run, "retrieve", |r, n| {
+            r.rows_pulled = n
+        })
         .await?;
         results.push(result);
     }
@@ -511,6 +513,7 @@ pub async fn retrieve(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ConflictResolution;
     use rusqlite::Connection;
     use tempfile::TempDir;
 
@@ -701,12 +704,10 @@ mod tests {
 
         let results = stash(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -756,12 +757,10 @@ mod tests {
 
         let results = retrieve(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -773,6 +772,123 @@ mod tests {
         // Verify local has all 3 rows now
         let items = read_items(&local_path);
         assert_eq!(items.len(), 3);
+    }
+
+    /// Build a local db whose `items` table holds two DISTINCT rows rendering
+    /// the same `__pk`. The PK column is declared `BLOB` (SQLite affinity NONE),
+    /// so integer `1` and text `'1'` keep their storage classes and never
+    /// compare equal to the unique index, but both render `"1"` under
+    /// `CAST(id AS TEXT)`.
+    fn create_colliding_db(path: &Path) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE items (id BLOB PRIMARY KEY, name TEXT NOT NULL, updated_at TEXT);
+             INSERT INTO items VALUES (1, 'MintedAsInt', '2024-01-01');
+             INSERT INTO items VALUES ('1', 'MintedAsText', '2024-01-02');",
+        )
+        .unwrap();
+    }
+
+    fn stash_config_for(relay_dir: &Path) -> StashConfig {
+        StashConfig {
+            url: format!("file://{}/relay.sqlite", relay_dir.display()),
+            access_key_id: None,
+            secret_access_key: None,
+            region: None,
+            endpoint: None,
+        }
+    }
+
+    /// `stash` refuses a duplicate `__pk` under the default policy.
+    ///
+    /// The relay path reaches `diff_table` through this module's own
+    /// `sync_table`, so it needs the guard as much as push/pull do -- and it is
+    /// CLI-reachable (`smugglr stash`).
+    #[tokio::test]
+    async fn stash_refuses_a_duplicate_pk_by_default() {
+        let dir = TempDir::new().unwrap();
+        let local_path = dir.path().join("local.sqlite");
+        let relay_dir = dir.path().join("relay_store");
+        std::fs::create_dir_all(&relay_dir).unwrap();
+        create_colliding_db(&local_path);
+
+        let err = stash(
+            &stash_config_for(&relay_dir),
+            &sync_cfg(ConflictResolution::LocalWins),
+            local_path.to_str().unwrap(),
+            None,
+            false,
+        )
+        .await
+        .expect_err("a duplicate __pk must refuse on the stash path too");
+
+        match err {
+            SyncError::DuplicatePrimaryKey { table, pk, .. } => {
+                assert_eq!(table, "items");
+                assert_eq!(pk, "1");
+            }
+            other => panic!("expected DuplicatePrimaryKey, got {other:?}"),
+        }
+    }
+
+    /// `stash` honors `duplicate_pk = "warn"`.
+    ///
+    /// This is the regression the `&SyncConfig` refactor closes. `stash` and
+    /// `retrieve` built their `LocalDb`s with no policy at all, so they took the
+    /// `Refuse` default unconditionally and silently ignored an operator who had
+    /// set `warn` to keep syncing while re-keying. It failed safe rather than
+    /// unsafe, which is exactly why nothing caught it -- the assertion is that
+    /// the run SUCCEEDS, since a refusal here is indistinguishable from the bug.
+    #[tokio::test]
+    async fn stash_honors_the_warn_policy_from_config() {
+        let dir = TempDir::new().unwrap();
+        let local_path = dir.path().join("local.sqlite");
+        let relay_dir = dir.path().join("relay_store");
+        std::fs::create_dir_all(&relay_dir).unwrap();
+        create_colliding_db(&local_path);
+
+        let mut sync = sync_cfg(ConflictResolution::LocalWins);
+        sync.duplicate_pk = crate::config::DuplicatePkPolicy::Warn;
+
+        let results = stash(
+            &stash_config_for(&relay_dir),
+            &sync,
+            local_path.to_str().unwrap(),
+            None,
+            false,
+        )
+        .await
+        .expect("configured duplicate_pk = warn must be honored on the stash path");
+
+        // The colliding rows collapse onto one entry -- that is what `warn`
+        // means -- so the table still stashes rather than stopping.
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].table, "items");
+    }
+
+    /// `retrieve` honors the policy too: it opens BOTH the relay and the local
+    /// db, and the diff builds metadata for both sides, so a policy applied to
+    /// only one of them would still refuse.
+    #[tokio::test]
+    async fn retrieve_honors_the_warn_policy_from_config() {
+        let dir = TempDir::new().unwrap();
+        let local_path = dir.path().join("local.sqlite");
+        let relay_dir = dir.path().join("relay_store");
+        std::fs::create_dir_all(&relay_dir).unwrap();
+        create_colliding_db(&local_path);
+
+        let mut sync = sync_cfg(ConflictResolution::LocalWins);
+        sync.duplicate_pk = crate::config::DuplicatePkPolicy::Warn;
+        let config = stash_config_for(&relay_dir);
+
+        // Seed the relay by stashing first, then pull it back down.
+        stash(&config, &sync, local_path.to_str().unwrap(), None, false)
+            .await
+            .expect("stash must honor warn");
+
+        retrieve(&config, &sync, local_path.to_str().unwrap(), None, false)
+            .await
+            .expect("configured duplicate_pk = warn must be honored on the retrieve path");
     }
 
     #[tokio::test]
@@ -794,12 +910,10 @@ mod tests {
 
         let results = stash(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             true, // dry run
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -831,12 +945,10 @@ mod tests {
 
         let result = retrieve(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             false,
-            &default_excludes(),
         )
         .await;
 
@@ -873,12 +985,10 @@ mod tests {
         // Only stash the "items" table
         let results = stash(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             Some("items".to_string()),
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -909,12 +1019,10 @@ mod tests {
 
         let results = stash(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -951,12 +1059,10 @@ mod tests {
         // Machine A stashes
         stash(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             machine_a.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -964,12 +1070,10 @@ mod tests {
         // Machine B retrieves
         let results = retrieve(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             machine_b.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -1005,12 +1109,10 @@ mod tests {
 
         let results = retrieve(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             true, // dry run
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -1046,12 +1148,10 @@ mod tests {
 
         let results = stash(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -1090,12 +1190,10 @@ mod tests {
         // NewerWins: relay is newer, so it should win
         let results = retrieve(
             &config,
+            &sync_cfg(ConflictResolution::NewerWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::NewerWins,
             None,
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -1128,12 +1226,10 @@ mod tests {
         // RemoteWins in retrieve context: local (dest) wins, relay changes are NOT applied
         let _results = retrieve(
             &config,
+            &sync_cfg(ConflictResolution::RemoteWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::RemoteWins,
             None,
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -1222,12 +1318,10 @@ mod tests {
         // Should only sync "items" (shared table), skip "extra" (relay-only)
         let results = retrieve(
             &config,
+            &sync_cfg(ConflictResolution::LocalWins),
             local_path.to_str().unwrap(),
-            "updated_at",
-            ConflictResolution::LocalWins,
             None,
             false,
-            &default_excludes(),
         )
         .await
         .unwrap();
@@ -1320,6 +1414,19 @@ mod tests {
         // A's data must survive intact.
         let got = std::fs::read(store_dir.join("relay.sqlite")).unwrap();
         assert_eq!(got, b"machine-a-rows");
+    }
+
+    /// The `[sync]` settings these tests used to pass as loose scalars, now
+    /// assembled into the struct the signature takes. Only `conflict_resolution`
+    /// varies across the suite; `timestamp_column` and `exclude_tables` were the
+    /// same at every call site, which is part of why they belonged in the struct.
+    fn sync_cfg(conflict_resolution: ConflictResolution) -> SyncConfig {
+        SyncConfig {
+            timestamp_column: "updated_at".to_string(),
+            conflict_resolution,
+            exclude_tables: default_excludes(),
+            ..Default::default()
+        }
     }
 
     fn default_excludes() -> Vec<String> {

--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -76,6 +76,12 @@ pub(crate) fn parse_table_info(table: &str, columns: &[String], rows: &[Vec<Valu
 /// Convert result rows (each with a synthetic `__pk` column) into RowMeta
 /// entries keyed by primary key. Used by both full-scan and incremental
 /// metadata fetches.
+///
+/// Returns `Err` when two rows render the same `__pk` and `duplicate_pk` is
+/// [`DuplicatePkPolicy::Refuse`] (#269). Every wasm caller passes the default:
+/// the `[sync].duplicate_pk` knob is native-config-only, because the browser
+/// adapters take their options from JS and never see a `SyncConfig`, so the
+/// browser paths always take the safe default and refuse.
 pub(crate) fn row_maps_to_metadata(
     maps: &[HashMap<String, Value>],
     column_order: &[String],

--- a/crates/smugglr-wasm/src/adapter_common.rs
+++ b/crates/smugglr-wasm/src/adapter_common.rs
@@ -5,6 +5,7 @@
 //! These functions are self-free (no adapter state) so they live here once
 //! and are called from both adapters as `adapter_common::<fn>`.
 
+use smugglr_core::config::DuplicatePkPolicy;
 use smugglr_core::datasource::{extract_updated_at, ColumnInfo, RowMeta, TableInfo};
 use smugglr_core::error::Result;
 use std::collections::HashMap;
@@ -81,8 +82,9 @@ pub(crate) fn row_maps_to_metadata(
     timestamp_column: &str,
     exclude_columns: &[String],
     table: &str,
-) -> HashMap<String, RowMeta> {
-    let mut result = HashMap::with_capacity(maps.len());
+    duplicate_pk: DuplicatePkPolicy,
+) -> Result<HashMap<String, RowMeta>> {
+    let mut result: HashMap<String, RowMeta> = HashMap::with_capacity(maps.len());
     for row in maps {
         // Parity with core local.rs: a NULL rendered __pk (a NULL part in a
         // composite PK propagates through `||`) cannot key pk-based sync.
@@ -100,26 +102,27 @@ pub(crate) fn row_maps_to_metadata(
         let updated_at = extract_updated_at(row.get(timestamp_column));
         let content_hash = content_hash(row, column_order, exclude_columns, timestamp_column);
 
-        if let Some(prev) = result.insert(
+        // Parity with core local.rs: checked BEFORE the insert so a `Refuse`
+        // returns while metadata is still being built -- upstream of the diff
+        // and of every write, so no row is upserted (#269).
+        if let Some(prev) = result.get(&pk) {
+            if let Some(message) =
+                duplicate_pk.check(table, &pk, &prev.content_hash, &content_hash)?
+            {
+                web_sys::console::warn_1(&format!("smugglr: {}", message).into());
+            }
+        }
+
+        result.insert(
             pk.clone(),
             RowMeta {
                 pk_value: pk.clone(),
                 updated_at,
                 content_hash,
             },
-        ) {
-            // Two rows rendering to the same PK text means the PK is not unique
-            // as encoded -- the metadata map silently lost `prev`. Surface it.
-            web_sys::console::warn_1(
-                &format!(
-                    "smugglr: duplicate primary key {} in {} -- a row was overwritten in change metadata (prev hash {})",
-                    pk, table, prev.content_hash
-                )
-                .into(),
-            );
-        }
+        );
     }
-    result
+    Ok(result)
 }
 
 /// Canonicalize every declared BLOB column across `maps` from the backend's
@@ -218,6 +221,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use smugglr_core::error::SyncError;
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[wasm_bindgen_test]
@@ -255,7 +259,9 @@ mod tests {
             "updated_at",
             &[],
             "items",
-        );
+            DuplicatePkPolicy::default(),
+        )
+        .expect("single row cannot collide");
 
         assert_eq!(
             meta.get("k1").expect("row keyed by __pk").updated_at,
@@ -277,12 +283,82 @@ mod tests {
         b.insert("__pk".to_string(), Value::Null);
         b.insert("name".to_string(), Value::String("bob".to_string()));
 
-        let meta = row_maps_to_metadata(&[a, b], &["name".to_string()], "updated_at", &[], "items");
+        let meta = row_maps_to_metadata(
+            &[a, b],
+            &["name".to_string()],
+            "updated_at",
+            &[],
+            "items",
+            DuplicatePkPolicy::default(),
+        )
+        .expect("NULL __pk rows are skipped, so no duplicate can be detected");
 
         assert!(
             meta.is_empty(),
             "NULL-__pk rows must be skipped, not collapsed onto one key; got {} entries",
             meta.len()
+        );
+    }
+
+    /// Two row maps rendering the same `__pk`, the wasm mirror of the native
+    /// and plugin collision tests. All three builders must reach the same
+    /// verdict or the guard is transport-dependent -- which is the failure
+    /// shape #231 already hit on this exact code path.
+    fn colliding_maps() -> Vec<HashMap<String, Value>> {
+        let mut a = HashMap::new();
+        a.insert("__pk".to_string(), Value::String("1".to_string()));
+        a.insert("name".to_string(), Value::String("alice".to_string()));
+        let mut b = HashMap::new();
+        b.insert("__pk".to_string(), Value::String("1".to_string()));
+        b.insert("name".to_string(), Value::String("bob".to_string()));
+        vec![a, b]
+    }
+
+    #[wasm_bindgen_test]
+    fn duplicate_pk_refuses_by_default() {
+        // #269 wasm path. The browser adapters have no SyncConfig, so they take
+        // the default -- this pins that the default is Refuse, not Warn.
+        let err = row_maps_to_metadata(
+            &colliding_maps(),
+            &["name".to_string()],
+            "updated_at",
+            &[],
+            "items",
+            DuplicatePkPolicy::default(),
+        )
+        .expect_err("two rows sharing __pk must refuse");
+
+        match err {
+            SyncError::DuplicatePrimaryKey {
+                table,
+                pk,
+                first_hash,
+                second_hash,
+            } => {
+                assert_eq!(table, "items");
+                assert_eq!(pk, "1");
+                assert_ne!(first_hash, second_hash);
+            }
+            other => panic!("expected DuplicatePrimaryKey, got {other:?}"),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn duplicate_pk_warn_policy_keeps_the_previous_behavior() {
+        let meta = row_maps_to_metadata(
+            &colliding_maps(),
+            &["name".to_string()],
+            "updated_at",
+            &[],
+            "items",
+            DuplicatePkPolicy::Warn,
+        )
+        .expect("warn must not stop the sync");
+
+        assert_eq!(
+            meta.len(),
+            1,
+            "warn collapses the collision, as it did before"
         );
     }
 }

--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -3,6 +3,7 @@
 //! Implements the DataSource trait from smugglr-core using web-sys fetch
 //! instead of reqwest. Shares profile definitions with the native http-sql plugin.
 
+use smugglr_core::config::DuplicatePkPolicy;
 use smugglr_core::datasource::{DataSource, RowMeta, TableInfo};
 use smugglr_core::error::{Result, SyncError};
 use smugglr_core::profile::{AuthFormat, Profile};
@@ -220,13 +221,17 @@ impl FetchDataSource {
         let mut maps = adapter_common::rows_to_maps(&columns, &rows);
         adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
-        Ok(adapter_common::row_maps_to_metadata(
+        // The `[sync].duplicate_pk` knob is native-config-only -- the wasm
+        // adapters take their options from JS and never see a SyncConfig -- so
+        // the browser paths always take the safe default and refuse (#269).
+        adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
             timestamp_column,
             exclude_columns,
             table,
-        ))
+            DuplicatePkPolicy::default(),
+        )
     }
 
     async fn cached_table_info(&self, table: &str) -> Result<TableInfo> {
@@ -295,13 +300,17 @@ impl DataSource for FetchDataSource {
         let mut maps = adapter_common::rows_to_maps(&columns, &rows);
         adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
-        Ok(adapter_common::row_maps_to_metadata(
+        // The `[sync].duplicate_pk` knob is native-config-only -- the wasm
+        // adapters take their options from JS and never see a SyncConfig -- so
+        // the browser paths always take the safe default and refuse (#269).
+        adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
             timestamp_column,
             exclude_columns,
             table,
-        ))
+            DuplicatePkPolicy::default(),
+        )
     }
 
     async fn get_rows(

--- a/crates/smugglr-wasm/src/fetch_adapter.rs
+++ b/crates/smugglr-wasm/src/fetch_adapter.rs
@@ -221,9 +221,6 @@ impl FetchDataSource {
         let mut maps = adapter_common::rows_to_maps(&columns, &rows);
         adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
-        // The `[sync].duplicate_pk` knob is native-config-only -- the wasm
-        // adapters take their options from JS and never see a SyncConfig -- so
-        // the browser paths always take the safe default and refuse (#269).
         adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
@@ -300,9 +297,6 @@ impl DataSource for FetchDataSource {
         let mut maps = adapter_common::rows_to_maps(&columns, &rows);
         adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
-        // The `[sync].duplicate_pk` knob is native-config-only -- the wasm
-        // adapters take their options from JS and never see a SyncConfig -- so
-        // the browser paths always take the safe default and refuse (#269).
         adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -114,9 +114,6 @@ impl LocalSqlDataSource {
         let mut maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
         adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
-        // The `[sync].duplicate_pk` knob is native-config-only -- the wasm
-        // adapters take their options from JS and never see a SyncConfig -- so
-        // the browser paths always take the safe default and refuse (#269).
         adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
@@ -190,9 +187,6 @@ impl DataSource for LocalSqlDataSource {
         let mut maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
         adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
-        // The `[sync].duplicate_pk` knob is native-config-only -- the wasm
-        // adapters take their options from JS and never see a SyncConfig -- so
-        // the browser paths always take the safe default and refuse (#269).
         adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,

--- a/crates/smugglr-wasm/src/local_adapter.rs
+++ b/crates/smugglr-wasm/src/local_adapter.rs
@@ -6,6 +6,7 @@
 //! better-sqlite3 (Node), official sqlite-wasm, or sql.js without
 //! changes here.
 
+use smugglr_core::config::DuplicatePkPolicy;
 use smugglr_core::datasource::{DataSource, RowMeta, TableInfo};
 use smugglr_core::error::{Result, SyncError};
 use std::collections::HashMap;
@@ -113,13 +114,17 @@ impl LocalSqlDataSource {
         let mut maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
         adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
-        Ok(adapter_common::row_maps_to_metadata(
+        // The `[sync].duplicate_pk` knob is native-config-only -- the wasm
+        // adapters take their options from JS and never see a SyncConfig -- so
+        // the browser paths always take the safe default and refuse (#269).
+        adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
             timestamp_column,
             exclude_columns,
             table,
-        ))
+            DuplicatePkPolicy::default(),
+        )
     }
 
     async fn cached_table_info(&self, table: &str) -> Result<TableInfo> {
@@ -185,13 +190,17 @@ impl DataSource for LocalSqlDataSource {
         let mut maps = adapter_common::rows_to_maps(&result.columns, &result.rows);
         adapter_common::canonicalize_json_blobs(&mut maps, &info);
 
-        Ok(adapter_common::row_maps_to_metadata(
+        // The `[sync].duplicate_pk` knob is native-config-only -- the wasm
+        // adapters take their options from JS and never see a SyncConfig -- so
+        // the browser paths always take the safe default and refuse (#269).
+        adapter_common::row_maps_to_metadata(
             &maps,
             &column_order,
             timestamp_column,
             exclude_columns,
             table,
-        ))
+            DuplicatePkPolicy::default(),
+        )
     }
 
     async fn get_rows(

--- a/crates/smugglr/src/broadcast.rs
+++ b/crates/smugglr/src/broadcast.rs
@@ -54,7 +54,9 @@ pub async fn run_broadcast(
         DEFAULT_GROUP, broadcast_config.port, interval_secs, instance_id, dry_run
     );
 
-    let local = Arc::new(LocalDb::open(config.local_db_path())?);
+    let local = Arc::new(
+        LocalDb::open(config.local_db_path())?.with_duplicate_pk(config.sync.duplicate_pk),
+    );
 
     if dry_run {
         // Advertise nothing, apply nothing -- just report what we would gossip.

--- a/crates/smugglr/src/main.rs
+++ b/crates/smugglr/src/main.rs
@@ -1045,12 +1045,10 @@ async fn run_stash(
 
     let results = smugglr_core::stash::stash(
         stash_config,
+        &config.sync,
         config.local_db_path(),
-        &config.sync.timestamp_column,
-        config.sync.conflict_resolution,
         table,
         dry_run,
-        &config.sync.exclude_tables,
     )
     .await?;
 
@@ -1070,12 +1068,10 @@ async fn run_retrieve(
 
     let results = smugglr_core::stash::retrieve(
         stash_config,
+        &config.sync,
         config.local_db_path(),
-        &config.sync.timestamp_column,
-        config.sync.conflict_resolution,
         table,
         dry_run,
-        &config.sync.exclude_tables,
     )
     .await?;
 

--- a/crates/smugglr/src/main.rs
+++ b/crates/smugglr/src/main.rs
@@ -17,7 +17,7 @@ use output::{
     SnapshotTableInfo, Status, StatusConfig, StatusDb, StatusOutput, StatusTable,
 };
 use serde_json::Value as JsonValue;
-use smugglr_core::config::{Config, ResolvedTarget};
+use smugglr_core::config::{Config, DuplicatePkPolicy, ResolvedTarget};
 use smugglr_core::datasource::{DataSource, RowMeta, TableInfo};
 use smugglr_core::diff::diff_table;
 use smugglr_core::error;
@@ -94,7 +94,18 @@ enum TargetSource {
 impl TargetSource {
     /// Open the resolved target. `writable` selects read-write vs read-only for
     /// SQLite targets (plugins manage their own access mode).
-    async fn open(target: &ResolvedTarget, writable: bool) -> error::Result<Self> {
+    ///
+    /// `duplicate_pk` comes from `[sync].duplicate_pk` and must match the policy
+    /// the local side was opened with: the diff builds metadata for BOTH sides,
+    /// so a target opened with a different policy would refuse a collision the
+    /// local side tolerates (or vice versa) and the knob would read as
+    /// half-applied (#269). Plugin targets are unaffected -- the plugin wire
+    /// request carries no policy, so they always refuse.
+    async fn open(
+        target: &ResolvedTarget,
+        writable: bool,
+        duplicate_pk: DuplicatePkPolicy,
+    ) -> error::Result<Self> {
         match target {
             ResolvedTarget::Sqlite { database } => {
                 let db = if writable {
@@ -102,7 +113,7 @@ impl TargetSource {
                 } else {
                     LocalDb::open_readonly(database)?
                 };
-                Ok(TargetSource::Sqlite(db))
+                Ok(TargetSource::Sqlite(db.with_duplicate_pk(duplicate_pk)))
             }
             ResolvedTarget::Plugin {
                 path,
@@ -607,7 +618,8 @@ async fn run_push(
     fmt: OutputFormat,
     verbose: bool,
 ) -> error::Result<()> {
-    let local = LocalDb::open_readonly(config.local_db_path())?;
+    let local =
+        LocalDb::open_readonly(config.local_db_path())?.with_duplicate_pk(config.sync.duplicate_pk);
     let tables = resolve_tables(&local, table)?;
     let progress = make_progress(fmt);
 
@@ -615,7 +627,7 @@ async fn run_push(
         ResolvedTarget::Sqlite { database } => info!("Push mode: local -> SQLite ({})", database),
         ResolvedTarget::Plugin { name, .. } => info!("Push mode: local -> plugin ({})", name),
     }
-    let target = TargetSource::open(&target, true).await?;
+    let target = TargetSource::open(&target, true, config.sync.duplicate_pk).await?;
     let results = push_all(&local, &target, config, tables, dry_run, progress.as_ref()).await?;
 
     emit_command_output(fmt, "push", &results, dry_run, verbose, |r| r.rows_pushed);
@@ -631,9 +643,9 @@ async fn run_pull(
     verbose: bool,
 ) -> error::Result<()> {
     let local = if dry_run {
-        LocalDb::open_readonly(config.local_db_path())?
+        LocalDb::open_readonly(config.local_db_path())?.with_duplicate_pk(config.sync.duplicate_pk)
     } else {
-        LocalDb::open(config.local_db_path())?
+        LocalDb::open(config.local_db_path())?.with_duplicate_pk(config.sync.duplicate_pk)
     };
     let tables = resolve_tables(&local, table)?;
     let progress = make_progress(fmt);
@@ -643,7 +655,7 @@ async fn run_pull(
         ResolvedTarget::Plugin { name, .. } => info!("Pull mode: plugin ({}) -> local", name),
     }
     // Pull reads from the target, so it is opened read-only.
-    let target = TargetSource::open(&target, false).await?;
+    let target = TargetSource::open(&target, false, config.sync.duplicate_pk).await?;
     let results = pull_all(&local, &target, config, tables, dry_run, progress.as_ref()).await?;
 
     emit_command_output(fmt, "pull", &results, dry_run, verbose, |r| r.rows_pulled);
@@ -659,9 +671,9 @@ async fn run_sync(
     verbose: bool,
 ) -> error::Result<()> {
     let local = if dry_run {
-        LocalDb::open_readonly(config.local_db_path())?
+        LocalDb::open_readonly(config.local_db_path())?.with_duplicate_pk(config.sync.duplicate_pk)
     } else {
-        LocalDb::open(config.local_db_path())?
+        LocalDb::open(config.local_db_path())?.with_duplicate_pk(config.sync.duplicate_pk)
     };
     let tables = resolve_tables(&local, table)?;
     let progress = make_progress(fmt);
@@ -674,7 +686,7 @@ async fn run_sync(
             info!("Sync mode: bidirectional (local <-> plugin {})", name)
         }
     }
-    let target = TargetSource::open(&target, true).await?;
+    let target = TargetSource::open(&target, true, config.sync.duplicate_pk).await?;
     let results = sync_all(&local, &target, config, tables, dry_run, progress.as_ref()).await?;
 
     // JSON output is identical to the other commands; only sync's text summary
@@ -712,8 +724,9 @@ async fn run_diff(
     fmt: OutputFormat,
 ) -> error::Result<()> {
     info!("Computing differences...");
-    let local = LocalDb::open_readonly(config.local_db_path())?;
-    let remote = TargetSource::open(&target, false).await?;
+    let local =
+        LocalDb::open_readonly(config.local_db_path())?.with_duplicate_pk(config.sync.duplicate_pk);
+    let remote = TargetSource::open(&target, false, config.sync.duplicate_pk).await?;
 
     let tables = match table {
         Some(t) => {
@@ -910,7 +923,7 @@ async fn run_status(
     };
 
     // Gather target info
-    let target_status = match TargetSource::open(&target, false).await {
+    let target_status = match TargetSource::open(&target, false, config.sync.duplicate_pk).await {
         Ok(remote) => gather_status(&remote, config).await,
         Err(e) => StatusDb {
             connected: false,

--- a/crates/smugglr/src/watch.rs
+++ b/crates/smugglr/src/watch.rs
@@ -68,7 +68,7 @@ pub async fn run_watch(
                         // Mirrors run_sync/run_pull's dry-run-readonly convention: in
                         // dry-run nothing is written (sync_all bails before
                         // transfer_rows), so the target does not need write access.
-                        let target_db = crate::TargetSource::open(&target, !dry_run).await?;
+                        let target_db = crate::TargetSource::open(&target, !dry_run, config.sync.duplicate_pk).await?;
                         sync_all(&local, &target_db, config, None, dry_run, &NoProgress).await
                     }
                     ResolvedTarget::Plugin { .. } => {
@@ -169,11 +169,12 @@ fn format_tick_summary(pushed: usize, pulled: usize, tables: usize, dry_run: boo
 /// diverges from the dry-run-readonly convention `run_sync`/`run_pull`
 /// establish (#217).
 fn open_local(config: &Config, dry_run: bool) -> Result<LocalDb> {
-    if dry_run {
-        LocalDb::open_readonly(config.local_db_path())
+    let db = if dry_run {
+        LocalDb::open_readonly(config.local_db_path())?
     } else {
-        LocalDb::open(config.local_db_path())
-    }
+        LocalDb::open(config.local_db_path())?
+    };
+    Ok(db.with_duplicate_pk(config.sync.duplicate_pk))
 }
 
 #[cfg(test)]
@@ -272,9 +273,13 @@ mod tests {
         };
         let dry_run = true;
 
-        let target_db = crate::TargetSource::open(&target, !dry_run)
-            .await
-            .expect("dry-run target open should succeed");
+        let target_db = crate::TargetSource::open(
+            &target,
+            !dry_run,
+            smugglr_core::config::DuplicatePkPolicy::default(),
+        )
+        .await
+        .expect("dry-run target open should succeed");
         let write = target_db
             .upsert_rows("t", std::slice::from_ref(&sample_row()))
             .await;

--- a/plugins/smugglr-http-sql/src/adapter.rs
+++ b/plugins/smugglr-http-sql/src/adapter.rs
@@ -3,6 +3,8 @@
 use crate::profile::{AuthFormat, Profile};
 use reqwest::Client;
 use serde_json::Value;
+use smugglr_core::config::DuplicatePkPolicy;
+use smugglr_core::error::SyncError;
 use smugglr_plugin_sdk::{ColumnInfo, PluginAdapter, PluginError, RowMeta, TableInfo};
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -275,13 +277,20 @@ impl PluginAdapter for HttpSqlAdapter {
         // Canonicalize BLOB columns (base64 on the wire) to the lowercase hex the
         // content hash pins, so blob columns converge with the native path (#292).
         canonicalize_row_blobs(&mut maps, &info);
-        Ok(build_row_metadata(
+        // The `[sync].duplicate_pk` knob is host-side config; the plugin wire
+        // request carries only (table, timestamp_column, exclude_columns), so
+        // the plugin always takes the safe default and refuses (#269). The
+        // refusal crosses back as a non-transient PluginError, which the host
+        // surfaces as SyncError::Plugin carrying this same message text.
+        build_row_metadata(
             &maps,
             &column_order,
             timestamp_column,
             exclude_columns,
             table,
-        ))
+            DuplicatePkPolicy::default(),
+        )
+        .map_err(|e| PluginError::new(e.to_string()))
     }
 
     async fn get_rows(
@@ -401,8 +410,9 @@ fn build_row_metadata(
     timestamp_column: &str,
     exclude_columns: &[String],
     table: &str,
-) -> HashMap<String, RowMeta> {
-    let mut result = HashMap::new();
+    duplicate_pk: DuplicatePkPolicy,
+) -> Result<HashMap<String, RowMeta>, SyncError> {
+    let mut result: HashMap<String, RowMeta> = HashMap::new();
     for row in maps {
         let pk = match row.get("__pk").and_then(|v| v.as_str()) {
             Some(pk) => pk.to_string(),
@@ -422,21 +432,27 @@ fn build_row_metadata(
             timestamp_column,
         );
 
-        if let Some(prev) = result.insert(
+        // Parity with core local.rs: checked BEFORE the insert so a `Refuse`
+        // returns while metadata is still being built -- upstream of the diff
+        // and of every write, so no row is upserted (#269).
+        if let Some(prev) = result.get(&pk) {
+            if let Some(message) =
+                duplicate_pk.check(table, &pk, &prev.content_hash, &content_hash)?
+            {
+                eprintln!("smugglr-http-sql: {}", message);
+            }
+        }
+
+        result.insert(
             pk.clone(),
             RowMeta {
                 pk_value: pk.clone(),
                 updated_at,
                 content_hash,
             },
-        ) {
-            eprintln!(
-                "smugglr-http-sql: duplicate primary key {} in {} -- a row was overwritten in change metadata (prev hash {})",
-                pk, table, prev.content_hash
-            );
-        }
+        );
     }
-    result
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -456,12 +472,82 @@ mod tests {
         b.insert("__pk".to_string(), Value::Null);
         b.insert("name".to_string(), Value::from("bob"));
 
-        let meta = build_row_metadata(&[a, b], &["name".to_string()], "updated_at", &[], "items");
+        let meta = build_row_metadata(
+            &[a, b],
+            &["name".to_string()],
+            "updated_at",
+            &[],
+            "items",
+            DuplicatePkPolicy::default(),
+        )
+        .expect("NULL __pk rows are skipped, so no duplicate can be detected");
 
         assert!(
             meta.is_empty(),
             "NULL-__pk rows must be skipped, not collapsed onto one key; got {} entries",
             meta.len()
+        );
+    }
+
+    /// Two row maps rendering the same `__pk`. The plugin receives `__pk`
+    /// already rendered by the backend, so the collision arrives as JSON rather
+    /// than being produced by a CAST here -- but it is the same condition the
+    /// native builder refuses, and it must refuse identically or the guard is
+    /// transport-dependent (the #231 failure shape on this exact code path).
+    fn colliding_maps() -> Vec<HashMap<String, Value>> {
+        let mut a = HashMap::new();
+        a.insert("__pk".to_string(), Value::from("1"));
+        a.insert("name".to_string(), Value::from("alice"));
+        let mut b = HashMap::new();
+        b.insert("__pk".to_string(), Value::from("1"));
+        b.insert("name".to_string(), Value::from("bob"));
+        vec![a, b]
+    }
+
+    #[test]
+    fn duplicate_pk_refuses_by_default() {
+        // #269 plugin path: parity with native local.rs.
+        let err = build_row_metadata(
+            &colliding_maps(),
+            &["name".to_string()],
+            "updated_at",
+            &[],
+            "items",
+            DuplicatePkPolicy::Refuse,
+        )
+        .expect_err("two rows sharing __pk must refuse");
+
+        match err {
+            SyncError::DuplicatePrimaryKey {
+                table,
+                pk,
+                first_hash,
+                second_hash,
+            } => {
+                assert_eq!(table, "items");
+                assert_eq!(pk, "1");
+                assert_ne!(first_hash, second_hash);
+            }
+            other => panic!("expected DuplicatePrimaryKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_pk_warn_policy_keeps_the_previous_behavior() {
+        let meta = build_row_metadata(
+            &colliding_maps(),
+            &["name".to_string()],
+            "updated_at",
+            &[],
+            "items",
+            DuplicatePkPolicy::Warn,
+        )
+        .expect("warn must not stop the sync");
+
+        assert_eq!(
+            meta.len(),
+            1,
+            "warn collapses the collision, as it did before"
         );
     }
 
@@ -498,7 +584,15 @@ mod tests {
         native.insert("__pk".to_string(), Value::from("1"));
         native.insert("id".to_string(), Value::from(1));
         native.insert("data".to_string(), Value::from("4865"));
-        let native_meta = build_row_metadata(&[native], &column_order, "updated_at", &[], "t");
+        let native_meta = build_row_metadata(
+            &[native],
+            &column_order,
+            "updated_at",
+            &[],
+            "t",
+            DuplicatePkPolicy::default(),
+        )
+        .expect("single row cannot collide");
 
         // JSON backend (base64) row: diverges until canonicalized.
         let mut json = HashMap::new();
@@ -507,7 +601,15 @@ mod tests {
         json.insert("data".to_string(), Value::from("SGU="));
         let mut maps = vec![json];
 
-        let raw_meta = build_row_metadata(&maps, &column_order, "updated_at", &[], "t");
+        let raw_meta = build_row_metadata(
+            &maps,
+            &column_order,
+            "updated_at",
+            &[],
+            "t",
+            DuplicatePkPolicy::default(),
+        )
+        .expect("single row cannot collide");
         assert_ne!(
             native_meta.get("1").unwrap().content_hash,
             raw_meta.get("1").unwrap().content_hash,
@@ -515,7 +617,15 @@ mod tests {
         );
 
         canonicalize_row_blobs(&mut maps, &info);
-        let json_meta = build_row_metadata(&maps, &column_order, "updated_at", &[], "t");
+        let json_meta = build_row_metadata(
+            &maps,
+            &column_order,
+            "updated_at",
+            &[],
+            "t",
+            DuplicatePkPolicy::default(),
+        )
+        .expect("single row cannot collide");
         assert_eq!(
             native_meta.get("1").unwrap().content_hash,
             json_meta.get("1").unwrap().content_hash,
@@ -530,7 +640,15 @@ mod tests {
         a.insert("__pk".to_string(), Value::from("k1"));
         a.insert("name".to_string(), Value::from("alice"));
 
-        let meta = build_row_metadata(&[a], &["name".to_string()], "updated_at", &[], "items");
+        let meta = build_row_metadata(
+            &[a],
+            &["name".to_string()],
+            "updated_at",
+            &[],
+            "items",
+            DuplicatePkPolicy::default(),
+        )
+        .expect("single row cannot collide");
 
         assert_eq!(meta.len(), 1);
         assert!(meta.contains_key("k1"));


### PR DESCRIPTION
Closes #269.

## Acceptance criteria mapping

- **Criterion 1 -- "A duplicate `__pk` refuses (default) rather than overwriting; error names the collision."** Satisfied by the three-builder flip and the check-before-insert reordering described immediately below; evidence is `local.rs`'s `duplicate_pk_refusal_names_both_rows_in_its_message`, which asserts on rendered message content rather than the enum discriminant, and `test_exit_code_duplicate_primary_key` in `error.rs`.
- **Criterion 2 -- "Tests cover the collision path; clippy + fmt pass."** Satisfied by 12 executing tests across `local.rs`, `config.rs`, `error.rs` and the http-sql adapter, plus 2 compile-verified wasm tests; `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings` and `cargo clippy --target wasm32-unknown-unknown` all clean, 438 core tests passing.

### Criterion 1 in detail

All three metadata builders flip to `Result` in lockstep -- native `local.rs`, wasm `adapter_common.rs`, http-sql `adapter.rs`. The check moved *before* the map insert rather than reading `insert`'s return value, and that ordering is load-bearing in two ways. It is what makes "no rows were written" true rather than aspirational: the builders are pure metadata passes that run upstream of the diff, and `diff_table` awaits both sides with `?`, so the refusal propagates before `push_table`/`pull_table` is ever called for that table. And it is the only way to name *both* hashes -- in the old shape `content_hash` was an owned `String` moved into the `RowMeta` literal that was itself the argument to `insert(...)`, so by the time the eviction branch ran, only the evicted row's hash was still reachable.

The error names the table, the colliding `__pk`, and both rows' content hashes, and prints the remedy:

```
duplicate primary key '1' in table 'items': two rows render the same __pk (content
hashes 6266c25b... and 84bec638...). smugglr matches rows by primary key, so
continuing would silently drop one of them -- the cross-node data loss that
globally-unique primary keys exist to prevent. No rows were written. Give the two
rows distinct primary keys, or set [sync] duplicate_pk = "warn" to restore the
previous overwrite-and-continue behavior.
```

`[sync].duplicate_pk` / `DuplicatePkPolicy` default to `refuse`. Exit code 4 -- "conflict, needs human" -- because the remedy is to re-key the rows, not to edit `smugglr.toml`.

### Criterion 2 in detail

12 executing tests plus 2 compile-verified. `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo clippy --target wasm32-unknown-unknown` all clean; 438 core tests, 0 failures workspace-wide.

## Not done

**It is not full cross-node enforcement, and the changelog must not read as if it were.** This covers the diff/sync metadata-build path only. The multicast gossip `on_delta` path applies rows via `local.upsert_rows_guarded` and never calls `get_row_metadata`, so no builder runs -- a duplicate `__pk` arriving as a Delta is not caught here. That lands with #278, deferred.

Also not done: PK-1, the first-run schema check (#268). And `exclude_columns` is now reachable in `stash.rs` but is deliberately not wired -- that is #322's sequencing problem, since stripping without the receive-side fix would null the destination value. The stale comment there that blamed plumbing has been corrected to say deliberate hold, and why.

## Two defects found during the build, both fixed here

**The refusal was being swallowed into a full-table pull.** `on_digest`'s `Err` arm caught *any* `row_hashes` failure, logged at `debug!`, and substituted an empty local view -- under a comment written for one cause, "table absent on a late joiner." So a broadcast node with a duplicate `__pk` would stop advertising its digest while continuing to receive them, read its own table as empty, Want every row the peer advertised, and apply them through `on_delta` -- the one path that bypasses this very guard. A refusal became a silent full-table pull. Narrowed to match on the variant. Verified non-vacuous by reverting the arm and watching the test fail on the Want payload, not on the event count.

**The knob was half-applied.** `stash()` and `retrieve()` constructed `LocalDb` at four sites with no policy, and their signatures had no parameter to thread -- so `smugglr stash` and `smugglr retrieve` always refused, ignoring a configured `warn`. Fixed by passing `&SyncConfig` rather than adding a seventh scalar parameter, which also removes a future collision with #322 Part B, which needs the same signatures. 7 parameters -> 5, and the 13 test call sites collapsed onto one helper because `timestamp_column` and `exclude_tables` were identical at every one.

## Carried caveat

The 2 `#[wasm_bindgen_test]` collision tests are **compile-verified only, not executed** -- no wasm-pack or headless runner in this environment. They had a line-by-line independent review, which held, but review is not execution. Stated rather than folded into the 438.

Follow-ups filed, none regressions from this change: #332 (the same `on_digest` arm also swallows `NoPrimaryKey`), #333 (the plugin boundary flattens exit code 4 into 1).