### PR TITLE
feat(#296): apply-driver + smugglr migrate apply -- compose lint/capture/apply/ledger

### DIFF
--- a/crates/smugglr-core/src/migrate/driver.rs
+++ b/crates/smugglr-core/src/migrate/driver.rs
@@ -114,7 +114,11 @@ impl Default for ApplyOptions {
 pub struct ApplyOutcome {
     /// The version the driver assigned and elected.
     pub version: u64,
-    /// The manifest checksum the ledger row was claimed under.
+    /// The **manifest's** checksum, copied from `sealed.checksum`. This is not
+    /// re-read from the ledger row and is not always what the row holds: on a
+    /// reclaim the stored checksum is left at the previous manifest's value (see
+    /// [`apply_migration`]'s "Known gap"). Read the row via [`Ledger::entry`]
+    /// when you need the value the ledger actually recorded.
     pub checksum: String,
     /// The election result. Only [`Election::Won`] means this call applied ops.
     pub election: Election,
@@ -146,9 +150,11 @@ pub fn apply_migration_to_file(
 ///
 /// The composition, and why each step sits where it does:
 ///
-/// 1. **Verify the checksum.** The ledger row is claimed under
-///    `sealed.checksum`; electing under a checksum that does not match the body
-///    about to be applied would record a content identity for ops nobody ran.
+/// 1. **Verify the checksum.** [`ChecksummedManifest::verify`] establishes
+///    exactly one thing: the body about to be applied matches the checksum
+///    *travelling with it*, so the manifest was not altered after sealing. It
+///    establishes nothing about the checksum on the ledger row, and the two can
+///    legitimately diverge -- see the note below.
 /// 2. **Ensure the ledger schema**, so a first-ever apply on a fresh database
 ///    does not fail reading a table that has never been created.
 /// 3. **Assign the version.** `current_version + 1`, or 1 on an empty ledger.
@@ -159,14 +165,34 @@ pub fn apply_migration_to_file(
 ///    on `UNIQUE(version)`, so this whole path is portable to a target with no
 ///    interactive transactions.
 /// 5. **Only if won:** lint, then apply, then settle. Everything past the
-///    election is wrapped so that *any* failure -- including a lint refusal --
-///    settles the claimed row as `failed` rather than abandoning it pending for
-///    a whole lease.
+///    election funnels through one settle point, so *any* failure -- a lint
+///    refusal, a failed op, or a failed `mark_success` -- settles the claimed
+///    row as `failed` rather than abandoning it pending for a whole lease. Only
+///    process death escapes the funnel, and the lease expiry covers that.
 ///
 /// The lint runs once over the manifest (both of its gates are manifest-level),
 /// while pre-image capture rides the per-op `pre_op` write-ahead hook
 /// [`apply_ops`] exposes, firing before each op's own transaction so it snapshots
 /// committed, pre-mutation state.
+///
+/// # Known gap: a reclaimed row keeps the previous manifest's checksum
+///
+/// [`Ledger::try_elect`] writes `sealed.checksum` **only** on the fresh-`INSERT`
+/// path. Its two reclaim paths (`reclaim_pending` at `ledger.rs:426`,
+/// `reclaim_failed` at `ledger.rs:442`) take no checksum parameter and their
+/// `UPDATE`s never touch the `checksum` column. So the ordinary fix-and-retry
+/// loop -- apply, fail, edit the manifest, re-apply -- reclaims row `vN` and
+/// settles it `success` while the row still holds the **previous** manifest's
+/// checksum. [`Ledger::verify_chain`] cannot catch it, because the chain is
+/// recomputed from the *stored* checksum: the row is internally consistent and
+/// merely factually wrong, so the tamper-evidence certifies the divergence
+/// rather than flagging it.
+///
+/// This driver cannot close that from the outside -- a checksum-aware reclaim
+/// is the ledger's to own (#272) -- and papering over it here (re-`UPDATE`ing
+/// the checksum after winning) would rewrite a chain-hash input out of band and
+/// trip the very tamper check it is trying to keep honest. Recorded rather than
+/// worked around.
 pub fn apply_migration(
     conn: &Connection,
     sealed: &ChecksummedManifest,
@@ -224,21 +250,32 @@ pub fn apply_migration(
         Ok((classifications, capturer.into_payload()))
     })();
 
-    match attempt {
-        Ok((classifications, payload)) => {
-            Ledger::mark_success(conn, version)?;
-            Ok(ApplyOutcome {
-                version,
-                checksum: sealed.checksum.clone(),
-                election,
-                classifications,
-                preimage: (!payload.is_empty()).then_some(payload),
-            })
-        }
+    // `mark_success` is folded INTO the funnel rather than run after it: a bare
+    // `?` here would leave the row `pending` with a live lease over a fully
+    // mutated database -- the abandoned-pending state this funnel exists to
+    // prevent, and worse than the lint-refusal case, because here the ops
+    // actually ran. Settling `failed` instead is honest about *this run* not
+    // completing, not a claim that nothing applied: apply is idempotent per-op,
+    // so the reclaimer re-drives the ops as no-ops and settles `success`. The
+    // one state that must never survive is a live lease nobody is holding.
+    let settled = attempt.and_then(|applied| {
+        Ledger::mark_success(conn, version)?;
+        Ok(applied)
+    });
+
+    match settled {
+        Ok((classifications, payload)) => Ok(ApplyOutcome {
+            version,
+            checksum: sealed.checksum.clone(),
+            election,
+            classifications,
+            preimage: (!payload.is_empty()).then_some(payload),
+        }),
         Err(e) => {
             // Best-effort settle: leave the row `failed` (and so immediately
             // reclaimable) rather than pending for the rest of the lease. The
-            // original error is what the caller sees.
+            // original error is what the caller sees -- if this settle also
+            // fails, the lease expiry is the backstop.
             let _ = Ledger::mark_failed(conn, version);
             Err(e)
         }
@@ -249,6 +286,7 @@ pub fn apply_migration(
 mod tests {
     use super::*;
     use crate::migrate::ledger::MigrationStatus;
+    use crate::migrate::reverse::{CapturedValue, TablePreimage};
     use crate::migrate::{Column, ColumnKind, Constraint, Flags, Manifest, Op, OpClass, Preimage};
     use rusqlite::OptionalExtension;
     use std::cell::RefCell;
@@ -389,11 +427,16 @@ mod tests {
         assert!(!table_exists(&conn, "users"));
     }
 
+    /// Pins #273's `apply_ops` hook **contract**, not this driver's use of it:
+    /// it drives `apply_ops` directly with its own closure, so it would still
+    /// pass if the driver's capture wiring were deleted. The driver's own
+    /// interleave is covered by
+    /// [`the_driver_interleaves_capture_per_op_before_each_mutates`].
     #[test]
-    fn the_write_ahead_hook_fires_once_per_op_before_it_mutates() {
-        // #289's seam: the hook must see every op, in order, and must observe
-        // pre-mutation state. `users` is created by op 1, so a hook that fires
-        // before op 1 cannot see it and a hook firing before op 2 must.
+    fn the_apply_ops_primitive_fires_the_hook_once_per_op_before_it_mutates() {
+        // The hook must see every op, in order, and must observe pre-mutation
+        // state. `users` is created by op 1, so a hook that fires before op 1
+        // cannot see it and a hook firing before op 2 must.
         let conn = conn();
         let sealed = manifest_with(
             vec![
@@ -418,6 +461,85 @@ mod tests {
 
         // Two ops, two firings, and the second saw the first op's committed effect.
         assert_eq!(seen.into_inner(), vec![false, true]);
+    }
+
+    #[test]
+    fn the_driver_interleaves_capture_per_op_before_each_mutates() {
+        // The composition's own interleave, asserted through `apply_migration`
+        // rather than through `apply_ops`: delete the wiring inside the driver
+        // and this fails. The captured VALUES are the proof of ordering -- a
+        // hook firing after its op would find the column already gone and
+        // capture nothing (or error), so recovering the pre-drop cells can only
+        // happen if the hook ran first. Two destructive ops give one capture
+        // each, in apply order, which is the per-op part.
+        let conn = conn();
+        let mut id = col("id", ColumnKind::Int);
+        id.constraints.push(Constraint::Pk);
+        apply_migration(
+            &conn,
+            &manifest_with(
+                vec![ClassifiedOp::new(Op::CreateTable {
+                    table: "users".into(),
+                    columns: vec![
+                        id,
+                        col("email", ColumnKind::Text),
+                        col("phone", ColumnKind::Text),
+                    ],
+                    without_rowid: false,
+                })],
+                None,
+            ),
+            &ApplyOptions::default(),
+        )
+        .unwrap();
+        conn.execute_batch(
+            "INSERT INTO users (id, email, phone) VALUES (1, 'a@example.com', '555-0100');",
+        )
+        .unwrap();
+
+        let sealed = manifest_with(
+            vec![
+                ClassifiedOp::new(Op::DropColumn {
+                    table: "users".into(),
+                    column: "email".into(),
+                }),
+                ClassifiedOp::new(Op::DropColumn {
+                    table: "users".into(),
+                    column: "phone".into(),
+                }),
+            ],
+            Some(Preimage::Inline {
+                rows: serde_json::json!({ "tables": [] }),
+            }),
+        );
+        let outcome = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap();
+
+        let payload = outcome.preimage.expect("the driver captured a pre-image");
+        assert_eq!(payload.tables.len(), 2, "one capture per destructive op");
+
+        // In apply order, each holding the value its own op was about to lose.
+        let dropped_values: Vec<(String, CapturedValue)> = payload
+            .tables
+            .iter()
+            .map(|t| match t {
+                TablePreimage::Column { dropped, rows, .. } => {
+                    (dropped.clone(), rows[0][1].clone())
+                }
+                other => panic!("expected a dropped-column capture, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            dropped_values,
+            vec![
+                (
+                    "email".to_string(),
+                    CapturedValue::Text("a@example.com".into())
+                ),
+                ("phone".to_string(), CapturedValue::Text("555-0100".into())),
+            ]
+        );
+        assert!(!column_exists(&conn, "users", "email"));
+        assert!(!column_exists(&conn, "users", "phone"));
     }
 
     #[test]
@@ -479,7 +601,17 @@ mod tests {
 
     #[test]
     fn an_under_declared_op_is_refused_before_anything_applies() {
+        // `users` must exist first, or "nothing applied" would hold trivially --
+        // a drop of an absent table leaves the schema unchanged either way, so
+        // the assertion would prove nothing about the lint.
         let conn = conn();
+        apply_migration(
+            &conn,
+            &manifest_with(vec![create_users()], None),
+            &ApplyOptions::default(),
+        )
+        .unwrap();
+
         let sealed = manifest_with(
             vec![ClassifiedOp::declared(
                 Op::DropTable {
@@ -492,7 +624,16 @@ mod tests {
 
         let err = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap_err();
         assert!(err.to_string().contains("under-states"));
-        assert_eq!(Ledger::current_version(&conn).unwrap(), None);
+
+        // Refused *before anything applied*: the table is still there. Checking
+        // only `current_version` would not say that -- it stays 1 under a
+        // ledger-after-apply ordering too, which is the bug this whole design
+        // exists to rule out.
+        assert!(table_exists(&conn, "users"));
+        let entry = Ledger::entry(&conn, 2).unwrap().expect("ledger row");
+        assert_eq!(entry.status, MigrationStatus::Failed);
+        assert_eq!(entry.lease_expires_at, None);
+        assert_eq!(Ledger::current_version(&conn).unwrap(), Some(1));
     }
 
     #[test]

--- a/crates/smugglr-core/src/migrate/driver.rs
+++ b/crates/smugglr-core/src/migrate/driver.rs
@@ -1,3 +1,561 @@
-//! The composing apply-driver (pre-stub). Body lands in #296 -- `smugglr migrate
-//! apply`, which composes lint -> capture -> apply -> ledger into the single
-//! sanctioned apply path. Native-only. Empty until then.
+//! The composing apply-driver (#296): the one sanctioned forward-apply path.
+//!
+//! Every other migrate module is deliberately a single-purpose primitive --
+//! [`ledger`](crate::migrate::ledger) records, [`apply`](crate::migrate::apply)
+//! mutates, [`lint`](crate::migrate::lint) judges, [`reverse`](crate::migrate::reverse)
+//! captures and restores -- and none of them composes. `apply.rs` in particular
+//! is **ledger-free by invariant** (#273): it imports no ledger and resolves no
+//! target. This module is where they are composed, so `apply.rs` never has to
+//! learn about the ledger and the composition never has to be duplicated by a
+//! CLI command or an embedder.
+//!
+//! # The apply lifecycle (`docs/plans/migration.md`, "Apply lifecycle")
+//!
+//! ```text
+//! verify checksum
+//!   -> ensure ledger schema
+//!   -> version = current_version + 1        (the DRIVER assigns it)
+//!   -> [optional reconcile preflight -- #290]
+//!   -> ledger.try_elect(version, checksum)
+//!   -> [only if Won]
+//!        lint_manifest + enforce_preimage
+//!        -> apply_ops(up, pre_op = capture_before)
+//!        -> ledger.mark_success   |   ledger.mark_failed on error
+//! ```
+//!
+//! ## The ledger write is two-phase, and election runs BEFORE apply
+//!
+//! There is no terminal "record the migration" step. Election claims the version
+//! *before* the first byte of the database is mutated, and `mark_success` /
+//! `mark_failed` only settle a row that already exists. That ordering is the
+//! whole point: a ledger written *after* a successful apply would leave a crash
+//! window in which the database has been mutated and the ledger is silent about
+//! it -- the exact unrecoverable state recovery (#289) and reconcile (#290)
+//! exist to avoid. With election first, every crash lands somewhere the ledger
+//! already describes:
+//!
+//! | Crash point | Database | Ledger row | Next run |
+//! |---|---|---|---|
+//! | after `try_elect`, before op 1 | untouched | `pending`, leased | reclaimed once the lease expires, re-driven from op 1 |
+//! | mid-loop | partially mutated | `pending`, leased | reclaimed, re-driven; per-op idempotency skips the applied ops |
+//! | error mid-loop | partially mutated | `failed`, lease cleared | immediately reclaimable, re-driven |
+//! | after the last op, before `mark_success` | fully mutated | `pending`, leased | reclaimed, re-driven as a no-op, then settles `success` |
+//!
+//! In every row of that table [`Ledger::current_version`] is unchanged, because
+//! it keys on `status = 'success'`. A partially-applied version therefore never
+//! advertises itself as applied.
+//!
+//! ## Local only
+//!
+//! 0.5.0 drives a local SQLite target and nothing else. Remote apply is not
+//! runnable: #273 ships D1 / Turso / rqlite as pure statement *generators*, and
+//! the host->target DDL transport is deferred to #291, which will build the
+//! programmatic embedder API **on** [`apply_migration`] rather than beside it.
+//! There must never be a second forward-apply loop.
+
+#![cfg(feature = "native")]
+
+use crate::error::Result;
+use crate::migrate::apply::apply_ops;
+use crate::migrate::ledger::{Election, Ledger, DEFAULT_LEASE_SECS};
+use crate::migrate::lint::{self, Classification};
+use crate::migrate::reverse::{PreimageCapturer, PreimagePayload};
+use crate::migrate::{ChecksummedManifest, ClassifiedOp, MigrateError};
+use rusqlite::{Connection, OpenFlags};
+use std::path::Path;
+use tracing::warn;
+
+/// Knobs for one forward apply.
+///
+/// Two fields are **declared seams, not implemented behaviour** in 0.5.0. They
+/// are here rather than in the later issues so the driver's success path -- a
+/// serialize lane shared with #289 and #290 -- already has the shape those
+/// issues fill in, instead of being reopened for a signature change. Setting
+/// either one logs a warning rather than silently pretending, because a caller
+/// who asked for a snapshot and did not get one is worse off than one who was
+/// told no.
+#[derive(Debug, Clone)]
+pub struct ApplyOptions {
+    /// How long the elected pending row's lease lasts, in seconds. A crash
+    /// inside this window is reclaimable only after it expires.
+    pub lease_secs: i64,
+
+    /// Run the schema-drift preflight before electing.
+    ///
+    /// **Seam for #290.** The projection compare belongs before `try_elect`:
+    /// refusing on drift must not leave a claimed pending row behind.
+    pub reconcile_preflight: bool,
+
+    /// Snapshot the database before mutating it (the coarse recovery parachute).
+    ///
+    /// **Seam for #289.** The `VACUUM INTO` snapshot belongs after the election
+    /// is won and before the lint/apply block, so it captures exactly the state
+    /// a failed apply must be restorable to.
+    pub paranoid: bool,
+}
+
+impl Default for ApplyOptions {
+    fn default() -> Self {
+        Self {
+            lease_secs: DEFAULT_LEASE_SECS,
+            reconcile_preflight: false,
+            paranoid: false,
+        }
+    }
+}
+
+/// What one [`apply_migration`] call did.
+///
+/// `election` is the honest outcome, not an error: losing an election is a
+/// normal masterless result. When it is anything other than [`Election::Won`]
+/// nothing was linted, applied, or captured, so `classifications` is empty and
+/// `preimage` is `None`.
+#[derive(Debug)]
+pub struct ApplyOutcome {
+    /// The version the driver assigned and elected.
+    pub version: u64,
+    /// The manifest checksum the ledger row was claimed under.
+    pub checksum: String,
+    /// The election result. Only [`Election::Won`] means this call applied ops.
+    pub election: Election,
+    /// The effective per-op classification of every applied `up` op, in order
+    /// (the lint's *surfacing* verdict, which honours over-declaration).
+    pub classifications: Vec<Classification>,
+    /// The delta-scoped pre-image captured while destructive ops ran, or `None`
+    /// when nothing destructive applied.
+    pub preimage: Option<PreimagePayload>,
+}
+
+/// Apply a migration to the local SQLite file at `db_path`.
+///
+/// Opens the database read-write **without** `CREATE`, matching
+/// [`LocalDb::open`](crate::local::LocalDb::open): migrating a database that
+/// does not exist is a mistake, not a request to conjure an empty one. Every
+/// other concern is [`apply_migration`]'s; this only owns the connection so a
+/// caller without a `rusqlite` dependency (the CLI) can still drive an apply.
+pub fn apply_migration_to_file(
+    db_path: &Path,
+    sealed: &ChecksummedManifest,
+    opts: &ApplyOptions,
+) -> Result<ApplyOutcome> {
+    let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
+    apply_migration(&conn, sealed, opts)
+}
+
+/// Compose a full forward apply of `sealed` against a local connection.
+///
+/// The composition, and why each step sits where it does:
+///
+/// 1. **Verify the checksum.** The ledger row is claimed under
+///    `sealed.checksum`; electing under a checksum that does not match the body
+///    about to be applied would record a content identity for ops nobody ran.
+/// 2. **Ensure the ledger schema**, so a first-ever apply on a fresh database
+///    does not fail reading a table that has never been created.
+/// 3. **Assign the version.** `current_version + 1`, or 1 on an empty ledger.
+///    The version is the *driver's* to assign, not the manifest's: the
+///    generator (#270) hardcodes `version: 1` on every manifest it scaffolds,
+///    so honouring `manifest.version` would make every migration claim v1.
+/// 4. **Elect.** [`Ledger::try_elect`] is transaction-free and resolves the race
+///    on `UNIQUE(version)`, so this whole path is portable to a target with no
+///    interactive transactions.
+/// 5. **Only if won:** lint, then apply, then settle. Everything past the
+///    election is wrapped so that *any* failure -- including a lint refusal --
+///    settles the claimed row as `failed` rather than abandoning it pending for
+///    a whole lease.
+///
+/// The lint runs once over the manifest (both of its gates are manifest-level),
+/// while pre-image capture rides the per-op `pre_op` write-ahead hook
+/// [`apply_ops`] exposes, firing before each op's own transaction so it snapshots
+/// committed, pre-mutation state.
+pub fn apply_migration(
+    conn: &Connection,
+    sealed: &ChecksummedManifest,
+    opts: &ApplyOptions,
+) -> Result<ApplyOutcome> {
+    sealed.verify()?;
+    let manifest = &sealed.manifest;
+
+    Ledger::ensure_schema(conn)?;
+    let version = Ledger::current_version(conn)?.map_or(1, |v| v + 1);
+
+    if opts.reconcile_preflight {
+        // Seam for #290: the schema-drift compare lands here, before the
+        // election, so a refusal leaves no claimed row behind.
+        warn!(
+            version,
+            "reconcile preflight requested but not implemented until #290; applying without a \
+             drift check"
+        );
+    }
+
+    let election = Ledger::try_elect(conn, version, &sealed.checksum, opts.lease_secs)?;
+    if election != Election::Won {
+        return Ok(ApplyOutcome {
+            version,
+            checksum: sealed.checksum.clone(),
+            election,
+            classifications: Vec::new(),
+            preimage: None,
+        });
+    }
+
+    if opts.paranoid {
+        // Seam for #289: the `VACUUM INTO` snapshot lands here -- after the win,
+        // before the first mutation.
+        warn!(
+            version,
+            "--paranoid requested but the pre-migration snapshot is not implemented until #289; \
+             applying without a parachute"
+        );
+    }
+
+    let attempt = (|| -> Result<(Vec<Classification>, PreimagePayload)> {
+        let classifications =
+            lint::lint_manifest(manifest).map_err(|e| MigrateError::Lint(e.to_string()))?;
+        lint::enforce_preimage(manifest).map_err(|e| MigrateError::Lint(e.to_string()))?;
+
+        let mut capturer = PreimageCapturer::new();
+        {
+            let mut pre_op = |op: &ClassifiedOp| -> std::result::Result<(), MigrateError> {
+                capturer.capture_before(conn, op)
+            };
+            apply_ops(conn, &manifest.up, &mut pre_op)?;
+        }
+        Ok((classifications, capturer.into_payload()))
+    })();
+
+    match attempt {
+        Ok((classifications, payload)) => {
+            Ledger::mark_success(conn, version)?;
+            Ok(ApplyOutcome {
+                version,
+                checksum: sealed.checksum.clone(),
+                election,
+                classifications,
+                preimage: (!payload.is_empty()).then_some(payload),
+            })
+        }
+        Err(e) => {
+            // Best-effort settle: leave the row `failed` (and so immediately
+            // reclaimable) rather than pending for the rest of the lease. The
+            // original error is what the caller sees.
+            let _ = Ledger::mark_failed(conn, version);
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::ledger::MigrationStatus;
+    use crate::migrate::{Column, ColumnKind, Constraint, Flags, Manifest, Op, OpClass, Preimage};
+    use rusqlite::OptionalExtension;
+    use std::cell::RefCell;
+
+    fn col(name: &str, kind: ColumnKind) -> Column {
+        Column {
+            name: name.to_string(),
+            kind,
+            constraints: Vec::new(),
+            tags: Vec::new(),
+        }
+    }
+
+    /// A manifest whose `version` is deliberately the generator's hardcoded 1 --
+    /// the driver is what assigns the real applied version.
+    fn manifest_with(up: Vec<ClassifiedOp>, preimage: Option<Preimage>) -> ChecksummedManifest {
+        ChecksummedManifest::seal(Manifest {
+            version: 1,
+            target_schema: "opaque".into(),
+            up,
+            down: Vec::new(),
+            preimage,
+            flags: Flags::default(),
+            author: None,
+        })
+        .expect("seal manifest")
+    }
+
+    /// `users` carries a real primary key: the delta-scoped pre-image capture
+    /// keys its surgical restore on the PK and refuses a PK-less table.
+    fn create_users() -> ClassifiedOp {
+        let mut id = col("id", ColumnKind::Int);
+        id.constraints.push(Constraint::Pk);
+        ClassifiedOp::new(Op::CreateTable {
+            table: "users".into(),
+            columns: vec![id, col("email", ColumnKind::Text)],
+            without_rowid: false,
+        })
+    }
+
+    fn conn() -> Connection {
+        Connection::open_in_memory().expect("open in-memory db")
+    }
+
+    /// Assert against the live schema rather than the driver's own report, so a
+    /// test cannot pass on a driver that returns the right outcome without
+    /// having mutated anything.
+    fn table_exists(conn: &Connection, table: &str) -> bool {
+        conn.query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [table],
+            |_| Ok(()),
+        )
+        .optional()
+        .expect("query sqlite_master")
+        .is_some()
+    }
+
+    fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA table_info(\"{table}\")"))
+            .expect("prepare table_info");
+        let mut rows = stmt.query([]).expect("query table_info");
+        while let Some(row) = rows.next().expect("read table_info row") {
+            let name: String = row.get(1).expect("column name");
+            if name == column {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn apply_writes_the_ledger_on_a_real_apply() {
+        // The property that makes reconcile (#290) non-hollow: after a real
+        // apply the ledger has a baseline to compare against, so drift is
+        // reportable instead of only "no baseline".
+        let conn = conn();
+        let sealed = manifest_with(vec![create_users()], None);
+
+        let outcome = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap();
+
+        assert_eq!(outcome.election, Election::Won);
+        assert_eq!(outcome.version, 1);
+        assert_eq!(outcome.checksum, sealed.checksum);
+        assert_eq!(Ledger::current_version(&conn).unwrap(), Some(1));
+
+        let entry = Ledger::entry(&conn, 1).unwrap().expect("ledger row");
+        assert_eq!(entry.status, MigrationStatus::Success);
+        assert_eq!(entry.checksum, sealed.checksum);
+        assert_eq!(entry.lease_expires_at, None);
+        // And the ops actually ran.
+        assert!(table_exists(&conn, "users"));
+    }
+
+    #[test]
+    fn driver_assigns_the_version_not_the_manifest() {
+        // Both manifests carry the generator's hardcoded `version: 1`; the
+        // second must still land on v2.
+        let conn = conn();
+        let first = manifest_with(vec![create_users()], None);
+        let second = manifest_with(
+            vec![ClassifiedOp::new(Op::AddColumn {
+                table: "users".into(),
+                column: col("nickname", ColumnKind::Text),
+            })],
+            None,
+        );
+        assert_eq!(first.manifest.version, 1);
+        assert_eq!(second.manifest.version, 1);
+
+        apply_migration(&conn, &first, &ApplyOptions::default()).unwrap();
+        let outcome = apply_migration(&conn, &second, &ApplyOptions::default()).unwrap();
+
+        assert_eq!(outcome.version, 2);
+        assert_eq!(Ledger::current_version(&conn).unwrap(), Some(2));
+    }
+
+    #[test]
+    fn a_held_election_applies_nothing() {
+        // Another node holds a live lease on the version this driver would
+        // claim: the driver reports the outcome and touches neither the schema
+        // nor the lint.
+        let conn = conn();
+        Ledger::ensure_schema(&conn).unwrap();
+        assert_eq!(
+            Ledger::try_elect(&conn, 1, "someone-elses-checksum", 300).unwrap(),
+            Election::Won
+        );
+
+        let sealed = manifest_with(vec![create_users()], None);
+        let outcome = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap();
+
+        assert_eq!(outcome.election, Election::HeldByOther);
+        assert!(outcome.classifications.is_empty());
+        assert!(outcome.preimage.is_none());
+        assert_eq!(Ledger::current_version(&conn).unwrap(), None);
+        assert!(!table_exists(&conn, "users"));
+    }
+
+    #[test]
+    fn the_write_ahead_hook_fires_once_per_op_before_it_mutates() {
+        // #289's seam: the hook must see every op, in order, and must observe
+        // pre-mutation state. `users` is created by op 1, so a hook that fires
+        // before op 1 cannot see it and a hook firing before op 2 must.
+        let conn = conn();
+        let sealed = manifest_with(
+            vec![
+                create_users(),
+                ClassifiedOp::new(Op::AddColumn {
+                    table: "users".into(),
+                    column: col("nickname", ColumnKind::Text),
+                }),
+            ],
+            None,
+        );
+
+        let seen = RefCell::new(Vec::new());
+        let mut capturer = PreimageCapturer::new();
+        {
+            let mut pre_op = |op: &ClassifiedOp| -> std::result::Result<(), MigrateError> {
+                seen.borrow_mut().push(table_exists(&conn, "users"));
+                capturer.capture_before(&conn, op)
+            };
+            apply_ops(&conn, &sealed.manifest.up, &mut pre_op).unwrap();
+        }
+
+        // Two ops, two firings, and the second saw the first op's committed effect.
+        assert_eq!(seen.into_inner(), vec![false, true]);
+    }
+
+    #[test]
+    fn a_failed_apply_marks_the_row_failed_and_does_not_advance_the_version() {
+        // Op 1 succeeds, op 2 renames a table that does not exist. The database
+        // is left partially mutated -- and the ledger says so, which is exactly
+        // the state ledger-after-apply would have hidden.
+        let conn = conn();
+        let sealed = manifest_with(
+            vec![
+                create_users(),
+                ClassifiedOp::new(Op::AddColumn {
+                    table: "ghosts".into(),
+                    column: col("boo", ColumnKind::Text),
+                }),
+            ],
+            None,
+        );
+
+        let err = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap_err();
+        assert_eq!(err.exit_code(), 4);
+
+        let entry = Ledger::entry(&conn, 1).unwrap().expect("ledger row");
+        assert_eq!(entry.status, MigrationStatus::Failed);
+        assert_eq!(entry.lease_expires_at, None);
+        assert_eq!(Ledger::current_version(&conn).unwrap(), None);
+        // Partially applied: op 1 landed, op 2 did not.
+        assert!(table_exists(&conn, "users"));
+    }
+
+    #[test]
+    fn a_lint_refusal_settles_the_claimed_row_rather_than_abandoning_it() {
+        // A destructive op with no pre-image is refused by `enforce_preimage`
+        // *after* the election is won, so the row must not be left pending.
+        let conn = conn();
+        apply_migration(
+            &conn,
+            &manifest_with(vec![create_users()], None),
+            &ApplyOptions::default(),
+        )
+        .unwrap();
+
+        let destructive = manifest_with(
+            vec![ClassifiedOp::new(Op::DropColumn {
+                table: "users".into(),
+                column: "email".into(),
+            })],
+            None,
+        );
+        let err = apply_migration(&conn, &destructive, &ApplyOptions::default()).unwrap_err();
+        assert!(err.to_string().contains("lint refused"));
+
+        let entry = Ledger::entry(&conn, 2).unwrap().expect("ledger row");
+        assert_eq!(entry.status, MigrationStatus::Failed);
+        assert_eq!(Ledger::current_version(&conn).unwrap(), Some(1));
+        // The refused op never ran.
+        assert!(column_exists(&conn, "users", "email"));
+    }
+
+    #[test]
+    fn an_under_declared_op_is_refused_before_anything_applies() {
+        let conn = conn();
+        let sealed = manifest_with(
+            vec![ClassifiedOp::declared(
+                Op::DropTable {
+                    table: "users".into(),
+                },
+                OpClass::Additive,
+            )],
+            None,
+        );
+
+        let err = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap_err();
+        assert!(err.to_string().contains("under-states"));
+        assert_eq!(Ledger::current_version(&conn).unwrap(), None);
+    }
+
+    #[test]
+    fn a_destructive_apply_captures_its_pre_image() {
+        // The manifest must already carry a pre-image to clear `enforce_preimage`
+        // (0.5.0's gate is manifest-level); the capturer is what makes the
+        // reverse honest by snapshotting the rows the drop is about to lose.
+        let conn = conn();
+        apply_migration(
+            &conn,
+            &manifest_with(vec![create_users()], None),
+            &ApplyOptions::default(),
+        )
+        .unwrap();
+        conn.execute_batch("INSERT INTO users (id, email) VALUES (1, 'a@example.com');")
+            .unwrap();
+
+        let sealed = manifest_with(
+            vec![ClassifiedOp::new(Op::DropColumn {
+                table: "users".into(),
+                column: "email".into(),
+            })],
+            Some(Preimage::Inline {
+                rows: serde_json::json!({ "tables": [] }),
+            }),
+        );
+        let outcome = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap();
+
+        assert_eq!(outcome.election, Election::Won);
+        assert_eq!(outcome.version, 2);
+        assert!(outcome.classifications[0].destructive);
+        let payload = outcome
+            .preimage
+            .expect("destructive apply captures a pre-image");
+        assert_eq!(payload.tables.len(), 1);
+        assert!(!column_exists(&conn, "users", "email"));
+    }
+
+    #[test]
+    fn an_additive_apply_captures_nothing() {
+        let conn = conn();
+        let outcome = apply_migration(
+            &conn,
+            &manifest_with(vec![create_users()], None),
+            &ApplyOptions::default(),
+        )
+        .unwrap();
+
+        assert!(outcome.preimage.is_none());
+        assert_eq!(outcome.classifications.len(), 1);
+        assert!(outcome.classifications[0].is_additive());
+    }
+
+    #[test]
+    fn a_tampered_manifest_never_reaches_the_ledger() {
+        let conn = conn();
+        let mut sealed = manifest_with(vec![create_users()], None);
+        sealed.manifest.target_schema = "swapped-after-sealing".into();
+
+        let err = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap_err();
+        assert!(err.to_string().contains("checksum mismatch"));
+        // The ledger schema exists only if `ensure_schema` ran; verification is
+        // ahead of it, so nothing was created and nothing was claimed.
+        assert!(Ledger::current_version(&conn).is_err());
+    }
+}

--- a/crates/smugglr-core/src/migrate/manifest.rs
+++ b/crates/smugglr-core/src/migrate/manifest.rs
@@ -55,6 +55,18 @@ pub enum MigrateError {
     #[error("migration apply failed: {0}")]
     Apply(String),
 
+    /// The destructive-lint refused the manifest at apply time (#275's rail,
+    /// called by the driver #296): an op under-states its structural danger, or
+    /// a destructive op has no captured pre-image so its reverse would be a lie.
+    ///
+    /// Carries the rendered [`crate::migrate::lint::LintError`] rather than the
+    /// typed value: `LintError` is deliberately lint-local (its doc says
+    /// `error.rs` stays untouched and the composing driver bridges it), and
+    /// nesting it here would drag the lint's types into every consumer of this
+    /// enum for no gain -- the rendering already names the offending `up` index.
+    #[error("migration lint refused the manifest: {0}")]
+    Lint(String),
+
     /// Remote apply (D1 / Turso / rqlite) generated its statements but cannot
     /// execute them: the host->target DDL transport does not exist in 0.5.0 and
     /// is deferred to #291. The statement *generators*

--- a/crates/smugglr/src/migrate_cli.rs
+++ b/crates/smugglr/src/migrate_cli.rs
@@ -100,7 +100,11 @@ struct ApplyOutput<'a> {
     status: Status,
     /// The version the driver assigned and claimed in the ledger.
     version: u64,
-    /// The manifest's content identity, as recorded on the ledger row.
+    /// The **applied manifest's** content identity. This is the checksum of the
+    /// file that was just applied, not a read-back of the ledger row's stored
+    /// value -- on a reclaimed row those diverge, because the ledger's reclaim
+    /// paths leave the stored checksum at the previous manifest's value (see
+    /// `driver::apply_migration`'s "Known gap", owned by #272).
     checksum: &'a str,
     /// `won` (this run applied), `already_applied`, or `held_by_other`.
     election: &'static str,

--- a/crates/smugglr/src/migrate_cli.rs
+++ b/crates/smugglr/src/migrate_cli.rs
@@ -6,10 +6,14 @@
 //! generator variant; later issues (#296 apply, #274 reverse, ...) add their
 //! variants HERE.
 
-use crate::output::OutputFormat;
+use crate::output::{OutputFormat, Status};
 use clap::Subcommand;
+use serde::Serialize;
 use smugglr_core::error::{self, SyncError};
+use smugglr_core::migrate::driver::{self, ApplyOptions, ApplyOutcome};
+use smugglr_core::migrate::ledger::Election;
 use smugglr_core::migrate::{generator, ChecksummedManifest};
+use std::path::{Path, PathBuf};
 
 /// Subcommands of `smugglr migrate`.
 #[derive(Subcommand)]
@@ -26,12 +30,47 @@ pub enum MigrateCommand {
         #[arg(value_name = "COLUMN")]
         columns: Vec<String>,
     },
+
+    /// Apply a migration manifest to a local SQLite database.
+    ///
+    /// The applied version is assigned by the ledger, not by the manifest: the
+    /// migration lands as `current_version + 1`, claimed *before* the first op
+    /// runs, and settled success/failed afterwards.
+    ///
+    /// Example:
+    ///   smugglr migrate apply migrations/create_contacts.json --db ./app.db
+    Apply {
+        /// Path to the checksummed manifest JSON (as emitted by `migrate new`).
+        #[arg(value_name = "MANIFEST")]
+        manifest: PathBuf,
+
+        /// The local SQLite database to apply against. Required and explicit --
+        /// migrate commands deliberately run before any config load, so a
+        /// migration applies where you point it, never where a stale
+        /// `config.toml` happens to point.
+        #[arg(long, value_name = "PATH")]
+        db: PathBuf,
+
+        /// Snapshot the database before applying (recovery parachute).
+        ///
+        /// Per-command, not global: the parachute is worth its cost on a
+        /// destructive run and not on a routine additive one. The snapshot
+        /// itself lands with recovery (#289); until then this warns rather than
+        /// silently pretending a snapshot was taken.
+        #[arg(long)]
+        paranoid: bool,
+    },
 }
 
 /// Dispatch a `migrate` subcommand.
 pub fn run(command: &MigrateCommand, fmt: OutputFormat) -> error::Result<()> {
     match command {
         MigrateCommand::New { name, columns } => run_new(name, columns, fmt),
+        MigrateCommand::Apply {
+            manifest,
+            db,
+            paranoid,
+        } => run_apply(manifest, db, *paranoid, fmt),
     }
 }
 
@@ -47,4 +86,215 @@ fn run_new(name: &str, columns: &[String], _fmt: OutputFormat) -> error::Result<
     let json = serde_json::to_string_pretty(&sealed)?;
     println!("{json}");
     Ok(())
+}
+
+/// The JSON rendering of one apply.
+///
+/// Lives here rather than in `output.rs` on purpose: `migrate_cli.rs` is the
+/// declared home for every migrate command (and its output), so the later
+/// migrate commands -- reverse (#274), recover (#289), reconcile (#290) -- add
+/// their shapes beside this one instead of contending for `output.rs`.
+#[derive(Serialize)]
+struct ApplyOutput<'a> {
+    command: &'static str,
+    status: Status,
+    /// The version the driver assigned and claimed in the ledger.
+    version: u64,
+    /// The manifest's content identity, as recorded on the ledger row.
+    checksum: &'a str,
+    /// `won` (this run applied), `already_applied`, or `held_by_other`.
+    election: &'static str,
+    /// How many forward ops ran. Zero unless the election was won.
+    ops_applied: usize,
+    /// Whether any applied op lost data (the lint's surfacing verdict).
+    destructive: bool,
+    /// Whether any applied op rewrites content hashes.
+    hash_rewriting: bool,
+    /// Whether a delta-scoped pre-image was captured for the destructive ops.
+    preimage_captured: bool,
+}
+
+/// `smugglr migrate apply`: read a sealed manifest, drive the one sanctioned
+/// forward-apply composition, report what the ledger now says.
+///
+/// A lost election is **not** an error: on a masterless fabric another node
+/// holding the version, or the version already being applied, is a normal
+/// outcome. It reports as `status: ok` with the election named, and exits 0 --
+/// only a real refusal (a failed checksum, a lint refusal, a failed op) is an
+/// error exit.
+fn run_apply(
+    manifest_path: &Path,
+    db: &Path,
+    paranoid: bool,
+    fmt: OutputFormat,
+) -> error::Result<()> {
+    let raw = std::fs::read(manifest_path)?;
+    let sealed: ChecksummedManifest = serde_json::from_slice(&raw)?;
+
+    let opts = ApplyOptions {
+        paranoid,
+        ..ApplyOptions::default()
+    };
+    let outcome = driver::apply_migration_to_file(db, &sealed, &opts)?;
+
+    match fmt {
+        OutputFormat::Json => {
+            let out = ApplyOutput {
+                command: "migrate apply",
+                status: Status::Ok,
+                version: outcome.version,
+                checksum: &outcome.checksum,
+                election: election_str(outcome.election),
+                ops_applied: outcome.classifications.len(),
+                destructive: any_destructive(&outcome),
+                hash_rewriting: any_hash_rewriting(&outcome),
+                preimage_captured: outcome.preimage.is_some(),
+            };
+            println!("{}", serde_json::to_string(&out)?);
+        }
+        OutputFormat::Text => print_apply_text(&outcome),
+    }
+    Ok(())
+}
+
+/// The wire rendering of an election outcome. A closed match, so a future
+/// [`Election`] variant is a compile error here rather than a silent gap.
+fn election_str(election: Election) -> &'static str {
+    match election {
+        Election::Won => "won",
+        Election::AlreadyApplied => "already_applied",
+        Election::HeldByOther => "held_by_other",
+    }
+}
+
+fn any_destructive(outcome: &ApplyOutcome) -> bool {
+    outcome.classifications.iter().any(|c| c.destructive)
+}
+
+fn any_hash_rewriting(outcome: &ApplyOutcome) -> bool {
+    outcome.classifications.iter().any(|c| c.hash_rewriting)
+}
+
+fn print_apply_text(outcome: &ApplyOutcome) {
+    match outcome.election {
+        Election::Won => {
+            println!(
+                "Applied migration v{} ({} op{}) -- checksum {}",
+                outcome.version,
+                outcome.classifications.len(),
+                if outcome.classifications.len() == 1 {
+                    ""
+                } else {
+                    "s"
+                },
+                outcome.checksum
+            );
+            if any_destructive(outcome) {
+                println!(
+                    "  destructive: pre-image {}",
+                    if outcome.preimage.is_some() {
+                        "captured"
+                    } else {
+                        "NOT captured"
+                    }
+                );
+            }
+            if any_hash_rewriting(outcome) {
+                println!("  hash-rewriting: peers must reach this version before rows converge");
+            }
+        }
+        Election::AlreadyApplied => {
+            println!(
+                "Migration v{} is already applied -- nothing to do",
+                outcome.version
+            );
+        }
+        Election::HeldByOther => {
+            println!(
+                "Migration v{} is held by another node -- back off and retry",
+                outcome.version
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smugglr_core::migrate::{ClassifiedOp, Column, ColumnKind, Flags, Manifest, Op};
+
+    /// Seal a one-op manifest and write it where `run_apply` expects to read it.
+    fn write_manifest(dir: &std::path::Path) -> PathBuf {
+        let manifest = Manifest {
+            // The generator's hardcoded version -- the driver overrides it.
+            version: 1,
+            target_schema: "opaque".into(),
+            up: vec![ClassifiedOp::new(Op::CreateTable {
+                table: "contacts".into(),
+                columns: vec![Column {
+                    name: "id".into(),
+                    kind: ColumnKind::Int,
+                    constraints: vec![],
+                    tags: vec![],
+                }],
+                without_rowid: false,
+            })],
+            down: vec![],
+            preimage: None,
+            flags: Flags::default(),
+            author: None,
+        };
+        let sealed = ChecksummedManifest::seal(manifest).expect("seal");
+        let path = dir.join("create_contacts.json");
+        std::fs::write(&path, serde_json::to_vec(&sealed).expect("serialize")).expect("write");
+        path
+    }
+
+    /// End-to-end through the CLI entry point: a real apply mutates the database
+    /// AND leaves a ledger row, which is the baseline reconcile (#290) compares
+    /// against. Without it, drift detection has nothing to report drift from.
+    #[test]
+    fn apply_mutates_the_database_and_writes_the_ledger() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("app.db");
+        rusqlite::Connection::open(&db).expect("create db");
+        let manifest = write_manifest(dir.path());
+
+        run_apply(&manifest, &db, false, OutputFormat::Json).expect("apply succeeds");
+
+        let conn = rusqlite::Connection::open(&db).expect("reopen db");
+        let table: String = conn
+            .query_row(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'contacts'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("contacts table exists");
+        assert_eq!(table, "contacts");
+
+        let (version, status): (i64, String) = conn
+            .query_row("SELECT version, status FROM _smugglr_migrations", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .expect("ledger row exists");
+        assert_eq!(version, 1);
+        assert_eq!(status, "success");
+    }
+
+    /// Applying against a database that does not exist refuses rather than
+    /// conjuring an empty one and reporting success.
+    #[test]
+    fn apply_refuses_a_missing_database() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = write_manifest(dir.path());
+        let missing = dir.path().join("nope.db");
+
+        let err = run_apply(&manifest, &missing, false, OutputFormat::Text)
+            .expect_err("a missing database is an error");
+        assert!(!missing.exists(), "no database was created");
+        assert!(
+            err.to_string().contains("Local database error"),
+            "unexpected error: {err}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #296.

## Acceptance criteria mapping

- **Criterion 1 -- "`apply_migration` composes a full forward apply on a local target using the ledger's REAL two-phase election protocol."** Satisfied by `driver.rs`'s composition, built to this criterion rather than the issue's stale Requirements prose; evidence is `a_held_election_applies_nothing` and `a_failed_apply_marks_the_row_failed_and_does_not_advance_the_version`, both of which fail under a ledger-after-apply ordering. Detail below.
- **Criterion 2 -- "The per-op write-ahead hook for #289 is the `pre_op` closure passed to `apply_ops`."** Satisfied by the driver composing capture into `pre_op`; evidence is `the_driver_interleaves_capture_per_op_before_each_mutates`, which goes through `apply_migration` and asserts one capture per op in apply order, each holding the value its own op was about to lose. Verified non-vacuous by stubbing `pre_op` to `Ok(())`.
- **Criterion 3 -- "`smugglr migrate apply` in a NEW `migrate_cli.rs`, the SOLE forward-apply path."** Satisfied by the `Apply` variant in `migrate_cli.rs`; `main.rs` is not re-touched, and evidence is the two end-to-end CLI tests including the refusal to conjure a database that does not exist.
- **Criterion 4 -- "`apply.rs` stays ledger-free; the ledger write lives in `driver.rs`."** Satisfied by leaving `apply.rs` untouched -- it is absent from the diff entirely.
- **Criterion 5 -- "Tests: a real apply writes the ledger and interleaves the write-ahead hook per op; clippy + fmt pass."** Satisfied by 11 driver tests and 2 CLI end-to-end tests; fmt, clippy host, clippy `wasm32-unknown-unknown`, 436 core + 32 CLI, 0 failures.

### Criterion 1 in detail

Built to the acceptance criteria, **not** to the issue's Requirements prose, which was stale and described ledger-*after*-apply. That ordering would leave a crash window where the database is mutated and the ledger is silent about it -- precisely the state #289 and #290 exist to clean up. The correction is recorded as a comment on #296.

As built: verify checksum -> ensure ledger schema -> version = `current_version + 1` (the *driver* assigns it; the generator hardcodes `version: 1`, so honouring the manifest would make every migration claim v1 forever) -> reconcile preflight seam -> `try_elect` -> **only if `Election::Won`**: `lint_manifest` + `enforce_preimage` -> pre-image capture -> `apply_ops` -> `mark_success` / `mark_failed`. No terminal `record` step; election precedes apply.

**"The per-op write-ahead hook for #289 is the `pre_op` closure passed to `apply_ops`."**

Wired, and the driver's *use* of it is now tested through `apply_migration` rather than only against the primitive -- two `DropColumn` ops against a seeded table, asserting one capture per op in apply order, each holding the value its own op was about to lose. The captured values are the ordering proof: a hook firing after its op would find the column gone. Verified non-vacuous by stubbing `pre_op` to `Ok(())` and watching it fail.

**"`smugglr migrate apply` in a NEW `migrate_cli.rs`, the SOLE forward-apply path."**

`--db` is required and explicit because migrate commands dispatch *before* the config load every sync command performs -- a migration applies where you point it, never where a stale `config.toml` happens to point. `--paranoid` is a seam only and says so out loud rather than pretending: `WARN --paranoid requested but the pre-migration snapshot is not implemented until #289; applying without a parachute`. A lost election exits 0 with the outcome named -- on a masterless fabric another node holding the version is normal, not an error.

**"`apply.rs` stays ledger-free."** Untouched. The ledger write lives in `driver.rs`.

**"Tests: a real apply writes the ledger; clippy + fmt pass."** 11 driver tests + 2 CLI end-to-end. fmt, clippy host, clippy `wasm32-unknown-unknown`, 436 core + 32 CLI, 0 failures.

## The property that makes #289 and #290 non-hollow

| Crash point | Database | Ledger row | Next run |
|---|---|---|---|
| after `try_elect`, before op 1 | untouched | `pending`, leased | reclaimed on lease expiry, re-driven |
| mid-loop | partly mutated | `pending`, leased | reclaimed, re-driven; per-op guards skip applied ops |
| error mid-loop | partly mutated | `failed`, lease cleared | immediately reclaimable |
| after last op, before `mark_success` | fully mutated | `pending`, leased | re-driven as no-op, settles `success` |

In every state `current_version` is unchanged, because it keys on `status = 'success'`. **A partially-applied version never advertises itself as applied.** Independently verified against the code rather than against the table, including the per-op idempotency claim rows 2 and 4 rest on -- every `Op` variant is guarded.

Everything past a won election funnels through one settle point, `mark_success` included: a failed `mark_success` now reaches `mark_failed` rather than abandoning the row `pending` with a live lease over a fully-mutated database. `failed` is the honest settle -- it says *this run* did not complete, not that nothing applied, and the reclaimer re-drives idempotently.

## Not done

Remote apply is not runnable. #273 ships D1/Turso/rqlite as pure statement generators; the transport is #291, which will build **on** `apply_migration` rather than fork a second loop. Recovery (#289) and reconcile (#290) are seams that warn, not implementations.

## Defects found while building, filed rather than silently repaired

The composition is specified by a settled design, so defects in what it composes were reported instead of patched mid-build: **#325** (re-applying the same manifest claims a new version, making `Election::AlreadyApplied` unreachable), **#326** (the pre-image gate is circular -- a generator-authored destructive manifest can never apply -- and is cleared by an empty placeholder), **#327** (`verify_chain` has no production caller; three docs claim tamper detection that never runs), **#328** (a reclaimed row keeps the previous manifest's checksum, and the chain certifies it).

#328 was found by independent review of this diff, and **two sentences in the original commit asserted it could not happen**. Both are retracted here rather than softened, plus a third instance on `ApplyOutcome::checksum` that the review did not name. A `# Known gap` section now names both reclaim sites, walks the fix-and-retry loop, and explains why the driver does not paper over it: re-`UPDATE`ing the checksum after winning would rewrite a chain-hash input out of band and trip the very tamper check it is trying to keep honest.