### PR TITLE
fix(#326): split the pre-image gate -- authoring honesty at lint, capture guarantee at apply

### DIFF
--- a/crates/smugglr-core/src/migrate/driver.rs
+++ b/crates/smugglr-core/src/migrate/driver.rs
@@ -508,9 +508,9 @@ mod tests {
                     column: "phone".into(),
                 }),
             ],
-            Some(Preimage::Inline {
-                rows: serde_json::json!({ "tables": [] }),
-            }),
+            // See the note in `a_destructive_apply_captures_its_pre_image`: an
+            // absent pre-image is the normal state, and the driver captures.
+            None,
         );
         let outcome = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap();
 
@@ -572,8 +572,15 @@ mod tests {
 
     #[test]
     fn a_lint_refusal_settles_the_claimed_row_rather_than_abandoning_it() {
-        // A destructive op with no pre-image is refused by `enforce_preimage`
-        // *after* the election is won, so the row must not be left pending.
+        // The property: a lint refusal lands *after* the election is won, so the
+        // claimed row must be settled `failed` rather than abandoned pending for a
+        // whole lease. Provoked here by an under-declared op -- a `DropColumn`
+        // declared `additive` -- which is a genuine `lint_manifest` refusal.
+        //
+        // This test previously provoked the refusal with a destructive op carrying
+        // no pre-image. That path was the #326 defect: the gate refused the normal
+        // pre-apply state of every honestly authored destructive manifest, so the
+        // test was resting on the bug it now must not depend on.
         let conn = conn();
         apply_migration(
             &conn,
@@ -582,15 +589,21 @@ mod tests {
         )
         .unwrap();
 
-        let destructive = manifest_with(
-            vec![ClassifiedOp::new(Op::DropColumn {
-                table: "users".into(),
-                column: "email".into(),
-            })],
+        let under_declared = manifest_with(
+            vec![ClassifiedOp::declared(
+                Op::DropColumn {
+                    table: "users".into(),
+                    column: "email".into(),
+                },
+                OpClass::Additive,
+            )],
             None,
         );
-        let err = apply_migration(&conn, &destructive, &ApplyOptions::default()).unwrap_err();
-        assert!(err.to_string().contains("lint refused"));
+        let err = apply_migration(&conn, &under_declared, &ApplyOptions::default()).unwrap_err();
+        assert!(
+            err.to_string().contains("under-states"),
+            "expected an under-declaration refusal, got: {err}"
+        );
 
         let entry = Ledger::entry(&conn, 2).unwrap().expect("ledger row");
         assert_eq!(entry.status, MigrationStatus::Failed);
@@ -656,9 +669,9 @@ mod tests {
                 table: "users".into(),
                 column: "email".into(),
             })],
-            Some(Preimage::Inline {
-                rows: serde_json::json!({ "tables": [] }),
-            }),
+            // `None` is the honest pre-apply state of a destructive manifest: the
+            // capture happens during `apply_ops`, so the body cannot carry one yet.
+            None,
         );
         let outcome = apply_migration(&conn, &sealed, &ApplyOptions::default()).unwrap();
 

--- a/crates/smugglr-core/src/migrate/lint.rs
+++ b/crates/smugglr-core/src/migrate/lint.rs
@@ -11,9 +11,32 @@
 //!   whose declared class understates the danger on some axis. Over-declaration (a
 //!   conservative author declaring an op *more* dangerous than it is) is allowed:
 //!   the rail catches dishonest *understatement*, never caution.
-//! - [`enforce_preimage`] gates the forward apply: a destructive op with no
-//!   captured pre-image **refuses**, because its reverse would be a lie
-//!   (decision 4 -- destructive reverse exists only against a pre-image).
+//! - [`enforce_preimage`] gates the forward apply on what a *manifest body* can
+//!   honestly be judged for before anything runs: it refuses a destructive
+//!   manifest that **claims** a pre-image it does not carry. It deliberately does
+//!   **not** require a pre-image payload to already exist -- see below.
+//!
+//! # The gate runs BEFORE capture, so it cannot check that a pre-image exists
+//!
+//! Pre-image capture happens *during* the forward apply, on the per-op `pre_op`
+//! write-ahead hook
+//! ([`PreimageCapturer::capture_before`](crate::migrate::reverse::PreimageCapturer::capture_before)),
+//! which fires immediately before each op mutates. Every manifest-level gate --
+//! this one included -- necessarily runs before that loop. So at gate time a
+//! freshly-authored destructive manifest has no pre-image *and cannot have one*:
+//! [`Manifest::preimage`] is inside the checksummed body (see
+//! [`Manifest`]'s canonicalization note), so the apply that captures a pre-image
+//! can never write it back into the manifest without changing that manifest's
+//! checksum -- and therefore its ledger identity. The captured payload leaves the
+//! apply through the driver's outcome instead (#296), never through the manifest.
+//!
+//! The requirement "a destructive op does not mutate without a pre-image" is
+//! therefore enforced **per op, at capture time**, by `capture_before` refusing a
+//! destructive op it cannot snapshot -- before the mutation, not after. Wiring
+//! that capture into the loop is what
+//! [`apply_with_capture`](crate::migrate::reverse::apply_with_capture) exists to
+//! make structural. The order is: this gate (is the body honest?) -> per-op
+//! capture (snapshot, or refuse) -> mutation.
 //!
 //! Scope: the lint reasons over the forward `up` path only. The reverse (`down`)
 //! ops are a legitimately-destructive-by-structure inverse (a `DropColumn` undoing
@@ -21,7 +44,9 @@
 //! module provides [`enforce_preimage`] but does **not** wire it into apply -- the
 //! composing driver (#296) is what calls the rail at apply time.
 
-use crate::migrate::{Manifest, Op, OpClass};
+use crate::migrate::reverse::PreimagePayload;
+use crate::migrate::{Manifest, Op, OpClass, Preimage};
+use serde::Deserialize;
 use thiserror::Error;
 
 /// The two independent safety axes of a single op.
@@ -126,10 +151,19 @@ pub enum LintError {
         derived: Classification,
     },
 
-    /// A destructive op has no captured pre-image, so its reverse would lose data
-    /// irrecoverably. Apply must refuse until a pre-image is captured (decision 5).
-    #[error("up[{index}]: destructive op refused -- no pre-image captured")]
-    MissingPreimage {
+    /// A destructive manifest carries a [`Preimage`] that holds no capture at all
+    /// -- an empty `Inline` placeholder, an unparseable one, or a `Ref` with a
+    /// blank key. The body claims a pre-image exists somewhere; it does not.
+    ///
+    /// This is the *dishonest-body* refusal, and it is the only pre-image verdict
+    /// a manifest-level gate can honestly reach: see the module docs on why
+    /// "the field is absent" is the **normal** state of a destructive manifest
+    /// awaiting apply, not a violation.
+    #[error(
+        "up[{index}]: destructive op refused -- the manifest carries a pre-image that holds no \
+         capture (an empty placeholder claims a snapshot that does not exist)"
+    )]
+    PlaceholderPreimage {
         /// Index into the manifest's `up` list.
         index: usize,
     },
@@ -173,32 +207,81 @@ pub fn lint_manifest(manifest: &Manifest) -> Result<Vec<Classification>, LintErr
     Ok(classifications)
 }
 
-/// Refuse the forward apply of any destructive op that has no captured pre-image.
+/// Refuse the forward apply of a destructive manifest whose carried pre-image is
+/// a placeholder holding no capture.
+///
+/// # Ordering: this runs before capture, and is scoped to what that allows
+///
+/// This is the pre-apply gate, so it runs **before** the apply loop in which
+/// pre-images are captured (module docs, "The gate runs BEFORE capture"). Two
+/// consequences define its whole contract:
+///
+/// - `manifest.preimage == None` on a destructive manifest is **not** a refusal.
+///   It is the expected state of every honestly-authored destructive migration
+///   awaiting its first apply: nothing has captured yet, and nothing *can* write
+///   a capture into the checksummed body afterwards. Refusing it made the honest
+///   path unrunnable while stopping nothing (#326).
+/// - `manifest.preimage == Some(placeholder)` **is** a refusal. A body that
+///   asserts a pre-image while carrying no capture is a lie, and it is exactly the
+///   bypass an author reached for while the absent-field refusal was in force. A
+///   [`Preimage::Inline`] whose payload holds no [`crate::migrate::reverse::TablePreimage`]
+///   (`{"tables": []}`, `null`, anything that will not deserialize) and a
+///   [`Preimage::Ref`] with a blank key all fail here. Note that a *present*
+///   capture with zero captured rows is legitimate -- dropping a column of an
+///   empty table loses no rows -- so the test is "is there a capture", never
+///   "are there rows".
+///
+/// The guarantee that a destructive op does not mutate without a snapshot is
+/// enforced per-op at capture time by
+/// [`PreimageCapturer::capture_before`](crate::migrate::reverse::PreimageCapturer::capture_before),
+/// which refuses before the mutation; wiring that hook into the loop is what
+/// [`apply_with_capture`](crate::migrate::reverse::apply_with_capture) makes
+/// structural.
 ///
 /// Gates on the **derived** classification ([`classify_op`]), not the declared
-/// class: a structurally-additive op has nothing to snapshot, so gating on a
-/// (possibly over-declared) destructive *declaration* would be an unsatisfiable
-/// false positive with no override built. Conversely, a drop dishonestly declared
-/// additive is still caught here, because the derive sees the data loss -- so this
-/// gate holds even when [`lint_manifest`] was not run first.
-///
-/// The pre-image is manifest-level ([`Manifest::preimage`]): its presence is what
-/// "captured" means for 0.5.0. The concrete capture shape
-/// ([`crate::migrate::Preimage::Inline`] vs [`crate::migrate::Preimage::Ref`]) is
-/// reverse's concern (#274); this gate only requires that
-/// *some* pre-image exists when a destructive op is present.
+/// class, for the same reason [`lint_manifest`]'s surfacing verdict does not: a
+/// structurally-additive op has nothing to snapshot, so keying on a (possibly
+/// over-declared) destructive *declaration* would refuse a manifest that risks no
+/// data. A drop dishonestly declared additive is still judged here, because the
+/// derive sees the data loss -- so this gate holds even when [`lint_manifest`] was
+/// not run first.
 pub fn enforce_preimage(manifest: &Manifest) -> Result<(), LintError> {
+    let Some(preimage) = manifest.preimage.as_ref() else {
+        return Ok(());
+    };
+    if !is_placeholder(preimage) {
+        return Ok(());
+    }
     for (index, classified) in manifest.up.iter().enumerate() {
-        if classify_op(&classified.op).destructive && manifest.preimage.is_none() {
-            return Err(LintError::MissingPreimage { index });
+        if classify_op(&classified.op).destructive {
+            return Err(LintError::PlaceholderPreimage { index });
         }
     }
     Ok(())
 }
 
+/// Whether a carried [`Preimage`] holds no capture at all.
+///
+/// Deserializes the inline payload into the real
+/// [`PreimagePayload`](crate::migrate::reverse::PreimagePayload) rather than
+/// poking at JSON keys, so this cannot drift from the shape reverse (#274)
+/// actually writes; a payload that will not deserialize into one carries no
+/// capture either, so it is a placeholder too. Borrows the `Value` (serde
+/// deserializes from `&Value`), so a large inline payload is not cloned to answer
+/// the question.
+fn is_placeholder(preimage: &Preimage) -> bool {
+    match preimage {
+        Preimage::Inline { rows } => PreimagePayload::deserialize(rows)
+            .map(|payload| payload.is_empty())
+            .unwrap_or(true),
+        Preimage::Ref { key } => key.trim().is_empty(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::migrate::reverse::{CapturedValue, TablePreimage};
     use crate::migrate::{ClassifiedOp, Column, ColumnKind, Flags, Manifest, Op, Preimage};
 
     /// A minimal typed column with no constraints or tags.
@@ -419,6 +502,37 @@ mod tests {
 
     // --- enforce_preimage ---------------------------------------------------
 
+    /// A one-table pre-image that actually carries a capture, serialized the way
+    /// reverse (#274) writes it.
+    fn real_inline_preimage() -> Preimage {
+        let payload = PreimagePayload {
+            tables: vec![TablePreimage::Column {
+                table: "users".into(),
+                dropped: "email".into(),
+                create_sql: "CREATE TABLE users (id TEXT PRIMARY KEY, email TEXT)".into(),
+                aux_ddl: Vec::new(),
+                dropped_requires_value: false,
+                pk: vec!["id".into()],
+                captured_columns: vec!["id".into(), "email".into()],
+                rows: vec![vec![
+                    CapturedValue::Text("u1".into()),
+                    CapturedValue::Text("a@x".into()),
+                ]],
+            }],
+        };
+        Preimage::Inline {
+            rows: serde_json::to_value(&payload).expect("payload serializes"),
+        }
+    }
+
+    /// The placeholder that used to clear the old presence check: a well-formed
+    /// `Inline` whose payload holds no capture at all.
+    fn empty_inline() -> Preimage {
+        Preimage::Inline {
+            rows: serde_json::json!({ "tables": [] }),
+        }
+    }
+
     #[test]
     fn enforce_allows_additive_only_without_preimage() {
         let m = manifest_with(vec![ClassifiedOp::new(add_column())]);
@@ -426,18 +540,80 @@ mod tests {
     }
 
     #[test]
-    fn enforce_refuses_destructive_without_preimage() {
+    fn enforce_allows_a_generator_shaped_destructive_manifest_with_no_preimage_yet() {
+        // The #326 headline: an honestly-authored destructive manifest -- derived
+        // op classes, `preimage: None` -- must pass the pre-apply gate, because the
+        // pre-image is captured *inside* the apply this gate runs before. Refusing
+        // here made the honest path unrunnable.
         let m = manifest_with(vec![ClassifiedOp::new(drop_column())]);
-        let err = enforce_preimage(&m).expect_err("destructive op needs a pre-image");
-        assert!(matches!(err, LintError::MissingPreimage { index: 0 }));
+        assert!(m.preimage.is_none());
+        assert!(enforce_preimage(&m).is_ok());
     }
 
     #[test]
-    fn enforce_allows_destructive_with_preimage() {
+    fn enforce_allows_destructive_with_a_real_preimage() {
         let mut m = manifest_with(vec![ClassifiedOp::new(drop_column())]);
         m.preimage = Some(Preimage::Ref {
             key: "snapshot-key".into(),
         });
+        assert!(enforce_preimage(&m).is_ok());
+
+        m.preimage = Some(real_inline_preimage());
+        assert!(enforce_preimage(&m).is_ok());
+    }
+
+    #[test]
+    fn enforce_refuses_an_empty_inline_placeholder() {
+        // The bypass #296's own test used: an `Inline` carrying nothing at all
+        // cleared the old presence check. It is a claim of a snapshot that does
+        // not exist, so it is now the thing that refuses.
+        let mut m = manifest_with(vec![ClassifiedOp::new(drop_column())]);
+        m.preimage = Some(empty_inline());
+        let err = enforce_preimage(&m).expect_err("an empty Inline carries no capture");
+        assert!(matches!(err, LintError::PlaceholderPreimage { index: 0 }));
+    }
+
+    #[test]
+    fn enforce_refuses_every_shape_of_empty_preimage() {
+        // Null, a bare object, a payload that will not deserialize into a
+        // PreimagePayload at all, and a blank relay key: none of them carries a
+        // capture, so none of them may pass.
+        for rows in [
+            serde_json::Value::Null,
+            serde_json::json!({}),
+            serde_json::json!("snapshot"),
+            serde_json::json!({ "tables": "not-a-list" }),
+        ] {
+            let mut m = manifest_with(vec![ClassifiedOp::new(drop_column())]);
+            m.preimage = Some(Preimage::Inline { rows: rows.clone() });
+            assert!(
+                matches!(
+                    enforce_preimage(&m),
+                    Err(LintError::PlaceholderPreimage { index: 0 })
+                ),
+                "inline {rows} must refuse"
+            );
+        }
+
+        for key in ["", "   "] {
+            let mut m = manifest_with(vec![ClassifiedOp::new(drop_column())]);
+            m.preimage = Some(Preimage::Ref { key: key.into() });
+            assert!(
+                matches!(
+                    enforce_preimage(&m),
+                    Err(LintError::PlaceholderPreimage { index: 0 })
+                ),
+                "blank ref key {key:?} must refuse"
+            );
+        }
+    }
+
+    #[test]
+    fn enforce_ignores_a_placeholder_on_an_additive_only_manifest() {
+        // The gate is scoped to destructive ops: a pointless placeholder on a
+        // manifest that loses no data risks nothing.
+        let mut m = manifest_with(vec![ClassifiedOp::new(add_column())]);
+        m.preimage = Some(empty_inline());
         assert!(enforce_preimage(&m).is_ok());
     }
 
@@ -445,21 +621,23 @@ mod tests {
     fn enforce_catches_a_drop_dishonestly_declared_additive() {
         // enforce_preimage keys on the derived class, so it holds even when the
         // declaration lies and lint_manifest was not run first.
-        let m = manifest_with(vec![ClassifiedOp::declared(
+        let mut m = manifest_with(vec![ClassifiedOp::declared(
             drop_column(),
             OpClass::Additive,
         )]);
-        let err = enforce_preimage(&m).expect_err("derived-destructive drop needs a pre-image");
-        assert!(matches!(err, LintError::MissingPreimage { index: 0 }));
+        m.preimage = Some(empty_inline());
+        let err = enforce_preimage(&m).expect_err("a derived-destructive drop is still judged");
+        assert!(matches!(err, LintError::PlaceholderPreimage { index: 0 }));
     }
 
     #[test]
-    fn enforce_reports_the_first_uncovered_destructive_index() {
-        let m = manifest_with(vec![
+    fn enforce_reports_the_first_destructive_index() {
+        let mut m = manifest_with(vec![
             ClassifiedOp::new(add_column()),
             ClassifiedOp::new(drop_column()),
         ]);
+        m.preimage = Some(empty_inline());
         let err = enforce_preimage(&m).expect_err("destructive op at index 1");
-        assert!(matches!(err, LintError::MissingPreimage { index: 1 }));
+        assert!(matches!(err, LintError::PlaceholderPreimage { index: 1 }));
     }
 }

--- a/crates/smugglr-core/src/migrate/reverse.rs
+++ b/crates/smugglr-core/src/migrate/reverse.rs
@@ -40,10 +40,27 @@
 //! ([`Preimage::Inline`], no relay) and **large payloads in a content-addressed
 //! store** ([`Preimage::Ref`], keyed by the SHA-256 of the payload, written
 //! through [`crate::stash::build_store`]). [`INLINE_MAX_BYTES`] pins the boundary
-//! where inline refuses and a relay becomes mandatory ([`store_preimage`]). A
-//! large payload's key is *read* from the ledger's forward-compat `preimage_ref`
-//! column ([`preimage_ref_of`], OQ2 "read-only"); **writing** that column is the
-//! driver's job (#296), out of scope here.
+//! where inline refuses and a relay becomes mandatory ([`store_preimage`]).
+//!
+//! The ledger's forward-compat `preimage_ref` column is **read-only from here**
+//! (OQ2) via [`preimage_ref_of`] -- and in 0.5.0 **nothing writes it**. No ledger
+//! setter for the column exists, and the forward driver (#296) hands the captured
+//! payload back in its apply outcome rather than stashing a key on the row, so the
+//! column stays NULL and [`preimage_ref_of`] returns `None` on every real ledger
+//! row. It is a reader waiting on a writer, kept so the column's meaning is fixed
+//! before something starts populating it (#326 corrected an earlier claim here
+//! that named #296 as the writer).
+//!
+//! # Capture is wired into the apply loop, not checked before it
+//!
+//! [`apply_with_capture`] is the sanctioned forward path for a manifest with any
+//! destructive op: it binds [`PreimageCapturer::capture_before`] as `apply_ops`'
+//! `pre_op` hook, so capture-then-mutate is structural per op rather than an
+//! ordering a caller has to remember. The manifest-level gate
+//! ([`crate::migrate::lint::enforce_preimage`]) necessarily runs *before* that
+//! loop and so cannot see a capture that does not exist yet; the "no mutation
+//! without a snapshot" guarantee lives in [`PreimageCapturer::capture_before`],
+//! which refuses a destructive op it cannot capture *before* the op runs.
 
 use crate::migrate::{ClassifiedOp, MigrateError, Op};
 use serde::{Deserialize, Serialize};
@@ -54,6 +71,8 @@ use crate::config::StashConfig;
 use crate::migrate::apply::{apply_ops, rebuild_to_schema, RebuildSpec, RebuildTarget};
 #[cfg(feature = "native")]
 use crate::migrate::ledger::{Election, Ledger, LedgerEntry};
+#[cfg(feature = "native")]
+use crate::migrate::lint::classify_op;
 #[cfg(feature = "native")]
 use crate::migrate::Preimage;
 #[cfg(feature = "native")]
@@ -366,11 +385,10 @@ fn captured_to_sql(v: &CapturedValue) -> SqlValue {
 /// [`apply_ops`](crate::migrate::apply::apply_ops): the hook fires *before* each
 /// op's own transaction, so [`Self::capture_before`] snapshots committed,
 /// pre-mutation state. Additive ops are ignored (their reverse carries no data).
+/// [`apply_with_capture`] does that wiring; prefer it over hand-binding the hook.
 ///
 /// ```ignore
-/// let mut cap = PreimageCapturer::new();
-/// apply_ops(conn, &up, &mut |op| cap.capture_before(conn, op))?;
-/// let payload = cap.into_payload();
+/// let payload = apply_with_capture(conn, &manifest.up)?;
 /// ```
 #[cfg(feature = "native")]
 #[derive(Debug, Default)]
@@ -389,11 +407,26 @@ impl PreimageCapturer {
     ///
     /// Must run **before** `op` mutates (it reads the current table). Additive
     /// ops carry no data, so they are skipped.
+    ///
+    /// This is where "a destructive op never mutates without a pre-image" is
+    /// actually enforced, and it is enforced write-ahead: driven as `apply_ops`'
+    /// `pre_op` hook, an `Err` here aborts before the op's own transaction opens,
+    /// so a destructive op whose pre-image cannot be captured never runs. The
+    /// manifest-level gate [`crate::migrate::lint::enforce_preimage`] cannot make
+    /// that guarantee -- it runs before this loop, when no capture exists yet.
+    ///
+    /// The final refusal is the reason the op match is not a bare catch-all: an
+    /// op that [`classify_op`] calls destructive but no arm above knows how to
+    /// snapshot is a data-loss hole, so it is refused rather than silently skipped
+    /// into the additive lane. Unreachable in 0.5.0 (`DropTable` and `DropColumn`
+    /// are the only destructive ops, and both are handled); it exists so adding a
+    /// destructive op without teaching capture about it fails loudly.
     pub fn capture_before(
         &mut self,
         conn: &Connection,
         op: &ClassifiedOp,
     ) -> Result<(), MigrateError> {
+        let captured_before = self.payload.tables.len();
         match &op.op {
             Op::DropColumn { table, column } => {
                 let capture = self.capture_drop_column(conn, table, column)?;
@@ -405,10 +438,22 @@ impl PreimageCapturer {
             }
             _ => {}
         }
+        if classify_op(&op.op).destructive && self.payload.tables.len() == captured_before {
+            return Err(MigrateError::Apply(format!(
+                "refusing to apply destructive op {:?}: pre-image capture does not know how to \
+                 snapshot it, so the loss would be irreversible",
+                op.op
+            )));
+        }
         Ok(())
     }
 
     /// Consume the capturer, yielding the accumulated pre-image.
+    ///
+    /// An empty payload is a legitimate outcome (no destructive op ran); so is a
+    /// capture with zero rows (a drop against an empty table loses nothing). What
+    /// is *not* legitimate -- a destructive op that ran with no capture -- cannot
+    /// reach here, because [`Self::capture_before`] refuses it before the mutation.
     pub fn into_payload(self) -> PreimagePayload {
         self.payload
     }
@@ -508,6 +553,43 @@ impl PreimageCapturer {
             rows,
         })
     }
+}
+
+/// Run a forward apply of `up` with pre-image capture wired in, returning what was
+/// captured.
+///
+/// This is [`apply_ops`] with [`PreimageCapturer::capture_before`] bound as its
+/// `pre_op` write-ahead hook -- not a second apply loop, the same one with the hook
+/// supplied. It exists so the ordering that makes a destructive apply reversible is
+/// **structural** instead of a convention each caller re-implements:
+///
+/// ```text
+/// per op:  capture pre-image (or refuse)  ->  mutate
+/// ```
+///
+/// Use it for any manifest whose `up` may contain a destructive op. A caller that
+/// binds its own `pre_op` -- to also log intent (#289), say -- must call
+/// `capture_before` from inside that hook; one that passes a no-op hook has opted
+/// out of reversibility, which is why the destructive forward path should come
+/// through here.
+///
+/// The returned payload is empty when nothing destructive ran. Errors propagate
+/// from capture (refusing before the op mutates) or from the op itself; on a
+/// mid-loop failure the already-applied ops stay applied, exactly as [`apply_ops`]
+/// documents. Ledger election and settlement are *not* here -- composing this with
+/// the ledger is the driver's job (#296).
+#[cfg(feature = "native")]
+pub fn apply_with_capture(
+    conn: &Connection,
+    up: &[ClassifiedOp],
+) -> Result<PreimagePayload, MigrateError> {
+    let mut capturer = PreimageCapturer::new();
+    {
+        let mut pre_op =
+            |op: &ClassifiedOp| -> Result<(), MigrateError> { capturer.capture_before(conn, op) };
+        apply_ops(conn, up, &mut pre_op)?;
+    }
+    Ok(capturer.into_payload())
 }
 
 /// Restore a captured pre-image: reconstruct the lost structure, then refill the
@@ -797,10 +879,21 @@ pub async fn load_preimage(
 
 /// The pre-image reference recorded on a ledger row, if any (OQ2, read-only).
 ///
-/// The forward driver (#296) *writes* `preimage_ref` when it stashes a large
-/// destructive pre-image; reverse only *reads* it here, resolving the stored key
-/// to a [`Preimage::Ref`] to feed [`load_preimage`]. `None` means the reverse's
-/// pre-image (if any) travels inline in the manifest instead.
+/// **Nothing writes `preimage_ref` in 0.5.0**, so this returns `None` for every
+/// row a 0.5.0 apply produces. The ledger exposes no setter for the column -- it
+/// appears in `ledger.rs`'s `CREATE TABLE` and in the `SELECT` projections, and in
+/// no write: [`Ledger::try_elect`]'s insert does not list it, so every row is born
+/// NULL and nothing updates it afterwards. The forward driver (#296) returns the
+/// captured payload in its apply outcome instead of stashing a key on the row.
+/// Until some component takes ownership of writing it, a `Ref` pre-image reaches a
+/// reverse by travelling on the manifest, not by being looked up here.
+///
+/// Kept as a reader anyway, and named as unwritten rather than deleted, so the
+/// column has one agreed interpretation -- the stored string is the
+/// content-addressed key of a [`Preimage::Ref`], feedable straight to
+/// [`load_preimage`] -- before anything starts populating it. An earlier version
+/// of this doc asserted #296 was the writer; it is not, and a doc naming an owner
+/// that does not do the thing is worse than silence (#326).
 #[cfg(feature = "native")]
 pub fn preimage_ref_of(entry: &LedgerEntry) -> Option<Preimage> {
     entry
@@ -1030,11 +1123,167 @@ mod tests {
     mod native {
         use super::*;
         use crate::migrate::apply::apply_ops;
+        use crate::migrate::generator;
         use crate::migrate::ledger::{Ledger, MigrationStatus};
+        use crate::migrate::lint::{enforce_preimage, lint_manifest};
+        use crate::migrate::{ChecksummedManifest, Flags, Manifest};
         use rusqlite::Connection;
 
         fn noop(_: &ClassifiedOp) -> Result<(), MigrateError> {
             Ok(())
+        }
+
+        // -- The honest destructive apply, end to end (#326) -----------------
+
+        /// The path that could not run before #326: author a destructive
+        /// migration the way the tooling authors one -- derived op classes, no
+        /// pre-image, because nothing has captured yet -- and drive it through the
+        /// whole forward sequence (seal, verify, lint, gate, apply-with-capture),
+        /// then reverse it from what the apply captured.
+        ///
+        /// The old gate refused this at the `enforce_preimage` line below, and the
+        /// only way past it was to paste an empty `Inline` placeholder -- which
+        /// applied the drop with no pre-image at all.
+        ///
+        /// The generator itself cannot author the destructive half: `generate`
+        /// emits only `CreateTable`/`CreateIndex` in 0.5.0. So the schema is stood
+        /// up by a real generated manifest and the drop is authored in exactly the
+        /// shape `generate` produces (`ClassifiedOp::new`, `preimage: None`, honest
+        /// `flags`).
+        #[test]
+        fn a_generator_shaped_destructive_migration_applies_captures_and_reverses() {
+            let conn = Connection::open_in_memory().unwrap();
+
+            // v1: a genuinely generated additive migration.
+            let created = generator::generate(
+                "create_contacts",
+                &["id:pk".to_string(), "email:text".to_string()],
+            )
+            .expect("generator scaffolds the create migration");
+            assert!(created.preimage.is_none());
+            let sealed = ChecksummedManifest::seal(created).unwrap();
+            sealed.verify().unwrap();
+            lint_manifest(&sealed.manifest).expect("a generated manifest lints clean");
+            enforce_preimage(&sealed.manifest).expect("an additive manifest needs no pre-image");
+            let captured = apply_with_capture(&conn, &sealed.manifest.up).unwrap();
+            assert!(
+                captured.is_empty(),
+                "an additive migration captures nothing"
+            );
+
+            conn.execute_batch(
+                "INSERT INTO contacts (id, email) VALUES ('c1', 'a@x'), ('c2', 'b@x');",
+            )
+            .unwrap();
+
+            // v2: the destructive migration, authored honestly -- and therefore
+            // carrying no pre-image, because the pre-image is captured during the
+            // apply this manifest has not had yet.
+            let drop = Manifest {
+                version: 2,
+                target_schema: String::new(),
+                up: vec![ClassifiedOp::new(Op::DropColumn {
+                    table: "contacts".into(),
+                    column: "email".into(),
+                })],
+                down: Vec::new(),
+                preimage: None,
+                flags: Flags {
+                    destructive: true,
+                    hash_rewriting: false,
+                },
+                author: None,
+            };
+            let sealed = ChecksummedManifest::seal(drop).unwrap();
+            sealed.verify().unwrap();
+            lint_manifest(&sealed.manifest).expect("an honest destructive manifest lints clean");
+            enforce_preimage(&sealed.manifest)
+                .expect("the gate must not demand a pre-image that only the apply can capture");
+
+            let payload = apply_with_capture(&conn, &sealed.manifest.up)
+                .expect("the destructive apply captures as it goes");
+
+            // The op really applied...
+            assert!(
+                table_info(&conn, "contacts")
+                    .unwrap()
+                    .iter()
+                    .all(|c| c.name != "email"),
+                "the column was actually dropped"
+            );
+
+            // ...and the pre-image it captured is real, not a placeholder: one
+            // capture, naming the dropped column, carrying both rows' values.
+            assert_eq!(payload.tables.len(), 1);
+            match &payload.tables[0] {
+                TablePreimage::Column {
+                    table,
+                    dropped,
+                    rows,
+                    ..
+                } => {
+                    assert_eq!(table, "contacts");
+                    assert_eq!(dropped, "email");
+                    assert_eq!(rows.len(), 2);
+                }
+                other => panic!("expected a Column capture, got {other:?}"),
+            }
+
+            // What the apply captured also satisfies the gate on its own terms --
+            // the same gate that refuses an empty placeholder accepts this.
+            let mut carried = sealed.manifest.clone();
+            carried.preimage = Some(Preimage::Inline {
+                rows: serde_json::to_value(&payload).unwrap(),
+            });
+            enforce_preimage(&carried).expect("a captured pre-image is not a placeholder");
+
+            // And the reverse is honest: the dropped data comes back.
+            restore_payload(&conn, &payload).unwrap();
+            let email = |id: &str| -> Option<String> {
+                conn.query_row(
+                    "SELECT email FROM contacts WHERE id = ?1",
+                    rusqlite::params![id],
+                    |r| r.get::<_, Option<String>>(0),
+                )
+                .unwrap()
+            };
+            assert_eq!(email("c1").as_deref(), Some("a@x"));
+            assert_eq!(email("c2").as_deref(), Some("b@x"));
+        }
+
+        #[test]
+        fn apply_with_capture_snapshots_before_the_op_mutates() {
+            // The ordering apply_with_capture exists to make structural: the
+            // capture reads pre-mutation state, so a drop of a table whose rows are
+            // gone by capture time would come back empty. It does not.
+            let conn = Connection::open_in_memory().unwrap();
+            seed_users(&conn);
+            let payload = apply_with_capture(
+                &conn,
+                &[ClassifiedOp::new(Op::DropTable {
+                    table: "users".into(),
+                })],
+            )
+            .unwrap();
+            match payload.tables.as_slice() {
+                [TablePreimage::Table { table, rows, .. }] => {
+                    assert_eq!(table, "users");
+                    assert_eq!(
+                        rows.len(),
+                        2,
+                        "captured the rows the drop was about to lose"
+                    );
+                }
+                other => panic!("expected one Table capture, got {other:?}"),
+            }
+            let exists: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='users'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(exists, 0, "and the table is gone");
         }
 
         fn apply(conn: &Connection, op: Op) {

--- a/crates/smugglr-core/src/migrate/reverse.rs
+++ b/crates/smugglr-core/src/migrate/reverse.rs
@@ -61,6 +61,13 @@
 //! loop and so cannot see a capture that does not exist yet; the "no mutation
 //! without a snapshot" guarantee lives in [`PreimageCapturer::capture_before`],
 //! which refuses a destructive op it cannot capture *before* the op runs.
+//!
+//! That guarantee is scoped to the **forward `up` path**, for the same reason the
+//! lint is (`lint.rs`, "Scope"): a `down` op is a legitimately-destructive-by-
+//! structure inverse -- the `DropColumn` that undoes an `AddColumn` -- whose data
+//! was never there to lose. So [`apply_compensating`] running `apply_ops` with a
+//! no-op hook over [`additive_down_ops`] is correct, not a hole: there is nothing
+//! to snapshot on the way back out.
 
 use crate::migrate::{ClassifiedOp, MigrateError, Op};
 use serde::{Deserialize, Serialize};
@@ -882,8 +889,9 @@ pub async fn load_preimage(
 /// **Nothing writes `preimage_ref` in 0.5.0**, so this returns `None` for every
 /// row a 0.5.0 apply produces. The ledger exposes no setter for the column -- it
 /// appears in `ledger.rs`'s `CREATE TABLE` and in the `SELECT` projections, and in
-/// no write: [`Ledger::try_elect`]'s insert does not list it, so every row is born
-/// NULL and nothing updates it afterwards. The forward driver (#296) returns the
+/// no write path: the election insert does not list it, so every row is born NULL,
+/// and none of [`Ledger::mark_success`], [`Ledger::mark_failed`], or either lease
+/// reclaim touches it afterwards. The forward driver (#296) returns the
 /// captured payload in its apply outcome instead of stashing a key on the row.
 /// Until some component takes ownership of writing it, a `Ref` pre-image reaches a
 /// reverse by travelling on the manifest, not by being looked up here.


### PR DESCRIPTION
Closes #326.

## Acceptance criteria mapping

### A destructive manifest as produced by the generator can be applied, with its pre-image captured

Relaxing the gate so `preimage: None` on a destructive manifest passes -- that is the normal pre-apply state of every honestly authored destructive migration. The test runs a real `generator::generate` manifest through seal/verify/lint/gate/apply, then a generator-shaped `DropColumn` through the same sequence, asserting a real capture (one `TablePreimage::Column`, correct table and dropped column, both rows) and a successful `restore_payload`. See **Not done** for what "as produced by the generator" can mean in 0.5.0.

### The gate distinguishes a pre-image that will be captured from one merely present, and an empty Inline does not clear it

Presence no longer counts. A carried pre-image holding no capture refuses -- empty or unparseable `Inline`, blank `Ref` key -- and emptiness is decided by `PreimagePayload::deserialize` against the real type rather than by poking at a JSON key, so it cannot drift from what reverse actually serializes. It keys on "is there a capture", never "are there rows": dropping a column of an empty table legitimately captures zero rows. The will-be-captured half is `apply_with_capture`, which binds `capture_before` as `apply_ops`' `pre_op` hook so the wiring is structural rather than conventional, and `capture_before` now refuses a derived-destructive op no capture arm handled instead of dropping it through the `_` arm into the additive lane.

### The preimage_ref column is either written by its owner, or the reverse.rs doc is corrected

Every write path in `ledger.rs` was checked: the only statements touching that column are the `CREATE TABLE` and two tests' raw UPDATEs. The election insert does not list it; `mark_success`, `mark_failed` and both lease reclaims set only status/lease/applied_at. Both doc sites now say the column is unwritten in 0.5.0 and that `preimage_ref_of` is a forward-compat reader awaiting a writer.

### The ordering relationship between the gate and capture is stated explicitly in the code

Both modules now state it: gate (is the body honest?) -> per-op capture (snapshot, or refuse) -> mutation. Evidence: the module doc headers in `lint.rs` and `reverse.rs`, and `apply_with_capture`'s own doc.

### A test that applies a generator-authored destructive migration end to end

`a_generator_shaped_destructive_migration_applies_captures_and_reverses` plus `apply_with_capture_snapshots_before_the_op_mutates`, in `reverse.rs`. Both proven non-vacuous under four separate mutations, listed below -- the decisive one being mutation 3, where deleting both the capture arm and the guard lets the apply succeed with zero captures.

## The fact that settles the design

**`Manifest.preimage` is inside the checksummed body.** `manifest.rs:299-303` declares field order to be part of the format, and `Manifest::checksum` hashes the whole struct.

So the apply that captures a pre-image can never write it back into the manifest without changing that manifest's checksum, and therefore its ledger identity. Gating on that field was not merely mis-ordered -- it was category-confused: **the field can never legitimately be populated by the apply that would need it.** #296 already returns the payload in `ApplyOutcome`, which is the right home. Nothing in the crate constructs `Some(Preimage)` outside tests, so relaxing the presence requirement breaks no producer.

That is why the fix is a split rather than a reordering.

## Alternatives rejected

- **Gate verifies a capturer is wired for this apply.** Requires a second parameter on `enforce_preimage`, which breaks #296's now-merged call site. A witness value passed by the caller would be forgeable anyway; only a function owning both the hook and the loop actually proves wiring, which is what `apply_with_capture` does.
- **Gate checks `flags.destructive` consistency instead.** Relocates the block rather than closing it. Nothing helps an author set that bool -- `generate` emits only `CreateTable`/`CreateIndex`, and `Manifest` is fenced so no derive helper can be added -- so an honestly authored `ClassifiedOp::new(DropColumn)` with `Flags::default()` would still be refused. If a manifest-level under-declaration rule for `flags` is wanted it belongs in `lint_manifest` (see #331).

## Proving the guard is load-bearing rather than decorative

Four mutations, all confirmed:

1. Swap `apply_with_capture`'s hook for a no-op -> both new tests fail (`expected one Table capture, got []`).
2. Delete the `DropColumn` capture arm -> the new write-ahead guard fires and the column is **not** dropped.
3. Delete the arm **and** the guard -> the apply **succeeds with zero captures.** That is precisely the hole the guard closes.
4. Restore the old `manifest.preimage.is_none()` gate -> 5 lint tests plus the end-to-end test fail, the latter at the gate line with `PlaceholderPreimage`.

Mutation 3 is the one that matters: it shows the guard is the thing standing between a destructive op and an unrecorded mutation.

## Not done

- **`CHANGELOG.md` untouched** -- deliberate, the changelog is written in one pass later.
- **The generator still cannot author a destructive manifest at all.** `generate` emits only `CreateTable` + `CreateIndex`, so `flags.destructive` is always false from it, and this issue's criteria 1 and 5 are literally unsatisfiable as worded in 0.5.0. Read as "authored in the generator's shape" and tested that way. Filed separately.
- **The same placeholder hole exists on the reverse side** -- `restore_payload` over an empty `PreimagePayload` silently no-ops, and `apply_compensating` accepts `Some(empty)`, so a destructive reverse against a placeholder reports success having restored nothing. #274/#289 territory, left untouched, filed separately.
- **No fenced file touched:** `local.rs`, `config.rs`, `error.rs`, `daemon.rs`, `multicast.rs`, `migrate/driver.rs`, `migrate/manifest.rs`, `migrate_cli.rs` are all absent from this diff.

## Rebase note -- supersedes PR #345

This branch replaces `fix/326-preimage-gate`, whose PR (#345) went red on all three platforms after #269, #296, #324 and #336 merged. It is rebased onto `d7feb64` and carries one extra commit. `legion push` has no force flag by design, so a rebased branch cannot reach an existing PR -- hence the new branch rather than a force-push.

**Three `driver.rs` tests failed, and all three failed for the right reason: they were resting on the bug this branch fixes.** Two pasted `Preimage::Inline { rows: {"tables": []} }` into the manifest purely to get past a gate that refused `preimage: None` -- exactly the placeholder the new `PlaceholderPreimage` refusal exists to reject. Both now pass `None`; the workaround is deleted, not replaced.

The third is the interesting one. `a_lint_refusal_settles_the_claimed_row_rather_than_abandoning_it` provoked its refusal with a destructive op carrying no pre-image, and its own comment said so: *"A destructive op with no pre-image is refused by `enforce_preimage` after the election is won."* That sentence describes the defect. The test verified a real and valuable property -- a lint refusal arriving past a won election must settle the row `failed` rather than abandon it pending for a whole lease -- but used the circular gate as its trigger, so fixing the gate removed the trigger. It now provokes a genuine `lint_manifest` under-declaration (`ClassifiedOp::declared(DropColumn, OpClass::Additive)`), which refuses on its own terms.

Its assertion was also wrong independently: it matched `"lint refused"`, a string no error message in this crate produces, so once reached it would have been a false pin. It now matches `"under-states"` -- `LintError::UnderDeclared`'s real `#[error]` text -- and prints the error on failure.

473 tests pass; fmt, clippy host and clippy `wasm32-unknown-unknown` clean; simplify gate `019fff49` recorded on HEAD.

## Sequencing note

#296's merged `driver.rs` calls `lint::enforce_preimage(manifest)` unchanged and its semantics improve for free. Its hand-rolled `apply_ops` + capturer block should adopt `apply_with_capture`; until it does, its guarantee rests on its own correct wiring plus the hardened `capture_before`, which is sound.