### PR TITLE
feat(#351): forger -- the crate, the schema model, and the fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,20 @@ jobs:
       # what `cargo publish` would actually ship.
       - run: python3 scripts/check-crate-versions.py
 
+  forger-boundary:
+    name: Forger boundary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # forger is an oracle only while it knows nothing about smugglr. Every
+      # other job here passes just as green with `smugglr-core` in forger's
+      # dependencies -- the code would compile, the tests would run, and the
+      # crate would quietly stop being extractable. This is the one check that
+      # reads the boundary itself.
+      - run: python3 scripts/check-forger-boundary.py
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,6 +1798,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smugglr-forger"
+version = "0.1.0"
+dependencies = [
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "smugglr-http-sql"
 version = "0.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,21 @@
 members = [
     "crates/smugglr-core",
     "crates/smugglr",
+    "crates/smugglr-forger",
     "crates/smugglr-plugin-sdk",
     "crates/smugglr-wasm",
     "crates/smugglr-wire",
     "plugins/smugglr-http-sql",
 ]
+# smugglr-wasm is the only member held out: it is #![cfg(target_arch =
+# "wasm32")] and compiles to nothing on the host. smugglr-forger is a default
+# member because its fixture teardown is a Windows-specific claim, and CI's
+# three-OS `cargo test` job is default-members-scoped -- held out, its tests
+# would never run on the platform they exist to defend.
 default-members = [
     "crates/smugglr-core",
     "crates/smugglr",
+    "crates/smugglr-forger",
     "crates/smugglr-plugin-sdk",
     "crates/smugglr-wire",
     "plugins/smugglr-http-sql",

--- a/crates/smugglr-forger/Cargo.toml
+++ b/crates/smugglr-forger/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "smugglr-forger"
+description = "Manufactures SQLite schemas and the fixtures that prove them -- an oracle the implementation's author did not write"
+# NOT version.workspace = true. forger is an independent artifact that happens
+# to live in this workspace: it knows nothing about smugglr and must be
+# extractable without a redesign, so it carries its own version line and moves
+# on its own cadence. scripts/check-crate-versions.py skips publish = false
+# members for exactly this reason.
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+# Never shipped to crates.io from this workspace. `forger` is taken there by an
+# unrelated crate, and the name was never what preserved the extraction option
+# anyway -- the dependency direction is.
+publish = false
+
+[dependencies]
+# Pinned to the same minor as smugglr-core. Two rusqlite minors in one graph
+# means two libsqlite3-sys packages, both declaring `links = "sqlite3"`, which
+# is a cargo hard error rather than a warning.
+rusqlite = { version = "0.34", features = ["bundled"] }
+
+# The schema model is the fixture format (FR-FORGER-009), so it derives serde
+# now and the file format costs nothing later.
+serde = { version = "1", features = ["derive"] }
+
+# File-backed fixtures. The TempDir is owned by the fixture so removal cannot
+# outrun the connection close.
+tempfile = "3"
+
+thiserror = "2"
+
+[dev-dependencies]
+# Proves the model round-trips through a real serde format. Not needed to build
+# the crate -- reading and writing fixture files is FR-FORGER-009.
+serde_json = "1"

--- a/crates/smugglr-forger/src/error.rs
+++ b/crates/smugglr-forger/src/error.rs
@@ -1,0 +1,136 @@
+//! forger's two error types, kept apart on purpose.
+//!
+//! [`ValidationError`] is a statement about a schema: it says the model
+//! describes something SQLite would reject, and it is produced before any
+//! database exists. [`ForgeError`] is a statement about a run.
+//!
+//! The split matters downstream. A differential oracle has to tell "the
+//! caller's transformation failed" apart from "the two schemas diverged", and
+//! a single flat error type collapses exactly that distinction --
+//! [`ForgeError::Transform`] is a separate matchable variant for that reason.
+
+use thiserror::Error;
+
+/// The error a caller-supplied transformation reports.
+///
+/// Boxed and type-erased so forger can accept any consumer's error type
+/// without naming it. That is the dependency boundary expressed as a type:
+/// forger cannot name smugglr's error enum, so it names none.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// A schema the model can hold but SQLite would reject.
+///
+/// Every variant names the table (and where it applies, the column) rather
+/// than describing the rule in the abstract, because these are read while
+/// authoring a probe, not while debugging forger.
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
+pub enum ValidationError {
+    #[error("identifier is empty")]
+    EmptyIdentifier,
+
+    #[error("identifier {name:?} contains a NUL byte, which SQLite cannot store")]
+    NulInIdentifier { name: String },
+
+    #[error("table {table:?} is declared twice")]
+    DuplicateTable { table: String },
+
+    #[error("name {name:?} is used by more than one schema object")]
+    DuplicateSchemaObject { name: String },
+
+    #[error("table {table:?} has no columns")]
+    EmptyTable { table: String },
+
+    #[error("table {table:?} declares column {column:?} twice")]
+    DuplicateColumn { table: String, column: String },
+
+    #[error("table {table:?} refers to column {column:?}, which it does not have")]
+    UnknownColumn { table: String, column: String },
+
+    #[error("table {table:?} declares more than one PRIMARY KEY")]
+    MultiplePrimaryKeys { table: String },
+
+    #[error("table {table:?} is WITHOUT ROWID, which requires a PRIMARY KEY")]
+    WithoutRowidNeedsPrimaryKey { table: String },
+
+    #[error(
+        "table {table:?} is WITHOUT ROWID, which has no rowid for AUTOINCREMENT \
+         on column {column:?} to allocate from"
+    )]
+    AutoincrementWithoutRowid { table: String, column: String },
+
+    #[error(
+        "column {table:?}.{column:?} declares AUTOINCREMENT, which SQLite allows \
+         only on a column declared exactly INTEGER PRIMARY KEY (ascending)"
+    )]
+    AutoincrementNeedsIntegerPrimaryKey { table: String, column: String },
+
+    #[error(
+        "column {table:?}.{column:?} is generated, so it cannot be part of the \
+         PRIMARY KEY"
+    )]
+    GeneratedPrimaryKey { table: String, column: String },
+
+    #[error("column {table:?}.{column:?} is generated, so it cannot carry a DEFAULT")]
+    GeneratedWithDefault { table: String, column: String },
+
+    #[error(
+        "table {table:?} is STRICT, so column {column:?} must declare one of \
+         INT, INTEGER, REAL, TEXT, BLOB or ANY"
+    )]
+    StrictNeedsStorageClass { table: String, column: String },
+
+    #[error(
+        "foreign key on table {table:?} maps {child} column(s) onto {parent} \
+         column(s) of {parent_table:?}"
+    )]
+    ForeignKeyArity {
+        table: String,
+        child: usize,
+        parent: usize,
+        parent_table: String,
+    },
+
+    #[error("foreign key on table {table:?} references table {parent_table:?}, which is not in the schema")]
+    UnknownForeignKeyTable { table: String, parent_table: String },
+
+    #[error(
+        "foreign key on table {table:?} references {parent_table:?}.{column:?}, \
+         which that table does not have"
+    )]
+    UnknownForeignKeyColumn {
+        table: String,
+        parent_table: String,
+        column: String,
+    },
+
+    #[error("trigger {trigger:?} on table {table:?} has an empty body")]
+    EmptyTriggerBody { table: String, trigger: String },
+
+    #[error(
+        "ON CONFLICT on column {table:?}.{column:?} has no constraint in front \
+         of it to attach to"
+    )]
+    OrphanConflictClause { table: String, column: String },
+
+    #[error("table {table:?} refines a referential action with no foreign key in front of it")]
+    NoForeignKeyToRefine { table: String },
+}
+
+/// Anything that can go wrong standing a fixture up or driving it.
+#[derive(Debug, Error)]
+pub enum ForgeError {
+    #[error("schema is not one SQLite would accept: {0}")]
+    Invalid(#[from] ValidationError),
+
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("fixture io: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The caller's transformation returned an error. Distinct from every
+    /// other variant because a transformation that legitimately fails is a
+    /// different signal from a schema that came out wrong.
+    #[error("the caller-supplied transformation failed: {0}")]
+    Transform(#[source] BoxError),
+}

--- a/crates/smugglr-forger/src/fixture.rs
+++ b/crates/smugglr-forger/src/fixture.rs
@@ -1,0 +1,178 @@
+//! Standing a database up and tearing it down, deterministically.
+//!
+//! # Why the fixture owns the connection
+//!
+//! On Windows an open handle blocks deletion of the file it points at. A
+//! fixture that hands out a `Connection` and separately owns a temp directory
+//! is one early `drop` away from a cleanup failure that reproduces on exactly
+//! one of three CI platforms -- the worst debugging shape available.
+//!
+//! So the connection is not handed out, it is lent: [`Fixture::conn`] returns
+//! a borrow whose lifetime is the fixture's, and [`Fixture`]'s own [`Drop`]
+//! closes the connection before releasing the directory. The ordering is a
+//! statement in the code rather than a convention someone has to remember, and
+//! because `Drop` runs while unwinding, it holds through a panicking test too.
+//!
+//! # Why both backings
+//!
+//! In memory is fast enough for schema comparison and leaves nothing behind by
+//! construction. Anything that reaches the filesystem -- `VACUUM INTO`, a
+//! file swap, byte-level inspection -- needs a real file, and choosing per
+//! call site rather than globally is what keeps the fast case fast.
+//!
+//! # What forger does not do
+//!
+//! It sets no pragmas, and that is worth stating precisely rather than
+//! generally. `rusqlite`'s bundled SQLite is compiled with
+//! `SQLITE_DEFAULT_FOREIGN_KEYS=1`, so a fixture connection enforces foreign
+//! keys immediately -- unlike the `sqlite3` shell, where the default is off.
+//! forger neither turns that on nor off: a fixture that quietly configured the
+//! connection would be testing its own defaults rather than the caller's
+//! behaviour, and a caller who needs the other setting says so on the
+//! connection it is handed.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+use crate::error::{BoxError, ForgeError};
+use crate::schema::Schema;
+
+/// Where a fixture's database lives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backing {
+    /// `:memory:`. Nothing to clean up, nothing to inspect on disk.
+    Memory,
+    /// A real file inside a temp directory the fixture owns.
+    File,
+}
+
+/// How a fixture is brought to a state.
+///
+/// One method takes all three, and the symmetry is load-bearing rather than
+/// cosmetic: a differential oracle builds one arm by applying the caller's
+/// transformation and the other by plain DDL, then compares them, without
+/// knowing anything about either.
+pub enum Route<'a> {
+    /// Apply a schema's rendered DDL.
+    Schema(&'a Schema),
+    /// Apply SQL verbatim -- several statements are fine.
+    Ddl(&'a str),
+    /// Run a caller-supplied transformation.
+    ///
+    /// `&mut Connection` rather than `&Connection` because
+    /// `Connection::transaction` takes `&mut self`, and a transformation that
+    /// cannot open a transaction cannot do the multi-statement work this
+    /// exists for. The error is boxed and type-erased so forger can accept any
+    /// consumer's error type without naming it -- forger knows nothing about
+    /// what the transformation is or which crate it came from.
+    Transform(&'a mut dyn FnMut(&mut Connection) -> Result<(), BoxError>),
+}
+
+/// A database, its connection, and (on [`Backing::File`]) the directory
+/// holding it.
+///
+/// Not `Clone` and not `Send`-through-a-handle: there is exactly one owner,
+/// and when it goes away the database goes away with it.
+pub struct Fixture {
+    // Held as Options only so `Drop` and `close` can take them; both are
+    // present for the whole observable life of the fixture.
+    conn: Option<Connection>,
+    dir: Option<TempDir>,
+    path: Option<PathBuf>,
+}
+
+impl Fixture {
+    /// Create an empty database on the given backing.
+    pub fn new(backing: Backing) -> Result<Self, ForgeError> {
+        match backing {
+            Backing::Memory => Ok(Self {
+                conn: Some(Connection::open_in_memory()?),
+                dir: None,
+                path: None,
+            }),
+            Backing::File => {
+                let dir = TempDir::new()?;
+                let path = dir.path().join("forge.db");
+                let conn = Connection::open(&path)?;
+                Ok(Self {
+                    conn: Some(conn),
+                    dir: Some(dir),
+                    path: Some(path),
+                })
+            }
+        }
+    }
+
+    /// Borrow the connection.
+    pub fn conn(&self) -> &Connection {
+        self.conn.as_ref().expect("fixture connection is open")
+    }
+
+    /// Borrow the connection mutably, which is what opening a transaction
+    /// needs.
+    pub fn conn_mut(&mut self) -> &mut Connection {
+        self.conn.as_mut().expect("fixture connection is open")
+    }
+
+    /// The database file, or `None` on [`Backing::Memory`].
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    /// Bring the database to a state, by whichever route.
+    pub fn bring_to(&mut self, route: Route<'_>) -> Result<(), ForgeError> {
+        match route {
+            Route::Schema(schema) => {
+                // Validate first: a schema that renders to DDL SQLite rejects
+                // should report which rule it broke, not a parse error.
+                schema.validate()?;
+                self.conn().execute_batch(&schema.to_ddl())?;
+                Ok(())
+            }
+            Route::Ddl(sql) => {
+                self.conn().execute_batch(sql)?;
+                Ok(())
+            }
+            Route::Transform(transform) => {
+                transform(self.conn_mut()).map_err(ForgeError::Transform)
+            }
+        }
+    }
+
+    /// Close the fixture and report what went wrong, if anything.
+    ///
+    /// `Drop` does the same work but cannot propagate, so a test that wants to
+    /// assert clean teardown calls this instead. Afterwards `Drop` finds
+    /// nothing left to do.
+    pub fn close(mut self) -> Result<(), ForgeError> {
+        if let Some(conn) = self.conn.take() {
+            conn.close().map_err(|(_, error)| error)?;
+        }
+        if let Some(dir) = self.dir.take() {
+            dir.close()?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        // Order is the entire point: the connection closes here, and only then
+        // does the TempDir get dropped and the directory removed.
+        if let Some(conn) = self.conn.take() {
+            if let Err((_, error)) = conn.close() {
+                eprintln!("forger: closing fixture connection failed: {error}");
+            }
+        }
+        if let Some(dir) = self.dir.take() {
+            // Drop cannot propagate, but swallowing this silently would hide
+            // exactly the Windows failure the ordering above exists to
+            // prevent.
+            if let Err(error) = dir.close() {
+                eprintln!("forger: removing fixture directory failed: {error}");
+            }
+        }
+    }
+}

--- a/crates/smugglr-forger/src/lib.rs
+++ b/crates/smugglr-forger/src/lib.rs
@@ -1,0 +1,52 @@
+//! forger manufactures SQLite schemas and the fixtures that prove them.
+//!
+//! It exists because a transformation that silently changes meaning passes
+//! every check written from the same premises as the transformation itself.
+//! Ten defects were found by hand in smugglr's migrate spine, every one of
+//! them in code with passing tests. forger's job is to be an oracle the
+//! implementation's author did not write.
+//!
+//! # The boundary
+//!
+//! forger depends on no `smugglr-*` crate and never will. It does not know
+//! what a transformation is -- a caller hands one in as a closure
+//! ([`Route::Transform`]) and forger holds the before and after states without
+//! understanding either. That is what makes it an oracle rather than a second
+//! opinion from the same author, and it is what keeps extracting this crate a
+//! mechanical move rather than a redesign. `scripts/check-forger-boundary.py`
+//! fails CI if the rule is broken.
+//!
+//! # What is here
+//!
+//! * [`schema`] -- `Schema`/`Table`/`Column` as plain owned data, a typed
+//!   builder for authoring one by hand, and the validity grammar that refuses
+//!   a schema SQLite would reject.
+//! * [`fixture`] -- stand a database up on either backing, hand out a
+//!   connection, tear it down reliably including on panic.
+//!
+//! ```
+//! use smugglr_forger::fixture::{Backing, Fixture, Route};
+//! use smugglr_forger::schema::builder::{schema, table, Attr::*};
+//! use smugglr_forger::schema::ColumnType::*;
+//!
+//! let target = schema()
+//!     .table(
+//!         table("users")
+//!             .pk_int("id")
+//!             .autoincrement()
+//!             .col("email", Text, [NotNull, Unique, OnConflictReplace]),
+//!     )
+//!     .build()
+//!     .expect("a valid schema");
+//!
+//! let mut fixture = Fixture::new(Backing::Memory).unwrap();
+//! fixture.bring_to(Route::Schema(&target)).unwrap();
+//! ```
+
+pub mod error;
+pub mod fixture;
+pub mod schema;
+
+pub use error::{BoxError, ForgeError, ValidationError};
+pub use fixture::{Backing, Fixture, Route};
+pub use schema::{Schema, Trait};

--- a/crates/smugglr-forger/src/schema/builder.rs
+++ b/crates/smugglr-forger/src/schema/builder.rs
@@ -305,19 +305,15 @@ impl<P, R> TableBuilder<P, R> {
 
     /// Set `ON DELETE` on the most recent foreign key.
     pub fn on_delete(self, action: ReferentialAction) -> Self {
-        self.set_fk_action(Some(action), None)
+        self.refine_last_fk(move |fk| fk.on_delete = Some(action))
     }
 
     /// Set `ON UPDATE` on the most recent foreign key.
     pub fn on_update(self, action: ReferentialAction) -> Self {
-        self.set_fk_action(None, Some(action))
+        self.refine_last_fk(move |fk| fk.on_update = Some(action))
     }
 
-    fn set_fk_action(
-        mut self,
-        on_delete: Option<ReferentialAction>,
-        on_update: Option<ReferentialAction>,
-    ) -> Self {
+    fn refine_last_fk(mut self, refine: impl FnOnce(&mut ForeignKey)) -> Self {
         let last = self
             .table
             .constraints
@@ -328,14 +324,7 @@ impl<P, R> TableBuilder<P, R> {
                 _ => None,
             });
         match last {
-            Some(fk) => {
-                if on_delete.is_some() {
-                    fk.on_delete = on_delete;
-                }
-                if on_update.is_some() {
-                    fk.on_update = on_update;
-                }
-            }
+            Some(fk) => refine(fk),
             // Nothing to attach to. The table itself would still be
             // well-formed, so the action would vanish silently -- which is the
             // exact defect shape forger exists to catch. Report it.
@@ -443,14 +432,20 @@ impl TableBuilder<IntPk, Rowid> {
     /// let t = table("k").pk_int("id").without_rowid().autoincrement();
     /// ```
     pub fn autoincrement(mut self) -> TableBuilder<IntPk, AutoKey> {
-        for column in &mut self.table.columns {
-            for constraint in &mut column.constraints {
-                if let ColumnConstraint::PrimaryKey { autoincrement, .. } = constraint {
-                    // The IntPk state guarantees this column exists.
-                    *autoincrement = true;
-                }
-            }
-        }
+        // The IntPk state is reachable only through pk_int, which pushed
+        // exactly one column-level key, so this finds it and there is no
+        // second one to find.
+        let key = self
+            .table
+            .columns
+            .iter_mut()
+            .flat_map(|column| column.constraints.iter_mut())
+            .find_map(|constraint| match constraint {
+                ColumnConstraint::PrimaryKey { autoincrement, .. } => Some(autoincrement),
+                _ => None,
+            })
+            .expect("the IntPk state means pk_int declared a key");
+        *key = true;
         self.retype()
     }
 }

--- a/crates/smugglr-forger/src/schema/builder.rs
+++ b/crates/smugglr-forger/src/schema/builder.rs
@@ -1,0 +1,690 @@
+//! The typed builder: the primary way a schema is authored.
+//!
+//! A probe nobody can read is a probe nobody maintains, so this is the surface
+//! that matters. It reads as a declaration:
+//!
+//! ```
+//! use smugglr_forger::schema::builder::{schema, table, Attr::*};
+//! use smugglr_forger::schema::{ColumnType::*, DefaultValue, ReferentialAction};
+//!
+//! let s = schema()
+//!     .table(
+//!         table("users")
+//!             .pk_int("id")
+//!             .autoincrement()
+//!             .col("email", Text, [NotNull, Unique, OnConflictReplace])
+//!             .col("created", Text, [Default(DefaultValue::expr("CURRENT_TIMESTAMP"))]),
+//!     )
+//!     .table(
+//!         table("posts")
+//!             .pk_int("id")
+//!             .col("author", Integer, [NotNull])
+//!             .fk(["author"], "users", ["id"])
+//!             .on_delete(ReferentialAction::Cascade),
+//!     )
+//!     .build()
+//!     .expect("a valid schema");
+//!
+//! assert_eq!(s.tables.len(), 2);
+//! ```
+//!
+//! # What the type system refuses
+//!
+//! Three of the validity grammar's rules are properties of the builder's
+//! *state* rather than of any value, so they are enforced by making the
+//! offending method not exist:
+//!
+//! * `AUTOINCREMENT` needs exactly `INTEGER PRIMARY KEY`, so
+//!   [`TableBuilder::autoincrement`] exists only after
+//!   [`pk_int`](TableBuilder::pk_int), not after
+//!   [`pk_text`](TableBuilder::pk_text), [`pk_col`](TableBuilder::pk_col) or
+//!   [`pk_composite`](TableBuilder::pk_composite).
+//! * `WITHOUT ROWID` has no rowid for `AUTOINCREMENT` to draw from, so the two
+//!   methods each consume the undecided state and neither is reachable from
+//!   the other's result.
+//! * `WITHOUT ROWID` needs a primary key, so
+//!   [`TableBuilder::without_rowid`] exists only once one is declared.
+//!
+//! A fourth is enforced by omission: [`Attr`] has no primary-key variant, so a
+//! generated column cannot be made one through this surface at all. The key is
+//! declared by the `pk_*` constructors, and those take no attributes.
+//!
+//! Everything else -- duplicate names, unresolvable foreign keys, a generated
+//! column inside a composite key, a STRICT table with a typeless column --
+//! depends on values the type system does not have and is caught by
+//! [`super::validate`] when [`SchemaBuilder::build`] runs.
+
+use std::marker::PhantomData;
+
+use crate::error::ValidationError;
+
+use super::{
+    Column, ColumnConstraint, ColumnType, DefaultValue, ForeignKey, Generated, IndexedColumn,
+    OnConflict, ReferentialAction, Schema, SortOrder, Table, TableConstraint, Trigger,
+};
+
+/// Start a schema.
+pub fn schema() -> SchemaBuilder {
+    SchemaBuilder::default()
+}
+
+/// Start a table with no primary key declared yet.
+pub fn table(name: impl Into<String>) -> TableBuilder<NoPk, Rowid> {
+    TableBuilder {
+        table: Table {
+            name: name.into(),
+            columns: Vec::new(),
+            constraints: Vec::new(),
+            without_rowid: false,
+            strict: false,
+            triggers: Vec::new(),
+        },
+        error: None,
+        state: PhantomData,
+    }
+}
+
+/// A column attribute as it is written when authoring.
+///
+/// Flat on purpose. SQLite's grammar binds a conflict algorithm to the
+/// constraint in front of it, and [`ColumnConstraint`] models that binding --
+/// but writing `NotNull(Some(OnConflict::Replace))` at every call site buys
+/// nothing and costs the legibility this surface exists for. So the attribute
+/// list is written flat and folded onto the preceding constraint at build
+/// time; a conflict algorithm with nothing in front of it is a construction
+/// error rather than a syntactically broken table.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Attr {
+    NotNull,
+    Unique,
+    /// Attaches to the `NotNull` or `Unique` immediately before it.
+    OnConflictRollback,
+    /// Attaches to the `NotNull` or `Unique` immediately before it.
+    OnConflictAbort,
+    /// Attaches to the `NotNull` or `Unique` immediately before it.
+    OnConflictFail,
+    /// Attaches to the `NotNull` or `Unique` immediately before it.
+    OnConflictIgnore,
+    /// Attaches to the `NotNull` or `Unique` immediately before it.
+    OnConflictReplace,
+    Check(String),
+    Default(DefaultValue),
+    Collate(String),
+    /// `GENERATED ALWAYS AS (expr) VIRTUAL`.
+    Virtual(String),
+    /// `GENERATED ALWAYS AS (expr) STORED`.
+    Stored(String),
+}
+
+/// No primary key declared yet.
+pub enum NoPk {}
+/// The key is a single ascending `INTEGER` column: the rowid alias, and the
+/// only shape `AUTOINCREMENT` is legal on.
+pub enum IntPk {}
+/// A key that is not the rowid alias -- another type, a descending order, or
+/// more than one column.
+pub enum KeyedPk {}
+
+/// Neither `AUTOINCREMENT` nor `WITHOUT ROWID` has been chosen.
+pub enum Rowid {}
+/// `AUTOINCREMENT` chosen, which forecloses `WITHOUT ROWID`.
+pub enum AutoKey {}
+/// `WITHOUT ROWID` chosen, which forecloses `AUTOINCREMENT`.
+pub enum NoRowid {}
+
+/// Implemented by the states in which a primary key exists.
+pub trait HasPk {}
+impl HasPk for IntPk {}
+impl HasPk for KeyedPk {}
+
+/// Accumulates tables. Errors are held until [`SchemaBuilder::build`] so the
+/// authoring chain stays free of `?`.
+#[derive(Debug, Default)]
+pub struct SchemaBuilder {
+    tables: Vec<Table>,
+    error: Option<ValidationError>,
+}
+
+impl SchemaBuilder {
+    /// Add a table. Generic over the builder's state, which is where the
+    /// typestate is erased: differently-parameterized `TableBuilder`s are
+    /// different types and could not otherwise share one `Vec`.
+    pub fn table<P, R>(mut self, builder: TableBuilder<P, R>) -> Self {
+        let (table, error) = builder.finish();
+        self.error = self.error.take().or(error);
+        self.tables.push(table);
+        self
+    }
+
+    /// Validate and hand over the schema. This is the one fallible point in
+    /// the chain, and it runs the full grammar, not only the errors the
+    /// builder collected.
+    pub fn build(self) -> Result<Schema, ValidationError> {
+        if let Some(error) = self.error {
+            return Err(error);
+        }
+        let schema = Schema {
+            tables: self.tables,
+        };
+        schema.validate()?;
+        Ok(schema)
+    }
+}
+
+/// A table under construction. `P` tracks what kind of primary key it has and
+/// `R` tracks whether the rowid question has been settled; both are erased by
+/// [`SchemaBuilder::table`].
+#[derive(Debug)]
+pub struct TableBuilder<P, R> {
+    table: Table,
+    error: Option<ValidationError>,
+    state: PhantomData<fn(P, R)>,
+}
+
+impl<P, R> TableBuilder<P, R> {
+    /// Move to another state. Private: the only transitions are the ones the
+    /// public methods below expose.
+    fn retype<P2, R2>(self) -> TableBuilder<P2, R2> {
+        TableBuilder {
+            table: self.table,
+            error: self.error,
+            state: PhantomData,
+        }
+    }
+
+    fn fail(&mut self, error: ValidationError) {
+        if self.error.is_none() {
+            self.error = Some(error);
+        }
+    }
+
+    /// Add a column with a declared type.
+    pub fn col(
+        self,
+        name: impl Into<String>,
+        decl_type: ColumnType,
+        attrs: impl IntoIterator<Item = Attr>,
+    ) -> Self {
+        self.push_column(name.into(), Some(decl_type), attrs)
+    }
+
+    /// Add a column with no declared type -- blank affinity, legal SQLite, and
+    /// a shape transformations invent a type for. See
+    /// [`Trait::TypelessColumn`](super::Trait::TypelessColumn).
+    pub fn typeless(self, name: impl Into<String>, attrs: impl IntoIterator<Item = Attr>) -> Self {
+        self.push_column(name.into(), None, attrs)
+    }
+
+    fn push_column(
+        mut self,
+        name: String,
+        decl_type: Option<ColumnType>,
+        attrs: impl IntoIterator<Item = Attr>,
+    ) -> Self {
+        let mut constraints: Vec<ColumnConstraint> = Vec::new();
+        let mut orphan = false;
+        for attr in attrs {
+            match attr {
+                Attr::NotNull => constraints.push(ColumnConstraint::NotNull(None)),
+                Attr::Unique => constraints.push(ColumnConstraint::Unique(None)),
+                Attr::OnConflictRollback => {
+                    orphan |= !attach_conflict(&mut constraints, OnConflict::Rollback)
+                }
+                Attr::OnConflictAbort => {
+                    orphan |= !attach_conflict(&mut constraints, OnConflict::Abort)
+                }
+                Attr::OnConflictFail => {
+                    orphan |= !attach_conflict(&mut constraints, OnConflict::Fail)
+                }
+                Attr::OnConflictIgnore => {
+                    orphan |= !attach_conflict(&mut constraints, OnConflict::Ignore)
+                }
+                Attr::OnConflictReplace => {
+                    orphan |= !attach_conflict(&mut constraints, OnConflict::Replace)
+                }
+                Attr::Check(expr) => constraints.push(ColumnConstraint::Check(expr)),
+                Attr::Default(value) => constraints.push(ColumnConstraint::Default(value)),
+                Attr::Collate(name) => constraints.push(ColumnConstraint::Collate(name)),
+                Attr::Virtual(expr) => constraints.push(ColumnConstraint::Generated {
+                    expr,
+                    storage: Generated::Virtual,
+                }),
+                Attr::Stored(expr) => constraints.push(ColumnConstraint::Generated {
+                    expr,
+                    storage: Generated::Stored,
+                }),
+            }
+        }
+        if orphan {
+            let table = self.table.name.clone();
+            self.fail(ValidationError::OrphanConflictClause {
+                table,
+                column: name.clone(),
+            });
+        }
+        self.table.columns.push(Column {
+            name,
+            decl_type,
+            constraints,
+        });
+        self
+    }
+
+    /// Add a table-level constraint verbatim, for shapes the sugar does not
+    /// cover.
+    pub fn constraint(mut self, constraint: TableConstraint) -> Self {
+        self.table.constraints.push(constraint);
+        self
+    }
+
+    /// Add a foreign key. Refine it with [`on_delete`](Self::on_delete) or
+    /// [`on_update`](Self::on_update) immediately after.
+    pub fn fk<C, P2>(
+        mut self,
+        columns: C,
+        parent_table: impl Into<String>,
+        parent_columns: P2,
+    ) -> Self
+    where
+        C: IntoIterator,
+        C::Item: Into<String>,
+        P2: IntoIterator,
+        P2::Item: Into<String>,
+    {
+        self.table
+            .constraints
+            .push(TableConstraint::ForeignKey(ForeignKey {
+                columns: columns.into_iter().map(Into::into).collect(),
+                parent_table: parent_table.into(),
+                parent_columns: parent_columns.into_iter().map(Into::into).collect(),
+                on_delete: None,
+                on_update: None,
+            }));
+        self
+    }
+
+    /// Set `ON DELETE` on the most recent foreign key.
+    pub fn on_delete(self, action: ReferentialAction) -> Self {
+        self.set_fk_action(Some(action), None)
+    }
+
+    /// Set `ON UPDATE` on the most recent foreign key.
+    pub fn on_update(self, action: ReferentialAction) -> Self {
+        self.set_fk_action(None, Some(action))
+    }
+
+    fn set_fk_action(
+        mut self,
+        on_delete: Option<ReferentialAction>,
+        on_update: Option<ReferentialAction>,
+    ) -> Self {
+        let last = self
+            .table
+            .constraints
+            .iter_mut()
+            .rev()
+            .find_map(|c| match c {
+                TableConstraint::ForeignKey(fk) => Some(fk),
+                _ => None,
+            });
+        match last {
+            Some(fk) => {
+                if on_delete.is_some() {
+                    fk.on_delete = on_delete;
+                }
+                if on_update.is_some() {
+                    fk.on_update = on_update;
+                }
+            }
+            // Nothing to attach to. The table itself would still be
+            // well-formed, so the action would vanish silently -- which is the
+            // exact defect shape forger exists to catch. Report it.
+            None => {
+                let table = self.table.name.clone();
+                self.fail(ValidationError::NoForeignKeyToRefine { table });
+            }
+        }
+        self
+    }
+
+    /// Attach a trigger to this table.
+    pub fn trigger(mut self, trigger: Trigger) -> Self {
+        self.table.triggers.push(trigger);
+        self
+    }
+
+    /// Mark the table STRICT, which narrows the legal type names to the six
+    /// storage classes and makes a typeless column illegal.
+    pub fn strict(mut self) -> Self {
+        self.table.strict = true;
+        self
+    }
+
+    fn finish(self) -> (Table, Option<ValidationError>) {
+        (self.table, self.error)
+    }
+}
+
+impl TableBuilder<NoPk, Rowid> {
+    /// `INTEGER PRIMARY KEY` -- the rowid alias, and the only key
+    /// `AUTOINCREMENT` can be added to.
+    pub fn pk_int(self, name: impl Into<String>) -> TableBuilder<IntPk, Rowid> {
+        self.push_pk_column(name.into(), ColumnType::Integer, SortOrder::Asc)
+            .retype()
+    }
+
+    /// A single-column key of another type.
+    pub fn pk_text(self, name: impl Into<String>) -> TableBuilder<KeyedPk, Rowid> {
+        self.push_pk_column(name.into(), ColumnType::Text, SortOrder::Asc)
+            .retype()
+    }
+
+    /// A single-column key, spelled out. `INTEGER` with [`SortOrder::Desc`]
+    /// lands here rather than in [`IntPk`] because a descending integer key is
+    /// not a rowid alias, so `AUTOINCREMENT` is not legal on it.
+    pub fn pk_col(
+        self,
+        name: impl Into<String>,
+        decl_type: ColumnType,
+        order: SortOrder,
+    ) -> TableBuilder<KeyedPk, Rowid> {
+        self.push_pk_column(name.into(), decl_type, order).retype()
+    }
+
+    /// A key over columns declared elsewhere in the table, as a table-level
+    /// constraint.
+    pub fn pk_composite(
+        mut self,
+        columns: impl IntoIterator<Item = IndexedColumn>,
+    ) -> TableBuilder<KeyedPk, Rowid> {
+        self.table.constraints.push(TableConstraint::PrimaryKey {
+            columns: columns.into_iter().collect(),
+            on_conflict: None,
+        });
+        self.retype()
+    }
+
+    fn push_pk_column(
+        mut self,
+        name: String,
+        decl_type: ColumnType,
+        order: SortOrder,
+    ) -> TableBuilder<NoPk, Rowid> {
+        self.table.columns.push(Column {
+            name,
+            decl_type: Some(decl_type),
+            constraints: vec![ColumnConstraint::PrimaryKey {
+                order,
+                autoincrement: false,
+                on_conflict: None,
+            }],
+        });
+        self
+    }
+}
+
+impl TableBuilder<IntPk, Rowid> {
+    /// Add `AUTOINCREMENT`. Reachable only from [`pk_int`](TableBuilder::pk_int),
+    /// and it consumes the undecided rowid state so `WITHOUT ROWID` can no
+    /// longer be asked for.
+    ///
+    /// A text key has no rowid sequence to draw from, so this does not exist
+    /// there:
+    ///
+    /// ```compile_fail
+    /// use smugglr_forger::schema::builder::table;
+    /// let t = table("k").pk_text("id").autoincrement();
+    /// ```
+    ///
+    /// Neither does it exist once `WITHOUT ROWID` has been chosen:
+    ///
+    /// ```compile_fail
+    /// use smugglr_forger::schema::builder::table;
+    /// let t = table("k").pk_int("id").without_rowid().autoincrement();
+    /// ```
+    pub fn autoincrement(mut self) -> TableBuilder<IntPk, AutoKey> {
+        for column in &mut self.table.columns {
+            for constraint in &mut column.constraints {
+                if let ColumnConstraint::PrimaryKey { autoincrement, .. } = constraint {
+                    // The IntPk state guarantees this column exists.
+                    *autoincrement = true;
+                }
+            }
+        }
+        self.retype()
+    }
+}
+
+/// Fold a conflict algorithm onto the constraint in front of it. Returns
+/// false when there is nothing in front of it, which is not expressible in
+/// SQLite's grammar.
+fn attach_conflict(constraints: &mut [ColumnConstraint], algorithm: OnConflict) -> bool {
+    match constraints.last_mut() {
+        Some(ColumnConstraint::NotNull(slot) | ColumnConstraint::Unique(slot)) => {
+            *slot = Some(algorithm);
+            true
+        }
+        _ => false,
+    }
+}
+
+impl<P: HasPk> TableBuilder<P, Rowid> {
+    /// Make the table `WITHOUT ROWID`. Reachable only once a primary key
+    /// exists, and it consumes the undecided rowid state so `AUTOINCREMENT`
+    /// can no longer be asked for.
+    ///
+    /// A `WITHOUT ROWID` table with no key has no way to address a row, so
+    /// this does not exist before one is declared:
+    ///
+    /// ```compile_fail
+    /// use smugglr_forger::schema::builder::table;
+    /// use smugglr_forger::schema::ColumnType::Text;
+    /// let t = table("k").col("v", Text, []).without_rowid();
+    /// ```
+    ///
+    /// And it is gone once `AUTOINCREMENT` has been chosen:
+    ///
+    /// ```compile_fail
+    /// use smugglr_forger::schema::builder::table;
+    /// let t = table("k").pk_int("id").autoincrement().without_rowid();
+    /// ```
+    pub fn without_rowid(mut self) -> TableBuilder<P, NoRowid> {
+        self.table.without_rowid = true;
+        self.retype()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::Column;
+
+    /// The property that makes the builder trustworthy: it is sugar over the
+    /// model and nothing else. If these two ever diverge, a probe written
+    /// against an authored schema stops meaning what it says.
+    #[test]
+    fn authored_and_literal_agree() {
+        let authored = schema()
+            .table(table("users").pk_int("id").autoincrement().col(
+                "email",
+                ColumnType::Text,
+                [Attr::NotNull, Attr::Unique, Attr::OnConflictReplace],
+            ))
+            .build()
+            .expect("valid");
+
+        let literal = Schema {
+            tables: vec![Table {
+                name: "users".into(),
+                columns: vec![
+                    Column {
+                        name: "id".into(),
+                        decl_type: Some(ColumnType::Integer),
+                        constraints: vec![ColumnConstraint::PrimaryKey {
+                            order: SortOrder::Asc,
+                            autoincrement: true,
+                            on_conflict: None,
+                        }],
+                    },
+                    Column {
+                        name: "email".into(),
+                        decl_type: Some(ColumnType::Text),
+                        constraints: vec![
+                            ColumnConstraint::NotNull(None),
+                            ColumnConstraint::Unique(Some(OnConflict::Replace)),
+                        ],
+                    },
+                ],
+                constraints: Vec::new(),
+                without_rowid: false,
+                strict: false,
+                triggers: Vec::new(),
+            }],
+        };
+
+        assert_eq!(authored, literal);
+    }
+
+    #[test]
+    fn a_conflict_algorithm_binds_to_the_constraint_in_front_of_it() {
+        let s = schema()
+            .table(table("t").col(
+                "v",
+                ColumnType::Text,
+                [Attr::Unique, Attr::OnConflictIgnore, Attr::NotNull],
+            ))
+            .build()
+            .expect("valid");
+
+        assert_eq!(
+            s.tables[0].columns[0].constraints,
+            vec![
+                ColumnConstraint::Unique(Some(OnConflict::Ignore)),
+                ColumnConstraint::NotNull(None),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_conflict_algorithm_with_nothing_in_front_of_it_is_refused() {
+        let error = schema()
+            .table(table("t").col("v", ColumnType::Text, [Attr::OnConflictAbort]))
+            .build()
+            .expect_err("ON CONFLICT cannot stand alone");
+
+        assert_eq!(
+            error,
+            ValidationError::OrphanConflictClause {
+                table: "t".into(),
+                column: "v".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_conflict_algorithm_cannot_attach_to_a_default() {
+        let error = schema()
+            .table(table("t").col(
+                "v",
+                ColumnType::Text,
+                [
+                    Attr::Default(DefaultValue::Integer(1)),
+                    Attr::OnConflictFail,
+                ],
+            ))
+            .build()
+            .expect_err("DEFAULT takes no conflict clause");
+
+        assert!(matches!(
+            error,
+            ValidationError::OrphanConflictClause { .. }
+        ));
+    }
+
+    #[test]
+    fn a_referential_action_lands_on_the_key_in_front_of_it() {
+        let s = schema()
+            .table(table("parent").pk_int("id"))
+            .table(
+                table("child")
+                    .pk_int("id")
+                    .col("a", ColumnType::Integer, [])
+                    .fk(["a"], "parent", ["id"])
+                    .on_delete(ReferentialAction::Cascade)
+                    .on_update(ReferentialAction::Restrict),
+            )
+            .build()
+            .expect("valid");
+
+        assert_eq!(
+            s.tables[1].constraints,
+            vec![TableConstraint::ForeignKey(ForeignKey {
+                columns: vec!["a".into()],
+                parent_table: "parent".into(),
+                parent_columns: vec!["id".into()],
+                on_delete: Some(ReferentialAction::Cascade),
+                on_update: Some(ReferentialAction::Restrict),
+            })]
+        );
+    }
+
+    #[test]
+    fn a_referential_action_with_no_key_in_front_of_it_is_refused() {
+        let error = schema()
+            .table(
+                table("t")
+                    .pk_int("id")
+                    .on_delete(ReferentialAction::Cascade),
+            )
+            .build()
+            .expect_err("nothing to attach the action to");
+
+        assert_eq!(
+            error,
+            ValidationError::NoForeignKeyToRefine { table: "t".into() }
+        );
+    }
+
+    /// The builder cannot express a generated primary key at column level --
+    /// [`Attr`] has no key variant -- but it can route one through a composite
+    /// key, and `build` is where that is caught.
+    #[test]
+    fn build_runs_the_whole_grammar_not_only_what_the_builder_collected() {
+        let error = schema()
+            .table(
+                table("t")
+                    .col("a", ColumnType::Integer, [])
+                    .col("g", ColumnType::Text, [Attr::Stored("'x'".into())])
+                    .pk_composite([
+                        IndexedColumn::new("a", SortOrder::Asc),
+                        IndexedColumn::new("g", SortOrder::Asc),
+                    ]),
+            )
+            .build()
+            .expect_err("a generated column cannot be part of the key");
+
+        assert_eq!(
+            error,
+            ValidationError::GeneratedPrimaryKey {
+                table: "t".into(),
+                column: "g".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn the_first_error_is_the_one_reported() {
+        let error = schema()
+            .table(table("t").col("v", ColumnType::Text, [Attr::OnConflictAbort]))
+            .table(table("t").col("w", ColumnType::Text, []))
+            .build()
+            .expect_err("two problems, one report");
+
+        // The builder's own error comes first because it was seen first, not
+        // because it outranks the duplicate table name.
+        assert!(matches!(
+            error,
+            ValidationError::OrphanConflictClause { .. }
+        ));
+    }
+}

--- a/crates/smugglr-forger/src/schema/ddl.rs
+++ b/crates/smugglr-forger/src/schema/ddl.rs
@@ -1,0 +1,472 @@
+//! Rendering a [`Schema`] to DDL SQLite accepts.
+//!
+//! The renderer is deliberately literal: it writes what the model says, in the
+//! order the model says it, and never normalizes. A renderer that tidied its
+//! input would hide exactly the differences forger exists to catch -- if
+//! rendering "fixed" a missing `ON CONFLICT`, a transformation that dropped
+//! one would round-trip clean.
+//!
+//! Every table is emitted before every trigger, because a trigger body may
+//! reach into a table declared after the one it fires on.
+
+use super::{
+    Column, ColumnConstraint, DefaultValue, ForeignKey, IndexedColumn, Schema, SortOrder, Table,
+    TableConstraint, Trigger, TriggerEvent, TriggerTiming,
+};
+
+pub fn render(schema: &Schema) -> String {
+    let mut out = String::new();
+    for table in &schema.tables {
+        out.push_str(&render_table(table));
+        out.push_str(";\n\n");
+    }
+    for table in &schema.tables {
+        for trigger in &table.triggers {
+            out.push_str(&render_trigger(&table.name, trigger));
+            out.push_str(";\n\n");
+        }
+    }
+    out
+}
+
+pub fn render_table(table: &Table) -> String {
+    let mut parts: Vec<String> = table.columns.iter().map(render_column).collect();
+    parts.extend(table.constraints.iter().map(render_table_constraint));
+
+    let mut sql = format!(
+        "CREATE TABLE {} (\n  {}\n)",
+        quote(&table.name),
+        parts.join(",\n  ")
+    );
+
+    // Table options are a comma-separated suffix outside the parentheses.
+    let mut options: Vec<&str> = Vec::new();
+    if table.strict {
+        options.push("STRICT");
+    }
+    if table.without_rowid {
+        options.push("WITHOUT ROWID");
+    }
+    if !options.is_empty() {
+        sql.push(' ');
+        sql.push_str(&options.join(", "));
+    }
+    sql
+}
+
+fn render_column(column: &Column) -> String {
+    let mut sql = quote(&column.name);
+    // A typeless column is the absence of a type name, not an empty one.
+    if let Some(decl) = &column.decl_type {
+        sql.push(' ');
+        sql.push_str(decl.as_sql());
+    }
+    for constraint in &column.constraints {
+        sql.push(' ');
+        sql.push_str(&render_column_constraint(constraint));
+    }
+    sql
+}
+
+fn render_column_constraint(constraint: &ColumnConstraint) -> String {
+    match constraint {
+        ColumnConstraint::PrimaryKey {
+            order,
+            autoincrement,
+            on_conflict,
+        } => {
+            let mut sql = String::from("PRIMARY KEY");
+            if *order == SortOrder::Desc {
+                sql.push_str(" DESC");
+            }
+            sql.push_str(&conflict_clause(on_conflict));
+            // AUTOINCREMENT trails the conflict clause; it is part of the key
+            // declaration rather than a constraint of its own.
+            if *autoincrement {
+                sql.push_str(" AUTOINCREMENT");
+            }
+            sql
+        }
+        ColumnConstraint::NotNull(on_conflict) => {
+            format!("NOT NULL{}", conflict_clause(on_conflict))
+        }
+        ColumnConstraint::Unique(on_conflict) => {
+            format!("UNIQUE{}", conflict_clause(on_conflict))
+        }
+        ColumnConstraint::Check(expr) => format!("CHECK ({expr})"),
+        ColumnConstraint::Default(value) => format!("DEFAULT {}", render_default(value)),
+        ColumnConstraint::Collate(name) => format!("COLLATE {name}"),
+        ColumnConstraint::Generated { expr, storage } => format!(
+            "GENERATED ALWAYS AS ({expr}) {}",
+            match storage {
+                super::Generated::Virtual => "VIRTUAL",
+                super::Generated::Stored => "STORED",
+            }
+        ),
+    }
+}
+
+fn render_default(value: &DefaultValue) -> String {
+    match value {
+        DefaultValue::Null => "NULL".to_string(),
+        DefaultValue::Integer(n) => n.to_string(),
+        DefaultValue::Real(n) => {
+            // Debug formatting keeps the decimal point on whole floats, so
+            // 1.0 does not silently become the integer literal 1.
+            format!("{n:?}")
+        }
+        DefaultValue::Text(s) => quote_literal(s),
+        DefaultValue::Blob(bytes) => {
+            let hex: String = bytes.iter().map(|b| format!("{b:02X}")).collect();
+            format!("X'{hex}'")
+        }
+        // The parentheses are what make this an expression rather than a
+        // literal. Rendering them is not cosmetic.
+        DefaultValue::Expr(expr) => format!("({expr})"),
+    }
+}
+
+fn render_table_constraint(constraint: &TableConstraint) -> String {
+    match constraint {
+        TableConstraint::PrimaryKey {
+            columns,
+            on_conflict,
+        } => format!(
+            "PRIMARY KEY ({}){}",
+            indexed_columns(columns),
+            conflict_clause(on_conflict)
+        ),
+        TableConstraint::Unique {
+            columns,
+            on_conflict,
+        } => format!(
+            "UNIQUE ({}){}",
+            indexed_columns(columns),
+            conflict_clause(on_conflict)
+        ),
+        TableConstraint::Check(expr) => format!("CHECK ({expr})"),
+        TableConstraint::ForeignKey(fk) => render_foreign_key(fk),
+    }
+}
+
+fn render_foreign_key(fk: &ForeignKey) -> String {
+    let mut sql = format!(
+        "FOREIGN KEY ({}) REFERENCES {} ({})",
+        fk.columns
+            .iter()
+            .map(|c| quote(c))
+            .collect::<Vec<_>>()
+            .join(", "),
+        quote(&fk.parent_table),
+        fk.parent_columns
+            .iter()
+            .map(|c| quote(c))
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    if let Some(action) = &fk.on_delete {
+        sql.push_str(&format!(" ON DELETE {}", action.as_sql()));
+    }
+    if let Some(action) = &fk.on_update {
+        sql.push_str(&format!(" ON UPDATE {}", action.as_sql()));
+    }
+    sql
+}
+
+pub fn render_trigger(table: &str, trigger: &Trigger) -> String {
+    let timing = match trigger.timing {
+        TriggerTiming::Before => "BEFORE",
+        TriggerTiming::After => "AFTER",
+    };
+    let event = match &trigger.event {
+        TriggerEvent::Insert => "INSERT".to_string(),
+        TriggerEvent::Delete => "DELETE".to_string(),
+        TriggerEvent::Update => "UPDATE".to_string(),
+        TriggerEvent::UpdateOf(columns) => format!(
+            "UPDATE OF {}",
+            columns
+                .iter()
+                .map(|c| quote(c))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    };
+
+    let mut sql = format!(
+        "CREATE TRIGGER {} {timing} {event} ON {}\nFOR EACH ROW",
+        quote(&trigger.name),
+        quote(table),
+    );
+    if let Some(when) = &trigger.when {
+        sql.push_str(&format!("\nWHEN {when}"));
+    }
+    sql.push_str("\nBEGIN\n");
+    for statement in &trigger.body {
+        sql.push_str(&format!("  {statement};\n"));
+    }
+    sql.push_str("END");
+    sql
+}
+
+fn indexed_columns(columns: &[IndexedColumn]) -> String {
+    columns
+        .iter()
+        .map(|c| match c.order {
+            SortOrder::Asc => quote(&c.name),
+            SortOrder::Desc => format!("{} DESC", quote(&c.name)),
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn conflict_clause(on_conflict: &Option<super::OnConflict>) -> String {
+    match on_conflict {
+        Some(algorithm) => format!(" ON CONFLICT {}", algorithm.as_sql()),
+        None => String::new(),
+    }
+}
+
+/// Quote an identifier. Doubling an embedded quote is what keeps a column
+/// named `a"b` from ending the identifier early.
+fn quote(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Quote a string literal. Single quotes double, same rule, different delimiter.
+fn quote_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::builder::{schema, table, Attr};
+    use crate::schema::{ColumnType, Generated, OnConflict, ReferentialAction, TriggerEvent};
+
+    fn one_table(builder: crate::schema::builder::SchemaBuilder) -> String {
+        let schema = builder.build().expect("valid");
+        render_table(&schema.tables[0])
+    }
+
+    #[test]
+    fn an_autoincrement_key_renders_as_the_rowid_alias() {
+        let sql = one_table(schema().table(table("t").pk_int("id").autoincrement()));
+        assert_eq!(
+            sql,
+            "CREATE TABLE \"t\" (\n  \"id\" INTEGER PRIMARY KEY AUTOINCREMENT\n)"
+        );
+    }
+
+    #[test]
+    fn a_conflict_algorithm_renders_against_its_own_constraint() {
+        let sql = one_table(schema().table(table("t").col(
+            "v",
+            ColumnType::Text,
+            [
+                Attr::NotNull,
+                Attr::OnConflictReplace,
+                Attr::Unique,
+                Attr::OnConflictIgnore,
+            ],
+        )));
+        assert!(
+            sql.contains("\"v\" TEXT NOT NULL ON CONFLICT REPLACE UNIQUE ON CONFLICT IGNORE"),
+            "{sql}"
+        );
+    }
+
+    #[test]
+    fn an_expression_default_keeps_its_parentheses() {
+        let sql = one_table(schema().table(table("t").col(
+            "v",
+            ColumnType::Text,
+            [Attr::Default(DefaultValue::expr("CURRENT_TIMESTAMP"))],
+        )));
+        assert!(sql.contains("DEFAULT (CURRENT_TIMESTAMP)"), "{sql}");
+    }
+
+    #[test]
+    fn a_text_default_is_quoted_and_a_quote_inside_it_is_doubled() {
+        let sql = one_table(schema().table(table("t").col(
+            "v",
+            ColumnType::Text,
+            [Attr::Default(DefaultValue::text("it's"))],
+        )));
+        assert!(sql.contains("DEFAULT 'it''s'"), "{sql}");
+    }
+
+    #[test]
+    fn a_whole_real_default_keeps_its_decimal_point() {
+        let sql = one_table(schema().table(table("t").col(
+            "v",
+            ColumnType::Real,
+            [Attr::Default(DefaultValue::Real(1.0))],
+        )));
+        assert!(sql.contains("DEFAULT 1.0"), "{sql}");
+    }
+
+    #[test]
+    fn a_blob_default_renders_as_a_hex_literal() {
+        let sql = one_table(schema().table(table("t").col(
+            "v",
+            ColumnType::Blob,
+            [Attr::Default(DefaultValue::Blob(vec![0x00, 0xde, 0xad]))],
+        )));
+        assert!(sql.contains("DEFAULT X'00DEAD'"), "{sql}");
+    }
+
+    #[test]
+    fn a_generated_column_names_its_storage() {
+        let sql = one_table(
+            schema().table(
+                table("t")
+                    .col("a", ColumnType::Integer, [])
+                    .col("v", ColumnType::Text, [Attr::Virtual("a + 1".into())])
+                    .col("s", ColumnType::Text, [Attr::Stored("a + 2".into())]),
+            ),
+        );
+        assert!(
+            sql.contains("\"v\" TEXT GENERATED ALWAYS AS (a + 1) VIRTUAL"),
+            "{sql}"
+        );
+        assert!(
+            sql.contains("\"s\" TEXT GENERATED ALWAYS AS (a + 2) STORED"),
+            "{sql}"
+        );
+    }
+
+    #[test]
+    fn a_typeless_column_gets_no_type_name() {
+        let sql = one_table(schema().table(table("t").typeless("v", [Attr::NotNull])));
+        assert!(sql.contains("\"v\" NOT NULL"), "{sql}");
+    }
+
+    #[test]
+    fn a_descending_key_says_so() {
+        let sql = one_table(schema().table(table("t").pk_col(
+            "id",
+            ColumnType::Integer,
+            SortOrder::Desc,
+        )));
+        assert!(sql.contains("\"id\" INTEGER PRIMARY KEY DESC"), "{sql}");
+    }
+
+    #[test]
+    fn table_options_follow_the_closing_parenthesis() {
+        let sql = one_table(schema().table(table("t").pk_text("id").strict().without_rowid()));
+        assert!(sql.ends_with(") STRICT, WITHOUT ROWID"), "{sql}");
+    }
+
+    #[test]
+    fn a_referential_action_renders_after_the_reference() {
+        let schema = schema()
+            .table(table("parent").pk_int("id"))
+            .table(
+                table("child")
+                    .pk_int("id")
+                    .col("a", ColumnType::Integer, [])
+                    .fk(["a"], "parent", ["id"])
+                    .on_delete(ReferentialAction::Cascade)
+                    .on_update(ReferentialAction::SetNull),
+            )
+            .build()
+            .expect("valid");
+        let sql = render_table(&schema.tables[1]);
+        assert!(
+            sql.contains(
+                "FOREIGN KEY (\"a\") REFERENCES \"parent\" (\"id\") \
+                 ON DELETE CASCADE ON UPDATE SET NULL"
+            ),
+            "{sql}"
+        );
+    }
+
+    #[test]
+    fn an_embedded_quote_does_not_end_the_identifier_early() {
+        let schema = Schema {
+            tables: vec![Table {
+                name: "we\"ird".into(),
+                columns: vec![Column {
+                    name: "a\"b".into(),
+                    decl_type: Some(ColumnType::Text),
+                    constraints: Vec::new(),
+                }],
+                constraints: Vec::new(),
+                without_rowid: false,
+                strict: false,
+                triggers: Vec::new(),
+            }],
+        };
+        let sql = render_table(&schema.tables[0]);
+        assert!(sql.starts_with("CREATE TABLE \"we\"\"ird\""), "{sql}");
+        assert!(sql.contains("\"a\"\"b\" TEXT"), "{sql}");
+    }
+
+    #[test]
+    fn a_trigger_renders_with_its_guard_and_body() {
+        let trigger = Trigger {
+            name: "bump".into(),
+            timing: TriggerTiming::After,
+            event: TriggerEvent::UpdateOf(vec!["v".into()]),
+            when: Some("new.v <> old.v".into()),
+            body: vec!["UPDATE \"t\" SET \"n\" = \"n\" + 1".into()],
+        };
+        let sql = render_trigger("t", &trigger);
+        assert_eq!(
+            sql,
+            "CREATE TRIGGER \"bump\" AFTER UPDATE OF \"v\" ON \"t\"\n\
+             FOR EACH ROW\n\
+             WHEN new.v <> old.v\n\
+             BEGIN\n  \
+             UPDATE \"t\" SET \"n\" = \"n\" + 1;\n\
+             END"
+        );
+    }
+
+    #[test]
+    fn triggers_render_after_every_table() {
+        let schema = schema()
+            .table(table("a").pk_int("id").trigger(Trigger {
+                name: "trg".into(),
+                timing: TriggerTiming::After,
+                event: TriggerEvent::Insert,
+                when: None,
+                body: vec!["INSERT INTO \"b\" DEFAULT VALUES".into()],
+            }))
+            .table(table("b").pk_int("id"))
+            .build()
+            .expect("valid");
+        let sql = render(&schema);
+        let trigger_at = sql.find("CREATE TRIGGER").expect("trigger rendered");
+        let last_table_at = sql.find("CREATE TABLE \"b\"").expect("table rendered");
+        assert!(
+            trigger_at > last_table_at,
+            "a trigger body may reach into a table declared after its own: {sql}"
+        );
+    }
+
+    #[test]
+    fn generated_storage_renders_both_ways() {
+        // Guards the match in render_column_constraint against a silent swap.
+        assert_eq!(
+            render_column_constraint(&ColumnConstraint::Generated {
+                expr: "1".into(),
+                storage: Generated::Stored,
+            }),
+            "GENERATED ALWAYS AS (1) STORED"
+        );
+    }
+
+    #[test]
+    fn every_conflict_algorithm_has_a_spelling() {
+        for (algorithm, expected) in [
+            (OnConflict::Rollback, "ROLLBACK"),
+            (OnConflict::Abort, "ABORT"),
+            (OnConflict::Fail, "FAIL"),
+            (OnConflict::Ignore, "IGNORE"),
+            (OnConflict::Replace, "REPLACE"),
+        ] {
+            assert_eq!(algorithm.as_sql(), expected);
+        }
+    }
+}

--- a/crates/smugglr-forger/src/schema/ddl.rs
+++ b/crates/smugglr-forger/src/schema/ddl.rs
@@ -152,17 +152,9 @@ fn render_table_constraint(constraint: &TableConstraint) -> String {
 fn render_foreign_key(fk: &ForeignKey) -> String {
     let mut sql = format!(
         "FOREIGN KEY ({}) REFERENCES {} ({})",
-        fk.columns
-            .iter()
-            .map(|c| quote(c))
-            .collect::<Vec<_>>()
-            .join(", "),
+        name_list(&fk.columns),
         quote(&fk.parent_table),
-        fk.parent_columns
-            .iter()
-            .map(|c| quote(c))
-            .collect::<Vec<_>>()
-            .join(", "),
+        name_list(&fk.parent_columns),
     );
     if let Some(action) = &fk.on_delete {
         sql.push_str(&format!(" ON DELETE {}", action.as_sql()));
@@ -182,14 +174,7 @@ pub fn render_trigger(table: &str, trigger: &Trigger) -> String {
         TriggerEvent::Insert => "INSERT".to_string(),
         TriggerEvent::Delete => "DELETE".to_string(),
         TriggerEvent::Update => "UPDATE".to_string(),
-        TriggerEvent::UpdateOf(columns) => format!(
-            "UPDATE OF {}",
-            columns
-                .iter()
-                .map(|c| quote(c))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
+        TriggerEvent::UpdateOf(columns) => format!("UPDATE OF {}", name_list(columns)),
     };
 
     let mut sql = format!(
@@ -206,6 +191,15 @@ pub fn render_trigger(table: &str, trigger: &Trigger) -> String {
     }
     sql.push_str("END");
     sql
+}
+
+/// A comma-separated list of quoted identifiers.
+fn name_list(names: &[String]) -> String {
+    names
+        .iter()
+        .map(|name| quote(name))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn indexed_columns(columns: &[IndexedColumn]) -> String {

--- a/crates/smugglr-forger/src/schema/mod.rs
+++ b/crates/smugglr-forger/src/schema/mod.rs
@@ -1,0 +1,324 @@
+//! The schema model: plain owned data, no lifetime tied to a connection.
+//!
+//! A [`Schema`] is a value. It can be authored by hand through
+//! [`builder`], constructed literally, sent through serde, compared, and
+//! cloned -- and none of that requires a database to exist. That is what lets
+//! a probe take a schema without knowing where it came from, and what lets a
+//! failing schema be pinned as a legible regression test.
+//!
+//! Validity is a separate concern from representability, deliberately. The
+//! model can hold a generated primary key; SQLite cannot. [`validate`] is
+//! where that gap is closed, and [`builder`] closes part of it earlier, in the
+//! type system. See the module docs there for which invariants land where.
+
+pub mod builder;
+pub mod ddl;
+pub mod validate;
+
+use serde::{Deserialize, Serialize};
+
+/// A set of tables and the triggers hanging off them.
+///
+/// Not `Eq`, because a `REAL` default is an `f64`. `PartialEq` is what the
+/// "authored and literal compare equal" property needs.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct Schema {
+    pub tables: Vec<Table>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Table {
+    pub name: String,
+    pub columns: Vec<Column>,
+    /// Constraints that span columns, or that a caller chose to write at the
+    /// table level even when a column-level form exists. SQLite treats the two
+    /// spellings differently in one place that matters -- `INTEGER PRIMARY
+    /// KEY` at column level is a rowid alias, `PRIMARY KEY("id")` at table
+    /// level is not -- so the model keeps them distinguishable.
+    #[serde(default)]
+    pub constraints: Vec<TableConstraint>,
+    #[serde(default)]
+    pub without_rowid: bool,
+    #[serde(default)]
+    pub strict: bool,
+    /// Triggers that fire on this table. They render after every `CREATE
+    /// TABLE`, since a trigger body may reach into a table declared later.
+    #[serde(default)]
+    pub triggers: Vec<Trigger>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Column {
+    pub name: String,
+    /// `None` is a typeless column -- legal SQLite, blank affinity, and a
+    /// shape that transformations reliably get wrong by inventing a type for
+    /// it. See [`Trait::TypelessColumn`].
+    pub decl_type: Option<ColumnType>,
+    #[serde(default)]
+    pub constraints: Vec<ColumnConstraint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ColumnType {
+    Integer,
+    Text,
+    Real,
+    Blob,
+    Numeric,
+    /// Any other declared type name. SQLite accepts arbitrary type names on a
+    /// non-STRICT table and resolves them to an affinity by rule, which is
+    /// another thing a transformation can quietly change.
+    Other(String),
+}
+
+impl ColumnType {
+    /// The type name as it is written in DDL.
+    pub fn as_sql(&self) -> &str {
+        match self {
+            ColumnType::Integer => "INTEGER",
+            ColumnType::Text => "TEXT",
+            ColumnType::Real => "REAL",
+            ColumnType::Blob => "BLOB",
+            ColumnType::Numeric => "NUMERIC",
+            ColumnType::Other(name) => name,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ColumnConstraint {
+    PrimaryKey {
+        order: SortOrder,
+        autoincrement: bool,
+        on_conflict: Option<OnConflict>,
+    },
+    NotNull(Option<OnConflict>),
+    Unique(Option<OnConflict>),
+    Check(String),
+    Default(DefaultValue),
+    Collate(String),
+    Generated {
+        expr: String,
+        storage: Generated,
+    },
+}
+
+/// A conflict resolution algorithm. It is never free-standing in SQLite: it
+/// attaches to the constraint in front of it, which is why every constraint
+/// that can carry one holds it inline rather than the column holding a
+/// separate list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OnConflict {
+    Rollback,
+    Abort,
+    Fail,
+    Ignore,
+    Replace,
+}
+
+impl OnConflict {
+    pub fn as_sql(&self) -> &'static str {
+        match self {
+            OnConflict::Rollback => "ROLLBACK",
+            OnConflict::Abort => "ABORT",
+            OnConflict::Fail => "FAIL",
+            OnConflict::Ignore => "IGNORE",
+            OnConflict::Replace => "REPLACE",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum SortOrder {
+    #[default]
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Generated {
+    Virtual,
+    Stored,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum DefaultValue {
+    Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Blob(Vec<u8>),
+    /// A parenthesized expression default. SQLite requires the parentheses,
+    /// and a transformation that re-renders the default without them produces
+    /// DDL that no longer parses -- or worse, parses as a literal.
+    Expr(String),
+}
+
+impl DefaultValue {
+    pub fn text(value: impl Into<String>) -> Self {
+        DefaultValue::Text(value.into())
+    }
+
+    pub fn expr(value: impl Into<String>) -> Self {
+        DefaultValue::Expr(value.into())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum TableConstraint {
+    PrimaryKey {
+        columns: Vec<IndexedColumn>,
+        on_conflict: Option<OnConflict>,
+    },
+    Unique {
+        columns: Vec<IndexedColumn>,
+        on_conflict: Option<OnConflict>,
+    },
+    Check(String),
+    ForeignKey(ForeignKey),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexedColumn {
+    pub name: String,
+    #[serde(default)]
+    pub order: SortOrder,
+}
+
+impl IndexedColumn {
+    pub fn new(name: impl Into<String>, order: SortOrder) -> Self {
+        Self {
+            name: name.into(),
+            order,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForeignKey {
+    pub columns: Vec<String>,
+    pub parent_table: String,
+    pub parent_columns: Vec<String>,
+    #[serde(default)]
+    pub on_delete: Option<ReferentialAction>,
+    #[serde(default)]
+    pub on_update: Option<ReferentialAction>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReferentialAction {
+    NoAction,
+    Restrict,
+    SetNull,
+    SetDefault,
+    Cascade,
+}
+
+impl ReferentialAction {
+    pub fn as_sql(&self) -> &'static str {
+        match self {
+            ReferentialAction::NoAction => "NO ACTION",
+            ReferentialAction::Restrict => "RESTRICT",
+            ReferentialAction::SetNull => "SET NULL",
+            ReferentialAction::SetDefault => "SET DEFAULT",
+            ReferentialAction::Cascade => "CASCADE",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Trigger {
+    pub name: String,
+    pub timing: TriggerTiming,
+    pub event: TriggerEvent,
+    /// The `WHEN` guard, without the keyword.
+    #[serde(default)]
+    pub when: Option<String>,
+    /// Statements for the `BEGIN ... END` block, each without its semicolon.
+    pub body: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TriggerTiming {
+    Before,
+    After,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TriggerEvent {
+    Insert,
+    Delete,
+    Update,
+    UpdateOf(Vec<String>),
+}
+
+/// A schema feature that a transformation has been observed to lose.
+///
+/// Each variant stands for a defect shape found by hand in a migrate spine
+/// whose tests were green: the feature survives a naive `CREATE TABLE` round
+/// trip in appearance and not in meaning. The variants are declared here
+/// because the model is where a feature is named; wiring each one to a seed
+/// and a probe, and dispatching over them exhaustively, is FR-FORGER-003.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Trait {
+    /// A foreign key carrying `ON DELETE`/`ON UPDATE`. A rebuild that
+    /// re-declares the key without its action silently turns a cascade into a
+    /// no-op, and no row count changes on the day of the migration.
+    ForeignKeyWithAction,
+    /// `GENERATED ALWAYS AS (expr) VIRTUAL` -- occupies a column position but
+    /// stores nothing, so any transformation that copies rows by position
+    /// either fails or writes into a column that refuses writes.
+    GeneratedVirtual,
+    /// `GENERATED ALWAYS AS (expr) STORED` -- indistinguishable from an
+    /// ordinary column in a row dump, and lost as a computation if re-created
+    /// as one.
+    GeneratedStored,
+    /// A conflict algorithm attached to a column constraint. Dropping it
+    /// changes what an `INSERT` does to existing rows, which is a data
+    /// outcome rather than a schema difference.
+    ColumnOnConflict,
+    /// `DEFAULT (expr)`. The parentheses are load-bearing; a re-render that
+    /// drops them changes an expression into a literal or a syntax error.
+    ExpressionDefault,
+    /// A column with no declared type: blank affinity, which a transformation
+    /// tends to "helpfully" resolve to TEXT, changing comparison semantics.
+    TypelessColumn,
+    /// A trigger on the table. Dropping and re-creating a table drops its
+    /// triggers with it, and nothing complains.
+    Trigger,
+    /// A primary key declared `DESC`. Also the case where `INTEGER PRIMARY
+    /// KEY DESC` is not a rowid alias, unlike its ascending spelling.
+    DescendingPrimaryKey,
+}
+
+impl Schema {
+    /// Reject anything SQLite would reject. See [`validate`].
+    pub fn validate(&self) -> Result<(), crate::error::ValidationError> {
+        validate::validate(self)
+    }
+
+    /// Render to `CREATE TABLE` (and `CREATE TRIGGER`) DDL. See [`ddl`].
+    pub fn to_ddl(&self) -> String {
+        ddl::render(self)
+    }
+
+    pub fn table(&self, name: &str) -> Option<&Table> {
+        self.tables.iter().find(|t| t.name == name)
+    }
+}
+
+impl Table {
+    pub fn column(&self, name: &str) -> Option<&Column> {
+        self.columns.iter().find(|c| c.name == name)
+    }
+}
+
+impl Column {
+    /// The `GENERATED ALWAYS AS` clause, if this column has one.
+    pub fn generated(&self) -> Option<(&str, Generated)> {
+        self.constraints.iter().find_map(|c| match c {
+            ColumnConstraint::Generated { expr, storage } => Some((expr.as_str(), *storage)),
+            _ => None,
+        })
+    }
+}

--- a/crates/smugglr-forger/src/schema/validate.rs
+++ b/crates/smugglr-forger/src/schema/validate.rs
@@ -1,0 +1,730 @@
+//! The validity grammar: every rule the model can violate and SQLite cannot.
+//!
+//! A schema is legal or illegal by cross-field invariants, not by field types.
+//! `AUTOINCREMENT` is fine, `WITHOUT ROWID` is fine, and the two together are
+//! not. A generated column is fine and a primary key is fine, and a generated
+//! primary key is not. No derive expresses that, which is why this is a rule
+//! engine rather than a macro, and why it is the bulk of the work in the model.
+//!
+//! # Where each invariant is enforced
+//!
+//! Three invariants are unrepresentable through [`super::builder`], which is
+//! to say they are compile errors rather than runtime ones: `AUTOINCREMENT` on
+//! a non-integer key, `AUTOINCREMENT` together with `WITHOUT ROWID`, and
+//! `WITHOUT ROWID` with no primary key. Each of those is a property of the
+//! *builder state*, which the type system can carry.
+//!
+//! Everything else needs values the type system does not have -- what the
+//! other tables are, what the other columns are called, how many of them
+//! there are -- and lands here, at construction. `Schema::validate` is run by
+//! `SchemaBuilder::build`, so an authored schema is checked without the author
+//! asking, and a literally-constructed schema can be checked on demand.
+//!
+//! The check stops at the first violation. Authoring is iterative and the
+//! first error is the one being fixed.
+
+use std::collections::HashSet;
+
+use crate::error::ValidationError;
+
+use super::{
+    Column, ColumnConstraint, ColumnType, ForeignKey, Schema, SortOrder, Table, TableConstraint,
+};
+
+/// Storage classes a STRICT table accepts, upper-cased for comparison.
+const STRICT_TYPES: [&str; 6] = ["INT", "INTEGER", "REAL", "TEXT", "BLOB", "ANY"];
+
+pub fn validate(schema: &Schema) -> Result<(), ValidationError> {
+    // Tables and triggers share one namespace in SQLite, so uniqueness is a
+    // schema-wide question rather than a per-table one.
+    let mut names: HashSet<&str> = HashSet::new();
+    for table in &schema.tables {
+        check_identifier(&table.name)?;
+        if !names.insert(&table.name) {
+            return Err(ValidationError::DuplicateTable {
+                table: table.name.clone(),
+            });
+        }
+    }
+    for table in &schema.tables {
+        for trigger in &table.triggers {
+            check_identifier(&trigger.name)?;
+            if !names.insert(&trigger.name) {
+                return Err(ValidationError::DuplicateSchemaObject {
+                    name: trigger.name.clone(),
+                });
+            }
+            if trigger.body.is_empty() {
+                return Err(ValidationError::EmptyTriggerBody {
+                    table: table.name.clone(),
+                    trigger: trigger.name.clone(),
+                });
+            }
+        }
+    }
+
+    for table in &schema.tables {
+        validate_table(table)?;
+        for constraint in &table.constraints {
+            if let TableConstraint::ForeignKey(fk) = constraint {
+                validate_foreign_key(schema, table, fk)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_table(table: &Table) -> Result<(), ValidationError> {
+    if table.columns.is_empty() {
+        return Err(ValidationError::EmptyTable {
+            table: table.name.clone(),
+        });
+    }
+
+    let mut seen: HashSet<&str> = HashSet::new();
+    for column in &table.columns {
+        check_identifier(&column.name)?;
+        if !seen.insert(&column.name) {
+            return Err(ValidationError::DuplicateColumn {
+                table: table.name.clone(),
+                column: column.name.clone(),
+            });
+        }
+    }
+
+    // Every column a constraint names has to exist. A foreign key's parent
+    // side is checked against the schema, not here.
+    for constraint in &table.constraints {
+        let named: Vec<&str> = match constraint {
+            TableConstraint::PrimaryKey { columns, .. }
+            | TableConstraint::Unique { columns, .. } => {
+                columns.iter().map(|c| c.name.as_str()).collect()
+            }
+            TableConstraint::ForeignKey(fk) => fk.columns.iter().map(String::as_str).collect(),
+            TableConstraint::Check(_) => Vec::new(),
+        };
+        for name in named {
+            if !seen.contains(name) {
+                return Err(ValidationError::UnknownColumn {
+                    table: table.name.clone(),
+                    column: name.to_string(),
+                });
+            }
+        }
+    }
+
+    validate_primary_key(table)?;
+
+    for column in &table.columns {
+        validate_column(table, column)?;
+    }
+
+    Ok(())
+}
+
+/// Exactly the rules that depend on how the key was declared.
+fn validate_primary_key(table: &Table) -> Result<(), ValidationError> {
+    let column_level = table
+        .columns
+        .iter()
+        .filter(|c| c.constraints.iter().any(is_primary_key))
+        .count();
+    let table_level = table
+        .constraints
+        .iter()
+        .filter(|c| matches!(c, TableConstraint::PrimaryKey { .. }))
+        .count();
+
+    // SQLite rejects a table with two PRIMARY KEY declarations regardless of
+    // whether they name the same columns.
+    if column_level + table_level > 1 {
+        return Err(ValidationError::MultiplePrimaryKeys {
+            table: table.name.clone(),
+        });
+    }
+    if table.without_rowid && column_level + table_level == 0 {
+        return Err(ValidationError::WithoutRowidNeedsPrimaryKey {
+            table: table.name.clone(),
+        });
+    }
+
+    // A generated column has no stored value of its own to key on, whichever
+    // way the key was spelled.
+    for column in &table.columns {
+        if column.generated().is_none() {
+            continue;
+        }
+        let in_key = column.constraints.iter().any(is_primary_key)
+            || table.constraints.iter().any(|c| match c {
+                TableConstraint::PrimaryKey { columns, .. } => {
+                    columns.iter().any(|ic| ic.name == column.name)
+                }
+                _ => false,
+            });
+        if in_key {
+            return Err(ValidationError::GeneratedPrimaryKey {
+                table: table.name.clone(),
+                column: column.name.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_column(table: &Table, column: &Column) -> Result<(), ValidationError> {
+    for constraint in &column.constraints {
+        match constraint {
+            ColumnConstraint::PrimaryKey {
+                order,
+                autoincrement: true,
+                ..
+            } => {
+                // AUTOINCREMENT hands out keys from the rowid sequence, so it
+                // needs a rowid to hand out from and a column that aliases it.
+                // "INTEGER PRIMARY KEY DESC" is not that alias.
+                if table.without_rowid {
+                    return Err(ValidationError::AutoincrementWithoutRowid {
+                        table: table.name.clone(),
+                        column: column.name.clone(),
+                    });
+                }
+                if column.decl_type != Some(ColumnType::Integer) || *order != SortOrder::Asc {
+                    return Err(ValidationError::AutoincrementNeedsIntegerPrimaryKey {
+                        table: table.name.clone(),
+                        column: column.name.clone(),
+                    });
+                }
+            }
+            ColumnConstraint::Default(_) if column.generated().is_some() => {
+                return Err(ValidationError::GeneratedWithDefault {
+                    table: table.name.clone(),
+                    column: column.name.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // A STRICT table admits six type names and nothing else, which makes the
+    // typeless column and the invented type name -- both legal elsewhere --
+    // illegal here.
+    if table.strict {
+        let ok = column
+            .decl_type
+            .as_ref()
+            .is_some_and(|t| STRICT_TYPES.contains(&t.as_sql().to_ascii_uppercase().as_str()));
+        if !ok {
+            return Err(ValidationError::StrictNeedsStorageClass {
+                table: table.name.clone(),
+                column: column.name.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_foreign_key(
+    schema: &Schema,
+    table: &Table,
+    fk: &ForeignKey,
+) -> Result<(), ValidationError> {
+    if fk.columns.is_empty() || fk.columns.len() != fk.parent_columns.len() {
+        return Err(ValidationError::ForeignKeyArity {
+            table: table.name.clone(),
+            child: fk.columns.len(),
+            parent: fk.parent_columns.len(),
+            parent_table: fk.parent_table.clone(),
+        });
+    }
+
+    // A self-reference is legal, so resolve against the whole schema rather
+    // than excluding the declaring table.
+    let parent =
+        schema
+            .table(&fk.parent_table)
+            .ok_or_else(|| ValidationError::UnknownForeignKeyTable {
+                table: table.name.clone(),
+                parent_table: fk.parent_table.clone(),
+            })?;
+
+    for column in &fk.parent_columns {
+        if parent.column(column).is_none() {
+            return Err(ValidationError::UnknownForeignKeyColumn {
+                table: table.name.clone(),
+                parent_table: fk.parent_table.clone(),
+                column: column.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn is_primary_key(constraint: &ColumnConstraint) -> bool {
+    matches!(constraint, ColumnConstraint::PrimaryKey { .. })
+}
+
+/// Identifiers are rendered inside double quotes with internal quotes doubled,
+/// so almost anything survives. Two things do not: an empty name, which SQLite
+/// rejects, and an embedded NUL, which truncates the statement.
+fn check_identifier(name: &str) -> Result<(), ValidationError> {
+    if name.is_empty() {
+        return Err(ValidationError::EmptyIdentifier);
+    }
+    if name.contains('\0') {
+        return Err(ValidationError::NulInIdentifier {
+            name: name.to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{
+        Column, DefaultValue, Generated, IndexedColumn, ReferentialAction, Trigger, TriggerEvent,
+        TriggerTiming,
+    };
+
+    /// Literal construction, because every rule here exists for a schema the
+    /// builder refuses to express -- writing these through the builder would
+    /// test nothing.
+    fn column(
+        name: &str,
+        decl_type: Option<ColumnType>,
+        constraints: Vec<ColumnConstraint>,
+    ) -> Column {
+        Column {
+            name: name.to_string(),
+            decl_type,
+            constraints,
+        }
+    }
+
+    fn pk(order: SortOrder, autoincrement: bool) -> ColumnConstraint {
+        ColumnConstraint::PrimaryKey {
+            order,
+            autoincrement,
+            on_conflict: None,
+        }
+    }
+
+    fn table_of(name: &str, columns: Vec<Column>) -> Table {
+        Table {
+            name: name.to_string(),
+            columns,
+            constraints: Vec::new(),
+            without_rowid: false,
+            strict: false,
+            triggers: Vec::new(),
+        }
+    }
+
+    fn schema_of(tables: Vec<Table>) -> Schema {
+        Schema { tables }
+    }
+
+    fn int_pk_table(name: &str) -> Table {
+        table_of(
+            name,
+            vec![column(
+                "id",
+                Some(ColumnType::Integer),
+                vec![pk(SortOrder::Asc, false)],
+            )],
+        )
+    }
+
+    #[test]
+    fn a_plain_table_is_valid() {
+        assert_eq!(validate(&schema_of(vec![int_pk_table("t")])), Ok(()));
+    }
+
+    #[test]
+    fn autoincrement_needs_a_rowid_to_draw_from() {
+        let mut table = int_pk_table("t");
+        table.columns[0].constraints = vec![pk(SortOrder::Asc, true)];
+        table.without_rowid = true;
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::AutoincrementWithoutRowid {
+                table: "t".into(),
+                column: "id".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn autoincrement_needs_an_integer_key() {
+        let table = table_of(
+            "t",
+            vec![column(
+                "id",
+                Some(ColumnType::Text),
+                vec![pk(SortOrder::Asc, true)],
+            )],
+        );
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::AutoincrementNeedsIntegerPrimaryKey {
+                table: "t".into(),
+                column: "id".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_descending_integer_key_is_not_the_rowid_alias() {
+        let table = table_of(
+            "t",
+            vec![column(
+                "id",
+                Some(ColumnType::Integer),
+                vec![pk(SortOrder::Desc, true)],
+            )],
+        );
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::AutoincrementNeedsIntegerPrimaryKey {
+                table: "t".into(),
+                column: "id".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn without_rowid_needs_a_key() {
+        let mut table = table_of("t", vec![column("v", Some(ColumnType::Text), Vec::new())]);
+        table.without_rowid = true;
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::WithoutRowidNeedsPrimaryKey { table: "t".into() })
+        );
+    }
+
+    #[test]
+    fn a_generated_column_cannot_be_the_key() {
+        let table = table_of(
+            "t",
+            vec![column(
+                "g",
+                Some(ColumnType::Text),
+                vec![
+                    pk(SortOrder::Asc, false),
+                    ColumnConstraint::Generated {
+                        expr: "1".into(),
+                        storage: Generated::Virtual,
+                    },
+                ],
+            )],
+        );
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::GeneratedPrimaryKey {
+                table: "t".into(),
+                column: "g".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_generated_column_cannot_hide_inside_a_composite_key() {
+        let mut table = table_of(
+            "t",
+            vec![
+                column("a", Some(ColumnType::Integer), Vec::new()),
+                column(
+                    "g",
+                    Some(ColumnType::Text),
+                    vec![ColumnConstraint::Generated {
+                        expr: "'x'".into(),
+                        storage: Generated::Stored,
+                    }],
+                ),
+            ],
+        );
+        table.constraints = vec![TableConstraint::PrimaryKey {
+            columns: vec![
+                IndexedColumn::new("a", SortOrder::Asc),
+                IndexedColumn::new("g", SortOrder::Asc),
+            ],
+            on_conflict: None,
+        }];
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::GeneratedPrimaryKey {
+                table: "t".into(),
+                column: "g".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_generated_column_cannot_carry_a_default() {
+        let table = table_of(
+            "t",
+            vec![column(
+                "g",
+                Some(ColumnType::Text),
+                vec![
+                    ColumnConstraint::Generated {
+                        expr: "'x'".into(),
+                        storage: Generated::Virtual,
+                    },
+                    ColumnConstraint::Default(DefaultValue::text("y")),
+                ],
+            )],
+        );
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::GeneratedWithDefault {
+                table: "t".into(),
+                column: "g".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn two_keys_are_one_too_many() {
+        let mut table = int_pk_table("t");
+        table.columns.push(column(
+            "other",
+            Some(ColumnType::Text),
+            vec![pk(SortOrder::Asc, false)],
+        ));
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::MultiplePrimaryKeys { table: "t".into() })
+        );
+    }
+
+    #[test]
+    fn a_strict_table_refuses_a_typeless_column() {
+        let mut table = int_pk_table("t");
+        table.strict = true;
+        table.columns.push(column("v", None, Vec::new()));
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::StrictNeedsStorageClass {
+                table: "t".into(),
+                column: "v".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_strict_table_refuses_an_invented_type_name() {
+        let mut table = int_pk_table("t");
+        table.strict = true;
+        table.columns.push(column(
+            "v",
+            Some(ColumnType::Other("VARCHAR(8)".into())),
+            Vec::new(),
+        ));
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::StrictNeedsStorageClass {
+                table: "t".into(),
+                column: "v".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_strict_table_accepts_any() {
+        let mut table = int_pk_table("t");
+        table.strict = true;
+        table.columns.push(column(
+            "v",
+            Some(ColumnType::Other("ANY".into())),
+            Vec::new(),
+        ));
+        assert_eq!(validate(&schema_of(vec![table])), Ok(()));
+    }
+
+    #[test]
+    fn tables_are_named_once() {
+        assert_eq!(
+            validate(&schema_of(vec![int_pk_table("t"), int_pk_table("t")])),
+            Err(ValidationError::DuplicateTable { table: "t".into() })
+        );
+    }
+
+    #[test]
+    fn a_trigger_shares_the_table_namespace() {
+        let mut table = int_pk_table("t");
+        table.triggers = vec![Trigger {
+            name: "t".into(),
+            timing: TriggerTiming::After,
+            event: TriggerEvent::Insert,
+            when: None,
+            body: vec!["SELECT 1".into()],
+        }];
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::DuplicateSchemaObject { name: "t".into() })
+        );
+    }
+
+    #[test]
+    fn a_trigger_needs_a_body() {
+        let mut table = int_pk_table("t");
+        table.triggers = vec![Trigger {
+            name: "trg".into(),
+            timing: TriggerTiming::After,
+            event: TriggerEvent::Insert,
+            when: None,
+            body: Vec::new(),
+        }];
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::EmptyTriggerBody {
+                table: "t".into(),
+                trigger: "trg".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn columns_are_named_once() {
+        let mut table = int_pk_table("t");
+        table
+            .columns
+            .push(column("id", Some(ColumnType::Text), Vec::new()));
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::DuplicateColumn {
+                table: "t".into(),
+                column: "id".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_table_needs_a_column() {
+        assert_eq!(
+            validate(&schema_of(vec![table_of("t", Vec::new())])),
+            Err(ValidationError::EmptyTable { table: "t".into() })
+        );
+    }
+
+    #[test]
+    fn a_constraint_cannot_name_a_column_that_is_not_there() {
+        let mut table = int_pk_table("t");
+        table.constraints = vec![TableConstraint::Unique {
+            columns: vec![IndexedColumn::new("nope", SortOrder::Asc)],
+            on_conflict: None,
+        }];
+        assert_eq!(
+            validate(&schema_of(vec![table])),
+            Err(ValidationError::UnknownColumn {
+                table: "t".into(),
+                column: "nope".into(),
+            })
+        );
+    }
+
+    fn child_with_fk(fk: ForeignKey) -> Table {
+        let mut table = table_of(
+            "child",
+            vec![column("parent_id", Some(ColumnType::Integer), Vec::new())],
+        );
+        table.constraints = vec![TableConstraint::ForeignKey(fk)];
+        table
+    }
+
+    #[test]
+    fn a_foreign_key_resolves_against_the_schema() {
+        let child = child_with_fk(ForeignKey {
+            columns: vec!["parent_id".into()],
+            parent_table: "ghost".into(),
+            parent_columns: vec!["id".into()],
+            on_delete: Some(ReferentialAction::Cascade),
+            on_update: None,
+        });
+        assert_eq!(
+            validate(&schema_of(vec![int_pk_table("parent"), child])),
+            Err(ValidationError::UnknownForeignKeyTable {
+                table: "child".into(),
+                parent_table: "ghost".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_foreign_key_resolves_its_parent_columns() {
+        let child = child_with_fk(ForeignKey {
+            columns: vec!["parent_id".into()],
+            parent_table: "parent".into(),
+            parent_columns: vec!["ghost".into()],
+            on_delete: None,
+            on_update: None,
+        });
+        assert_eq!(
+            validate(&schema_of(vec![int_pk_table("parent"), child])),
+            Err(ValidationError::UnknownForeignKeyColumn {
+                table: "child".into(),
+                parent_table: "parent".into(),
+                column: "ghost".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_foreign_key_maps_one_column_onto_one_column() {
+        let child = child_with_fk(ForeignKey {
+            columns: vec!["parent_id".into()],
+            parent_table: "parent".into(),
+            parent_columns: vec!["id".into(), "id".into()],
+            on_delete: None,
+            on_update: None,
+        });
+        assert_eq!(
+            validate(&schema_of(vec![int_pk_table("parent"), child])),
+            Err(ValidationError::ForeignKeyArity {
+                table: "child".into(),
+                child: 1,
+                parent: 2,
+                parent_table: "parent".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_self_reference_resolves() {
+        let mut table = int_pk_table("node");
+        table
+            .columns
+            .push(column("parent", Some(ColumnType::Integer), Vec::new()));
+        table.constraints = vec![TableConstraint::ForeignKey(ForeignKey {
+            columns: vec!["parent".into()],
+            parent_table: "node".into(),
+            parent_columns: vec!["id".into()],
+            on_delete: Some(ReferentialAction::SetNull),
+            on_update: None,
+        })];
+        assert_eq!(validate(&schema_of(vec![table])), Ok(()));
+    }
+
+    #[test]
+    fn an_empty_name_is_not_an_identifier() {
+        assert_eq!(
+            validate(&schema_of(vec![int_pk_table("")])),
+            Err(ValidationError::EmptyIdentifier)
+        );
+    }
+
+    #[test]
+    fn a_nul_truncates_a_statement_so_it_is_refused() {
+        assert_eq!(
+            validate(&schema_of(vec![int_pk_table("a\0b")])),
+            Err(ValidationError::NulInIdentifier {
+                name: "a\0b".into()
+            })
+        );
+    }
+}

--- a/crates/smugglr-forger/tests/fixture_lifecycle.rs
+++ b/crates/smugglr-forger/tests/fixture_lifecycle.rs
@@ -1,0 +1,190 @@
+//! Standing a fixture up, driving it, and getting rid of it.
+//!
+//! The teardown tests assert on the filesystem rather than on the absence of a
+//! panic. "Nothing blew up" is satisfied by a leaked connection; "the path is
+//! gone" is not, and on Windows a leaked connection is exactly what stops the
+//! path from going away.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::PathBuf;
+
+use rusqlite::Connection;
+use smugglr_forger::error::{BoxError, ForgeError};
+use smugglr_forger::fixture::{Backing, Fixture, Route};
+use smugglr_forger::schema::builder::{schema, table, Attr::*};
+use smugglr_forger::schema::{ColumnType::*, Schema};
+
+fn target() -> Schema {
+    schema()
+        .table(
+            table("account")
+                .pk_int("id")
+                .col("email", Text, [NotNull, Unique, OnConflictAbort])
+                .col("nickname", Text, []),
+        )
+        .build()
+        .expect("valid")
+}
+
+fn columns_of(fixture: &Fixture, table: &str) -> Vec<String> {
+    fixture
+        .conn()
+        .prepare("SELECT name FROM pragma_table_xinfo(?1) ORDER BY cid")
+        .expect("prepare")
+        .query_map([table], |row| row.get(0))
+        .expect("query")
+        .collect::<Result<_, _>>()
+        .expect("rows")
+}
+
+#[test]
+fn both_backings_hand_out_a_usable_connection() {
+    for backing in [Backing::Memory, Backing::File] {
+        let mut fixture = Fixture::new(backing).expect("fixture");
+        fixture.bring_to(Route::Schema(&target())).expect("apply");
+        fixture
+            .conn()
+            .execute("INSERT INTO \"account\" (\"email\") VALUES ('a@b.c')", [])
+            .expect("insert");
+        let count: i64 = fixture
+            .conn()
+            .query_row("SELECT count(*) FROM \"account\"", [], |row| row.get(0))
+            .expect("count");
+        assert_eq!(count, 1, "{backing:?}");
+    }
+}
+
+#[test]
+fn an_in_memory_fixture_has_no_path_to_leave_behind() {
+    let fixture = Fixture::new(Backing::Memory).expect("fixture");
+    assert!(fixture.path().is_none());
+}
+
+#[test]
+fn a_file_fixture_exists_while_it_is_alive_and_not_after() {
+    let fixture = Fixture::new(Backing::File).expect("fixture");
+    let path = fixture
+        .path()
+        .expect("file backing has a path")
+        .to_path_buf();
+    assert!(path.exists(), "the database file is there to be inspected");
+
+    drop(fixture);
+    assert!(!path.exists(), "the file went with the fixture");
+    assert!(
+        !path.parent().expect("temp dir").exists(),
+        "and so did the directory holding it"
+    );
+}
+
+#[test]
+fn a_panic_mid_fixture_leaves_nothing_behind() {
+    let mut captured = PathBuf::new();
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let mut fixture = Fixture::new(Backing::File).expect("fixture");
+        captured = fixture.path().expect("file backing").to_path_buf();
+        fixture.bring_to(Route::Schema(&target())).expect("apply");
+        // The fixture is live and holding an open connection right here.
+        panic!("a test failed the way tests fail");
+    }));
+
+    assert!(result.is_err(), "the panic was not swallowed");
+    assert!(
+        !captured.exists(),
+        "{} survived the panic",
+        captured.display()
+    );
+    assert!(!captured.parent().expect("temp dir").exists());
+}
+
+#[test]
+fn close_reports_what_drop_can_only_print() {
+    let mut fixture = Fixture::new(Backing::File).expect("fixture");
+    let path = fixture.path().expect("file backing").to_path_buf();
+    fixture.bring_to(Route::Schema(&target())).expect("apply");
+    fixture.close().expect("clean teardown");
+    assert!(!path.exists());
+}
+
+/// The symmetry #355 is built on: a fixture reaches a state by DDL or by a
+/// caller's transformation, through one method, and forger does not know which
+/// of the two it just ran.
+#[test]
+fn every_route_arrives_at_the_same_place() {
+    let target = target();
+
+    let mut by_schema = Fixture::new(Backing::Memory).expect("fixture");
+    by_schema.bring_to(Route::Schema(&target)).expect("apply");
+
+    let mut by_ddl = Fixture::new(Backing::Memory).expect("fixture");
+    by_ddl
+        .bring_to(Route::Ddl(&target.to_ddl()))
+        .expect("apply");
+
+    // The transformation is opaque to forger: a closure that takes a
+    // connection and reports its own error type. Nothing about it is named in
+    // the fixture API.
+    let start = schema()
+        .table(
+            table("account")
+                .pk_int("id")
+                .col("email", Text, [NotNull, Unique, OnConflictAbort]),
+        )
+        .build()
+        .expect("valid");
+    let mut migrate = |conn: &mut Connection| -> Result<(), BoxError> {
+        let tx = conn.transaction()?;
+        tx.execute("ALTER TABLE \"account\" ADD COLUMN \"nickname\" TEXT", [])?;
+        tx.commit()?;
+        Ok(())
+    };
+
+    let mut by_transform = Fixture::new(Backing::Memory).expect("fixture");
+    by_transform.bring_to(Route::Schema(&start)).expect("apply");
+    by_transform
+        .bring_to(Route::Transform(&mut migrate))
+        .expect("the transformation ran");
+
+    let expected = vec!["id".to_string(), "email".into(), "nickname".into()];
+    assert_eq!(columns_of(&by_schema, "account"), expected);
+    assert_eq!(columns_of(&by_ddl, "account"), expected);
+    assert_eq!(columns_of(&by_transform, "account"), expected);
+}
+
+#[test]
+fn a_failing_transformation_is_its_own_signal() {
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    fixture.bring_to(Route::Schema(&target())).expect("apply");
+
+    let mut fails =
+        |_: &mut Connection| -> Result<(), BoxError> { Err("the caller could not do it".into()) };
+    let error = fixture
+        .bring_to(Route::Transform(&mut fails))
+        .expect_err("the transformation failed");
+
+    // Not a Sqlite error and not an Invalid one: a differential oracle has to
+    // tell "the transformation failed" apart from "the schemas diverged".
+    assert!(
+        matches!(error, ForgeError::Transform(_)),
+        "expected a Transform error, got {error:?}"
+    );
+    assert!(error.to_string().contains("the caller could not do it"));
+}
+
+#[test]
+fn a_schema_route_reports_the_broken_rule_rather_than_a_parse_error() {
+    // Literal construction, because the builder cannot express this one.
+    let mut broken = target();
+    broken.tables[0].without_rowid = true;
+    broken.tables[0].columns[0].constraints = Vec::new();
+
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    let error = fixture
+        .bring_to(Route::Schema(&broken))
+        .expect_err("WITHOUT ROWID with no key");
+    assert!(
+        matches!(error, ForgeError::Invalid(_)),
+        "expected a validation error, got {error:?}"
+    );
+}

--- a/crates/smugglr-forger/tests/sqlite_accepts_the_ddl.rs
+++ b/crates/smugglr-forger/tests/sqlite_accepts_the_ddl.rs
@@ -2,16 +2,18 @@
 //! accepts.
 //!
 //! A rendering test that only compares strings proves the renderer agrees with
-//! itself. These go through a real database, and the schema they go through
-//! with carries one instance of every feature [`Trait`] declares, because
-//! those are the shapes a transformation has been observed to lose.
+//! itself. These go through a real database. The first schema carries one
+//! instance of every feature the `Trait` enum declares, because those are the
+//! shapes a transformation has been observed to lose; the second exists to
+//! reach the renderer arms the first does not, since an arm SQLite has never
+//! parsed is a rendering nobody has actually checked.
 
 use rusqlite::params;
 use smugglr_forger::fixture::{Backing, Fixture, Route};
 use smugglr_forger::schema::builder::{schema, table, Attr::*};
 use smugglr_forger::schema::{
-    ColumnType::*, DefaultValue, IndexedColumn, ReferentialAction, Schema, SortOrder, Trigger,
-    TriggerEvent, TriggerTiming,
+    ColumnConstraint, ColumnType::*, DefaultValue, IndexedColumn, OnConflict, ReferentialAction,
+    Schema, SortOrder, TableConstraint, Trigger, TriggerEvent, TriggerTiming,
 };
 
 /// One instance of every declared trait, in one schema.
@@ -156,6 +158,111 @@ fn a_generated_column_computes_rather_than_stores_what_it_was_given() {
         .expect("read back");
     assert_eq!(slug, "hello");
     assert_eq!(shout, "HELLO");
+}
+
+/// Everything the trait corpus does not happen to use: conflict algorithms on
+/// keys, table-level constraints, the remaining literal defaults, the
+/// remaining trigger timings and events, and the type names that are not
+/// storage classes.
+fn remaining_grammar() -> Schema {
+    let mut target = schema()
+        .table(
+            table("ledger")
+                .pk_int("id")
+                .autoincrement()
+                .col(
+                    "note",
+                    Text,
+                    [Collate("NOCASE".into()), Default(DefaultValue::Null)],
+                )
+                .col("amount", Numeric, [Default(DefaultValue::Real(1.5))])
+                .col("sig", Blob, [Default(DefaultValue::Blob(vec![0x00, 0xff]))])
+                .col("qty", Integer, [Default(DefaultValue::Integer(0))])
+                .col(
+                    "tag",
+                    Other("VARCHAR(32)".into()),
+                    [Check("length(\"tag\") < 32".into())],
+                )
+                .trigger(Trigger {
+                    name: "ledger_before_delete".into(),
+                    timing: TriggerTiming::Before,
+                    event: TriggerEvent::Delete,
+                    when: None,
+                    body: vec!["UPDATE \"counter\" SET \"n\" = \"n\" + 1".into()],
+                }),
+        )
+        .table(
+            table("pair")
+                .col("a", Text, [NotNull])
+                .col("b", Text, [NotNull])
+                .col("note", Text, [])
+                .pk_composite([
+                    IndexedColumn::new("a", SortOrder::Asc),
+                    IndexedColumn::new("b", SortOrder::Desc),
+                ])
+                .constraint(TableConstraint::Unique {
+                    columns: vec![IndexedColumn::new("note", SortOrder::Asc)],
+                    on_conflict: Some(OnConflict::Replace),
+                })
+                .constraint(TableConstraint::Check("\"a\" <> \"b\"".into()))
+                .trigger(Trigger {
+                    name: "pair_after_update".into(),
+                    timing: TriggerTiming::After,
+                    event: TriggerEvent::Update,
+                    when: None,
+                    body: vec!["UPDATE \"counter\" SET \"n\" = \"n\" + 1".into()],
+                }),
+        )
+        .table(table("counter").pk_int("id").col("n", Integer, []))
+        .build()
+        .expect("valid");
+
+    // A conflict algorithm on a key is not reachable through the builder --
+    // the pk_* constructors take no attributes, which is what keeps a
+    // generated column from becoming one. Reach into the model for it, since
+    // the rendering still has to be right.
+    target.tables[0].columns[0].constraints = vec![ColumnConstraint::PrimaryKey {
+        order: SortOrder::Asc,
+        autoincrement: true,
+        on_conflict: Some(OnConflict::Rollback),
+    }];
+    target.tables[1].constraints[0] = TableConstraint::PrimaryKey {
+        columns: vec![
+            IndexedColumn::new("a", SortOrder::Asc),
+            IndexedColumn::new("b", SortOrder::Desc),
+        ],
+        on_conflict: Some(OnConflict::Ignore),
+    };
+    target.validate().expect("still a legal schema");
+    target
+}
+
+#[test]
+fn sqlite_accepts_every_arm_the_renderer_can_take() {
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    fixture
+        .bring_to(Route::Schema(&remaining_grammar()))
+        .expect("SQLite accepts the rendered DDL");
+
+    // The defaults are the arms most likely to render as something that parses
+    // and means the wrong thing, so read them back rather than trusting the
+    // statement's acceptance.
+    fixture
+        .conn()
+        .execute("INSERT INTO \"ledger\" (\"tag\") VALUES ('x')", [])
+        .expect("insert");
+    let (note, amount, sig, qty): (Option<String>, f64, Vec<u8>, i64) = fixture
+        .conn()
+        .query_row(
+            "SELECT \"note\", \"amount\", \"sig\", \"qty\" FROM \"ledger\"",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("read back");
+    assert_eq!(note, None);
+    assert_eq!(amount, 1.5);
+    assert_eq!(sig, vec![0x00, 0xff]);
+    assert_eq!(qty, 0);
 }
 
 #[test]

--- a/crates/smugglr-forger/tests/sqlite_accepts_the_ddl.rs
+++ b/crates/smugglr-forger/tests/sqlite_accepts_the_ddl.rs
@@ -1,0 +1,167 @@
+//! The claim this crate stands or falls on: what the builder authors, SQLite
+//! accepts.
+//!
+//! A rendering test that only compares strings proves the renderer agrees with
+//! itself. These go through a real database, and the schema they go through
+//! with carries one instance of every feature [`Trait`] declares, because
+//! those are the shapes a transformation has been observed to lose.
+
+use rusqlite::params;
+use smugglr_forger::fixture::{Backing, Fixture, Route};
+use smugglr_forger::schema::builder::{schema, table, Attr::*};
+use smugglr_forger::schema::{
+    ColumnType::*, DefaultValue, IndexedColumn, ReferentialAction, Schema, SortOrder, Trigger,
+    TriggerEvent, TriggerTiming,
+};
+
+/// One instance of every declared trait, in one schema.
+fn awkward_schema() -> Schema {
+    schema()
+        .table(
+            table("author")
+                .pk_int("id")
+                .autoincrement()
+                .col("email", Text, [NotNull, Unique, OnConflictReplace])
+                .col(
+                    "created",
+                    Text,
+                    [Default(DefaultValue::expr("CURRENT_TIMESTAMP"))],
+                )
+                .typeless("scratch", []),
+        )
+        .table(
+            table("post")
+                .pk_int("id")
+                .col("author_id", Integer, [NotNull])
+                .col("title", Text, [NotNull])
+                .col("slug", Text, [Stored("lower(title)".into())])
+                .col("shout", Text, [Virtual("upper(title)".into())])
+                .col("revision", Integer, [Default(DefaultValue::Integer(0))])
+                .fk(["author_id"], "author", ["id"])
+                .on_delete(ReferentialAction::Cascade)
+                .on_update(ReferentialAction::Restrict)
+                .trigger(Trigger {
+                    name: "post_revision".into(),
+                    timing: TriggerTiming::After,
+                    event: TriggerEvent::UpdateOf(vec!["title".into()]),
+                    when: Some("new.title <> old.title".into()),
+                    body: vec!["UPDATE \"post\" SET \"revision\" = \"revision\" + 1 \
+                         WHERE \"id\" = new.\"id\""
+                        .into()],
+                }),
+        )
+        .table(
+            // A descending key is not the rowid alias, whatever its type says.
+            table("event")
+                .pk_col("at", Integer, SortOrder::Desc)
+                .col("kind", Text, [NotNull]),
+        )
+        .table(
+            // WITHOUT ROWID over a composite key, and STRICT, which forbids
+            // both the typeless column and the invented type name above.
+            table("membership")
+                .col("team", Text, [NotNull])
+                .col("person", Text, [NotNull])
+                .col("role", Text, [Default(DefaultValue::text("member"))])
+                .pk_composite([
+                    IndexedColumn::new("team", SortOrder::Asc),
+                    IndexedColumn::new("person", SortOrder::Asc),
+                ])
+                .strict()
+                .without_rowid(),
+        )
+        .build()
+        .expect("the awkward schema is a legal one")
+}
+
+#[test]
+fn sqlite_accepts_a_schema_carrying_every_declared_trait() {
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    fixture
+        .bring_to(Route::Schema(&awkward_schema()))
+        .expect("SQLite accepts the rendered DDL");
+
+    let objects: Vec<String> = fixture
+        .conn()
+        .prepare("SELECT name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY name")
+        .expect("prepare")
+        .query_map([], |row| row.get(0))
+        .expect("query")
+        .collect::<Result<_, _>>()
+        .expect("rows");
+
+    assert_eq!(
+        objects,
+        vec![
+            "author".to_string(),
+            "event".into(),
+            "membership".into(),
+            "post".into(),
+            "post_revision".into(),
+        ],
+        "every table and the trigger reached the database"
+    );
+}
+
+#[test]
+fn the_rendered_columns_are_the_authored_columns() {
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    let target = awkward_schema();
+    fixture.bring_to(Route::Schema(&target)).expect("apply");
+
+    for table in &target.tables {
+        let found: Vec<String> = fixture
+            .conn()
+            .prepare("SELECT name FROM pragma_table_xinfo(?1) ORDER BY cid")
+            .expect("prepare")
+            .query_map(params![table.name], |row| row.get(0))
+            .expect("query")
+            .collect::<Result<_, _>>()
+            .expect("rows");
+        let authored: Vec<String> = table.columns.iter().map(|c| c.name.clone()).collect();
+        assert_eq!(found, authored, "columns of {}", table.name);
+    }
+}
+
+/// The generated columns are the ones most likely to render as something
+/// SQLite tolerates but does not mean, so check they compute.
+#[test]
+fn a_generated_column_computes_rather_than_stores_what_it_was_given() {
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    fixture
+        .bring_to(Route::Schema(&awkward_schema()))
+        .expect("apply");
+    // The bundled SQLite enforces foreign keys by default, so the parent row
+    // is not optional here.
+    fixture
+        .conn()
+        .execute(
+            "INSERT INTO \"author\" (\"email\") VALUES ('a@example.com')",
+            [],
+        )
+        .expect("insert author");
+    fixture
+        .conn()
+        .execute(
+            "INSERT INTO \"post\" (\"author_id\", \"title\") VALUES (1, 'Hello')",
+            [],
+        )
+        .expect("insert post");
+
+    let (slug, shout): (String, String) = fixture
+        .conn()
+        .query_row("SELECT \"slug\", \"shout\" FROM \"post\"", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .expect("read back");
+    assert_eq!(slug, "hello");
+    assert_eq!(shout, "HELLO");
+}
+
+#[test]
+fn a_schema_survives_a_round_trip_through_serde() {
+    let target = awkward_schema();
+    let json = serde_json::to_string(&target).expect("serialize");
+    let back: Schema = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, target);
+}

--- a/scripts/check-crate-versions.py
+++ b/scripts/check-crate-versions.py
@@ -36,14 +36,22 @@ INTERNAL_PREFIX = "smugglr"
 
 
 def workspace_version(meta: dict) -> str:
-    """The single version every workspace member shares.
+    """The single version every publishable workspace member shares.
 
-    Every member inherits `version.workspace = true`, so any member's
-    version is the workspace version -- but assert that rather than
-    trusting it, because a member that opts out is exactly the kind of
+    Publishable members inherit `version.workspace = true`, so any of
+    their versions is the workspace version -- but assert that rather
+    than trusting it, because one that opts out is exactly the kind of
     drift this script exists to catch.
+
+    `publish = false` members are excluded from the consensus, not
+    overlooked by it. Their versions never reach the registry and no req
+    is ever resolved against them, so a crate like smugglr-forger -- an
+    independent artifact that happens to live here, sitting at 0.1.0
+    while the workspace is at 0.5.x -- is not drift. It is the point.
     """
-    members = {p["name"]: p["version"] for p in meta["packages"]}
+    members = {
+        p["name"]: p["version"] for p in meta["packages"] if p.get("publish") != []
+    }
     versions = set(members.values())
     if len(versions) != 1:
         detail = ", ".join(f"{n} {v}" for n, v in sorted(members.items()))

--- a/scripts/check-forger-boundary.py
+++ b/scripts/check-forger-boundary.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Assert smugglr-forger depends on no smugglr crate, and nothing depends on
+it outside test builds.
+
+forger manufactures schemas and fixtures to test a transformation it knows
+nothing about. That ignorance is the whole value: an oracle written from the
+same premises as the implementation reproduces the implementation's blind
+spots, which is how ten defects reached a migrate spine whose tests were
+green.
+
+The rule is not the crate name. A crate that compiles standalone can be
+renamed at publish time in an afternoon; a crate that reached into
+smugglr-core cannot be extracted at any name. So the boundary is the
+dependency direction, and it runs exactly one way:
+
+    smugglr's tests --> forger          (dev-dependencies only)
+    forger --> anything smugglr         (never)
+
+Both halves are checked here. The forward rule bites today. The reverse rule
+is vacuous until smugglr's tests start using forger, and binding from the
+moment they do -- a normal dependency on forger would put forger in the
+shipped artifact and, together with the forward rule, form a cycle.
+
+Every dependency kind counts, dev and build included. A dev-dependency on
+smugglr-core would still break "forger builds with the smugglr crates absent
+from the workspace", which is the property that makes extraction mechanical.
+
+Reads `cargo metadata` rather than parsing manifests, so a dependency added
+through any spelling -- path, version, workspace inheritance, a target-
+specific table -- is seen.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+FORGER = "smugglr-forger"
+INTERNAL_PREFIX = "smugglr"
+
+
+def main() -> int:
+    proc = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr, file=sys.stderr)
+        raise SystemExit("cargo metadata failed")
+
+    meta = json.loads(proc.stdout)
+    packages = {p["name"]: p for p in meta["packages"]}
+
+    forger = packages.get(FORGER)
+    if forger is None:
+        # The crate is the subject of the check. If it is gone, the check is
+        # not passing, it is not running.
+        raise SystemExit(f"{FORGER} is not a member of this workspace")
+
+    failures: list[str] = []
+
+    # Forward: forger reaches for nothing of ours.
+    for dep in forger["dependencies"]:
+        if dep["name"].startswith(INTERNAL_PREFIX):
+            kind = dep.get("kind") or "normal"
+            failures.append(
+                f"{FORGER} declares a {kind} dependency on {dep['name']}. "
+                f"forger must know nothing about smugglr -- a transformation "
+                f"is handed in as a closure, never imported."
+            )
+
+    # Reverse: whoever uses forger uses it in test builds only.
+    for name, pkg in sorted(packages.items()):
+        if name == FORGER:
+            continue
+        for dep in pkg["dependencies"]:
+            if dep["name"] != FORGER:
+                continue
+            # cargo metadata reports kind as null for a normal dependency,
+            # "dev" for dev-dependencies and "build" for build-dependencies.
+            if dep.get("kind") != "dev":
+                kind = dep.get("kind") or "normal"
+                failures.append(
+                    f"{name} declares a {kind} dependency on {FORGER}. "
+                    f"forger is test-only scaffolding: a non-dev dependency "
+                    f"ships it to users and closes the loop the forward rule "
+                    f"opens."
+                )
+
+    if failures:
+        print("the forger dependency boundary is broken:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        print(
+            "\nThis boundary is what keeps extracting forger a mechanical "
+            "move rather than a redesign. See FR-FORGER-011.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"ok: {FORGER} depends on no smugglr crate, and nothing depends on it outside tests")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #351. Also closes #352 and #353 -- the crate, the schema model and the fixture land together because the model has no home until the crate exists and the fixture has nothing to build until the model does.

First code for **forger**: a tool that manufactures SQLite schemas and the seeded data that proves them, so a transformation which silently changes meaning fails loudly instead of passing every check. Grounded in thesis `019fff81-cb4a-7d60-b552-a58071363a97` and requirements FR-FORGER-011, -002, -001.

## Acceptance criteria mapping

### crates/smugglr-forger exists as a workspace member with publish = false, and the crate builds

Own version `0.1.0`, deliberately NOT `version.workspace = true` -- forger's version should not move because the sync engine released. Dependencies are `rusqlite` (bundled, matching the workspace pin), `serde`, `tempfile`, `thiserror`, with `serde_json` dev-only.

Evidence: `cargo build -p smugglr-forger` succeeds; the crate is in both `members` and `default-members`, the latter deliberately -- see the Windows note below.

### forger's Cargo.toml declares no dependency on any smugglr crate

Nothing in the manifest or the source names smugglr. The purpose of forger is to test smugglr's reconstruction, and the resolution of that apparent contradiction is that the dependency runs one way and only in test builds: smugglr's tests will depend on forger, never the reverse.

Evidence: `cargo tree -p smugglr-forger --edges normal,build,dev` shows no smugglr node anywhere, and the crate was built **and its full suite run** in a scratch workspace containing no smugglr crate at all.

### A CI job fails when smugglr-core is added to forger's dependencies

`scripts/check-forger-boundary.py`, shaped after the existing `scripts/check-crate-versions.py`, wired into `.github/workflows/ci.yml` as a `forger-boundary` job.

Evidence: both directions verified by breaking them and restoring -- a `[dev-dependencies]` entry on `smugglr-core`, and a normal dep on forger from `smugglr`. A boundary check that has never been observed failing is not a check.

### A Schema authored through the builder equals the same schema constructed literally

`Schema` / `Table` / `Column` / `Trait` are plain owned data with no lifetime tied to a connection, deriving `Serialize`/`Deserialize` so the fixture format (#361) costs nothing later. Errors accumulate in the builder and surface at `build()`, so an authoring chain carries one `?` at the end rather than one per line.

Evidence: a test constructs both ways and compares equal.

### The builder refuses a schema SQLite would reject

Split deliberately across compile time and construction time, because the two catch different classes and only one of them can be expressed in the type system. Four invariants are made unrepresentable by a typestate `TableBuilder<PkKind, RowidMode>` -- AUTOINCREMENT after a non-integer key, WITHOUT ROWID before any key, the mutual exclusion of those two, and a generated primary key. The remaining twenty-four run in `Schema::validate` at `build()`, covering rules the typestate structurally cannot reach, such as a generated column arriving through the `pk_composite` path or STRICT with an invented type name.

Evidence: each compile-time refusal is pinned as a `compile_fail` doctest, verified to fail for the intended reason by compiling the snippet and reading the error first. Each construction-time rule has a test, plus non-vacuity cases proving a legitimate schema still passes -- a self-referencing foreign key resolves, and STRICT accepts `ANY`.

### A Schema renders to CREATE TABLE DDL that SQLite accepts

The renderer is exercised against a live connection rather than against expected strings, because string comparison only proves the renderer agrees with itself -- which is precisely the failure mode this crate exists to eliminate, and leaving that gap in an oracle would have been self-contradictory.

Evidence: `tests/sqlite_accepts_the_ddl.rs` executes the rendered DDL against real SQLite. A second schema was added in `fece177` after a self-review found renderer arms no test had ever put in front of the engine -- conflict algorithms on keys, table-level `PRIMARY KEY`/`UNIQUE`/`CHECK`, the `NULL`/`BLOB`/`REAL`/`INTEGER` defaults, `BEFORE` triggers, plain `DELETE` and `UPDATE` events, and type names that are not storage classes. That addition confirmed the `PRIMARY KEY ON CONFLICT ROLLBACK AUTOINCREMENT` clause ordering against real SQLite rather than against a remembered grammar diagram.

## Not done

- **No generator, no `rand` dependency, no shrinker.** Random generation is cancelled by the #362 ruling; schemas are hand-authored.
- **`Trait` is declared with all eight variants and nothing dispatches on it.** The exhaustive seed/probe registry is #354. No `Schema::traits()` derivation was added to manufacture a caller for it.
- **No seeds, probes, differential oracle, execution accounting, failure formatting, or fixture serialization.** Those are #354-#361 and are absent rather than stubbed -- a TODO no test covers is the shape this crate exists to eliminate.
- **FR-FORGER-002's third criterion is vacuous and is not claimed satisfied.** "Every probe accepts a Schema without knowing whether it was authored or generated" -- there is no generator and there are no probes. The other four are met.

## The validity grammar, which is the actual work

A legal SQLite schema has cross-field invariants, and enforcing them is a rule engine rather than a struct definition. Four are unrepresentable at compile time via a typestate `TableBuilder<PkKind, RowidMode>`:

- `autoincrement()` exists only on `TableBuilder<IntPk, Rowid>`, so it is unreachable after `pk_text`, `pk_col` or `pk_composite`
- `without_rowid()` requires `P: HasPk`, so it is unreachable before a key is declared
- the two mutually exclude, each consuming the undecided rowid state
- a generated primary key is unrepresentable, since `Attr` has no primary-key variant and the `pk_*` constructors take no attributes

Each was verified to fail **for the intended reason** by compiling the snippet and reading the error, then pinned as a `compile_fail` doctest. A `compile_fail` test that passes for an unrelated reason is worse than none.

The remainder run at construction in `Schema::validate` -- 24 rules including AUTOINCREMENT on a non-INTEGER or descending key, generated column in a key (including the `pk_composite` path the typestate cannot block), STRICT with an invented type name, unresolvable FK parent, trigger names colliding with the table namespace. Each has a test, plus non-vacuity cases.

One grammar subtlety worth naming: `Attr` is a flat authoring enum, but the model binds each conflict algorithm to the constraint it belongs to (`Unique(Some(OnConflict::Replace))`), because SQLite's grammar does. A flat list would render an orphan `ON CONFLICT`, which is a syntax error. The fold happens at build time and an unattached conflict algorithm is a construction error rather than broken SQL.

## Fixture teardown is structural, not remembered

`Fixture` owns `Option<Connection>` and `Option<TempDir>` and implements `Drop` explicitly -- connection closed, then directory released. Written out rather than left to field order, because field order produces the same sequence today and breaks silently the day someone reorders the struct, into a Windows-only cleanup failure. `close(self)` propagates what `Drop` can only print.

The panic test captures the path, unwinds under `catch_unwind`, and asserts both `!path.exists()` and `!path.parent().exists()`. "Nothing blew up" would pass with a leaked connection; the path assertion will not.

`bring_to(Route)` takes `Route::Schema`, `Route::Ddl`, or `Route::Transform(&mut dyn FnMut(&mut Connection) -> Result<(), BoxError>)`. `&mut Connection` because `Connection::transaction()` requires it and a transformation that cannot open a transaction cannot do the work this exists for. `Box<dyn Error + Send + Sync>` because forger must accept any consumer's error type without naming it -- the dependency boundary expressed as a type. `ForgeError::Transform` stays a distinct matchable variant so #355 can tell "the transformation failed" from "the schemas diverged", which are different signals.

## Two findings

**`scripts/check-crate-versions.py` would have hard-failed the moment forger landed.** It asserted every workspace member shares one version, which forger at `0.1.0` breaks immediately. Fixed by taking the consensus over publishable members only -- the same predicate the dependency loop below it already used -- and correcting the now-false docstring. Not introduced here, but guaranteed by #351's own-version requirement.

**rusqlite's bundled SQLite compiles with `SQLITE_DEFAULT_FOREIGN_KEYS=1`.** Measured, not assumed: `PRAGMA foreign_keys` reads `1` on a fresh fixture connection, unlike the `sqlite3` shell where it is off. Found because a test insert hit a real FK violation. A consumer would otherwise inherit that premise unknowingly, which is precisely the shape forger exists to eliminate. forger neither sets nor clears it; the module doc states the measured fact rather than the general claim it originally carried, which was wrong.

## One criterion structurally satisfied but not yet observed

#353 asks for teardown verified on Windows CI. Adding forger to `default-members` is what makes the three-OS `cargo test` job run its teardown tests -- CI's `check`, `clippy` and `test` jobs are all default-members-scoped, so held out, those tests would never run on the platform they exist to defend. The Windows run cannot be observed from the authoring environment; this PR's own CI is the first observation.

Closes #353
