### PR TITLE
feat(#354): forger -- the trait registry, its seeds and probes, and seventeen breaks

### DIFF
--- a/crates/smugglr-forger/src/error.rs
+++ b/crates/smugglr-forger/src/error.rs
@@ -1,13 +1,19 @@
-//! forger's two error types, kept apart on purpose.
+//! forger's three error types, kept apart on purpose.
 //!
 //! [`ValidationError`] is a statement about a schema: it says the model
 //! describes something SQLite would reject, and it is produced before any
 //! database exists. [`ForgeError`] is a statement about a run.
+//! [`ProbeError`] is a statement about what a database did.
 //!
-//! The split matters downstream. A differential oracle has to tell "the
+//! The splits matter downstream. A differential oracle has to tell "the
 //! caller's transformation failed" apart from "the two schemas diverged", and
 //! a single flat error type collapses exactly that distinction --
 //! [`ForgeError::Transform`] is a separate matchable variant for that reason.
+//! It has to tell both of those apart from "the probe could not have observed
+//! anything either way", which is [`ProbeError::Unseeded`]: a probe whose
+//! precondition does not hold is not evidence of a healthy database, and
+//! reporting it as either a pass or a behavioural failure is a lie about what
+//! was measured.
 
 use thiserror::Error;
 
@@ -114,6 +120,33 @@ pub enum ValidationError {
 
     #[error("table {table:?} refines a referential action with no foreign key in front of it")]
     NoForeignKeyToRefine { table: String },
+}
+
+/// What a probe reports about the database in front of it.
+///
+/// Three variants and no more. Severity, context stacks and diff rendering are
+/// FR-FORGER-008's problem, and a probe that formats its own report is a probe
+/// whose message drifts from every other one.
+#[derive(Debug, Error)]
+pub enum ProbeError {
+    /// The construct did not do what the schema said it does. This is the
+    /// finding: the message names the observation, not the rule.
+    #[error("{0}")]
+    Failed(String),
+
+    /// The probe's precondition does not hold, so the assertion under it would
+    /// have been vacuous -- the seed did not run, or the connection is not in
+    /// the state the probe needs. Distinct from [`Failed`](Self::Failed)
+    /// because an empty database is green on every behavioural assertion ever
+    /// written, and "nothing to see" must never read as "nothing wrong".
+    #[error("nothing to observe: {0}")]
+    Unseeded(String),
+
+    /// SQLite refused a statement the probe did not expect it to refuse.
+    /// Statements a probe expects to fail are handled inline, so anything
+    /// reaching here is the probe itself being wrong about the database.
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
 }
 
 /// Anything that can go wrong standing a fixture up or driving it.

--- a/crates/smugglr-forger/src/lib.rs
+++ b/crates/smugglr-forger/src/lib.rs
@@ -23,6 +23,8 @@
 //!   a schema SQLite would reject.
 //! * [`fixture`] -- stand a database up on either backing, hand out a
 //!   connection, tear it down reliably including on panic.
+//! * [`registry`] -- one [`Trait`], one schema carrying it, one seed and one
+//!   probe, matched exhaustively so a trait without a probe does not compile.
 //!
 //! ```
 //! use smugglr_forger::fixture::{Backing, Fixture, Route};
@@ -45,8 +47,10 @@
 
 pub mod error;
 pub mod fixture;
+pub mod registry;
 pub mod schema;
 
-pub use error::{BoxError, ForgeError, ValidationError};
+pub use error::{BoxError, ForgeError, ProbeError, ValidationError};
 pub use fixture::{Backing, Fixture, Route};
+pub use registry::TraitCase;
 pub use schema::{Schema, Trait};

--- a/crates/smugglr-forger/src/registry/cases.rs
+++ b/crates/smugglr-forger/src/registry/cases.rs
@@ -1,0 +1,1219 @@
+//! The eight cases: one schema, one seed and one probe per [`Trait`].
+//!
+//! Each case is a single function, and its three parts sit next to each other
+//! on purpose -- the seed's values are the probe's expectations, and splitting
+//! them across files is how the two drift apart. Where a probe expects a
+//! specific number, that number and the expression or seed value it comes from
+//! are declared together as constants, because a probe that recomputed its own
+//! expectation from the schema would be a second, worse implementation of
+//! SQLite.
+//!
+//! A probe finds the construct it exists for by reading the schema it is handed
+//! -- the generated column, the key declared `DESC`, the child table whose
+//! foreign key says `CASCADE`. The scaffolding around it (`id`, `label`, the
+//! audit table) is this module's own and is named directly. The line between
+//! the two is: whatever the trait is *about* is resolved, whatever is there to
+//! hold the trait up is not.
+
+use rusqlite::Connection;
+
+use crate::error::ProbeError;
+use crate::schema::builder::{schema, table, Attr};
+use crate::schema::ddl::quote;
+use crate::schema::{
+    Column, ColumnConstraint, ColumnType::Integer, ColumnType::Text, DefaultValue, ForeignKey,
+    Generated, OnConflict, ReferentialAction, Schema, SortOrder, Table, TableConstraint, Trait,
+    Trigger, TriggerEvent, TriggerTiming,
+};
+
+use super::{count, one_column, text, TraitCase};
+
+/// Every case seeds through this column so a probe can say which row it means
+/// without depending on a rowid.
+const KEY: &str = "id";
+/// A plain column that carries no trait at all. It is here so that every case
+/// leaves at least one ordinary value on the far side of a transformation --
+/// FR-FORGER-004's surviving-column rule -- and so a rebuild that drops a
+/// column has something to drop that is not the construct under test.
+const LABEL: &str = "label";
+
+// ---------------------------------------------------------------------------
+// ForeignKeyWithAction
+// ---------------------------------------------------------------------------
+
+/// The parent row `ON DELETE CASCADE` is expected to take its children with.
+const DOOMED: i64 = 1;
+/// The parent row an `ON DELETE RESTRICT` child is expected to pin in place.
+const PROTECTED: i64 = 2;
+
+pub(super) fn foreign_key_with_action() -> TraitCase {
+    let schema = schema()
+        .table(table("keeper").pk_int(KEY).col(LABEL, Text, []))
+        .table(
+            table("cascade_child")
+                .pk_int(KEY)
+                .col("keeper_id", Integer, [])
+                .col(LABEL, Text, [])
+                .fk(["keeper_id"], "keeper", [KEY])
+                .on_delete(ReferentialAction::Cascade),
+        )
+        .table(
+            table("restrict_child")
+                .pk_int(KEY)
+                .col("keeper_id", Integer, [])
+                .col(LABEL, Text, [])
+                .fk(["keeper_id"], "keeper", [KEY])
+                .on_delete(ReferentialAction::Restrict),
+        )
+        .build()
+        .expect("the ForeignKeyWithAction case schema is valid");
+
+    TraitCase {
+        kind: Trait::ForeignKeyWithAction,
+        schema,
+        seed: |conn| {
+            conn.execute_batch(&format!(
+                "INSERT INTO \"keeper\" (\"{KEY}\", \"{LABEL}\") \
+                   VALUES ({DOOMED}, 'its children go with it'), \
+                          ({PROTECTED}, 'its child pins it in place');
+                 INSERT INTO \"cascade_child\" (\"{KEY}\", \"keeper_id\", \"{LABEL}\") \
+                   VALUES (10, {DOOMED}, 'first'), (11, {DOOMED}, 'second');
+                 INSERT INTO \"restrict_child\" (\"{KEY}\", \"keeper_id\", \"{LABEL}\") \
+                   VALUES (20, {PROTECTED}, 'only');"
+            ))?;
+            Ok(())
+        },
+        probe: probe_foreign_key_with_action,
+    }
+}
+
+fn probe_foreign_key_with_action(schema: &Schema, conn: &Connection) -> Result<(), ProbeError> {
+    require_foreign_keys_enforced(conn)?;
+
+    let cascading = children_with(schema, ReferentialAction::Cascade);
+    let restricting = children_with(schema, ReferentialAction::Restrict);
+    if cascading.is_empty() || restricting.is_empty() {
+        return Err(ProbeError::Failed(format!(
+            "the schema handed to this probe declares {} ON DELETE CASCADE and {} ON DELETE \
+             RESTRICT foreign keys, and the probe needs one of each to have anything to assert",
+            cascading.len(),
+            restricting.len()
+        )));
+    }
+
+    // The parent is whatever the cascading key points at, so the probe deletes
+    // the row the schema says the cascade hangs off.
+    let (parent, parent_key) = parent_of(cascading[0].1)?;
+
+    // A cascade with nothing to cascade over, or a restriction with nothing
+    // pinning it, is green on an empty table.
+    for (children, referenced) in [(&cascading, DOOMED), (&restricting, PROTECTED)] {
+        for (child, fk) in children.iter() {
+            let child_column = child_column_of(fk)?;
+            let rows = count(
+                conn,
+                &format!(
+                    "SELECT count(*) FROM {} WHERE {} = {referenced}",
+                    quote(&child.name),
+                    quote(child_column)
+                ),
+            )?;
+            if rows == 0 {
+                return Err(ProbeError::Unseeded(format!(
+                    "{} has no row referencing {parent}.{parent_key} = {referenced}, so deleting \
+                     that parent would prove nothing either way",
+                    child.name
+                )));
+            }
+        }
+    }
+
+    // CASCADE: the delete goes through and the children go with it.
+    let doomed_gone = conn.execute(
+        &format!(
+            "DELETE FROM {} WHERE {} = {DOOMED}",
+            quote(parent),
+            quote(parent_key)
+        ),
+        [],
+    );
+    if let Err(error) = doomed_gone {
+        return Err(ProbeError::Failed(format!(
+            "deleting {parent}.{parent_key} = {DOOMED} was refused ({error}), and a child \
+             declared ON DELETE CASCADE does not refuse it -- the action was reconstructed as \
+             something else, or dropped, which leaves NO ACTION"
+        )));
+    }
+    for (child, fk) in &cascading {
+        let child_column = child_column_of(fk)?;
+        let survivors = count(
+            conn,
+            &format!(
+                "SELECT count(*) FROM {} WHERE {} = {DOOMED}",
+                quote(&child.name),
+                quote(child_column)
+            ),
+        )?;
+        if survivors != 0 {
+            return Err(ProbeError::Failed(format!(
+                "{survivors} row(s) of {} still reference {parent}.{parent_key} = {DOOMED} after \
+                 that parent was deleted; ON DELETE CASCADE did not cascade",
+                child.name
+            )));
+        }
+    }
+
+    // RESTRICT: the end state is the assertion, not which statement raised.
+    // Under deferred enforcement the refusal arrives at COMMIT rather than at
+    // the DELETE, and the probe should be reporting on the referential action
+    // rather than on the transaction shape it happens to be running in.
+    let attempt = conn.execute(
+        &format!(
+            "DELETE FROM {} WHERE {} = {PROTECTED}",
+            quote(parent),
+            quote(parent_key)
+        ),
+        [],
+    );
+    let parent_left = count(
+        conn,
+        &format!(
+            "SELECT count(*) FROM {} WHERE {} = {PROTECTED}",
+            quote(parent),
+            quote(parent_key)
+        ),
+    )?;
+    if parent_left != 1 {
+        return Err(ProbeError::Failed(format!(
+            "{parent}.{parent_key} = {PROTECTED} was deleted even though a child declared ON \
+             DELETE RESTRICT references it (the DELETE {}); the restriction did not restrict",
+            match &attempt {
+                Ok(rows) => format!("reported {rows} row(s) changed"),
+                Err(error) => format!("reported {error}, and the row went anyway"),
+            }
+        )));
+    }
+    for (child, fk) in &restricting {
+        let child_column = child_column_of(fk)?;
+        let left = count(
+            conn,
+            &format!(
+                "SELECT count(*) FROM {} WHERE {} = {PROTECTED}",
+                quote(&child.name),
+                quote(child_column)
+            ),
+        )?;
+        if left != 1 {
+            return Err(ProbeError::Failed(format!(
+                "{} lost the row referencing {parent}.{parent_key} = {PROTECTED}; a RESTRICT \
+                 child is neither cascaded nor nulled, it refuses",
+                child.name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Foreign keys in the schema whose `ON DELETE` is this action, with the table
+/// that declares them.
+fn children_with(schema: &Schema, action: ReferentialAction) -> Vec<(&Table, &ForeignKey)> {
+    schema
+        .tables
+        .iter()
+        .flat_map(|table| {
+            table
+                .constraints
+                .iter()
+                .filter_map(move |constraint| match constraint {
+                    TableConstraint::ForeignKey(fk) if fk.on_delete == Some(action) => {
+                        Some((table, fk))
+                    }
+                    _ => None,
+                })
+        })
+        .collect()
+}
+
+/// The parent table and column a single-column foreign key points at.
+fn parent_of(fk: &ForeignKey) -> Result<(&str, &str), ProbeError> {
+    let column = fk.parent_columns.first().ok_or_else(|| {
+        ProbeError::Failed(format!(
+            "the foreign key on {} names no parent column",
+            fk.parent_table
+        ))
+    })?;
+    Ok((fk.parent_table.as_str(), column.as_str()))
+}
+
+/// The child column a single-column foreign key is declared on.
+fn child_column_of(fk: &ForeignKey) -> Result<&str, ProbeError> {
+    fk.columns.first().map(String::as_str).ok_or_else(|| {
+        ProbeError::Failed(format!(
+            "the foreign key on {} names no child column",
+            fk.parent_table
+        ))
+    })
+}
+
+/// Refuse to draw a conclusion from a `DELETE` nobody was enforcing keys for.
+///
+/// Children surviving a deleted parent because enforcement is off looks
+/// identical, at the row counts, to a `CASCADE` that came back without its
+/// action. Reading the pragma is a precondition on the connection rather than
+/// an assertion about the schema -- the assertions below it are all behavioural
+/// -- and it is read in autocommit because `PRAGMA foreign_keys` is a silent
+/// no-op inside an open transaction.
+fn require_foreign_keys_enforced(conn: &Connection) -> Result<(), ProbeError> {
+    if !conn.is_autocommit() {
+        return Err(ProbeError::Unseeded(
+            "this probe reads PRAGMA foreign_keys, which does not reflect what will apply while a \
+             transaction is open"
+                .to_string(),
+        ));
+    }
+    let enforced: i64 = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
+    if enforced == 0 {
+        return Err(ProbeError::Unseeded(
+            "foreign key enforcement is off on this connection, so a deleted parent leaves its \
+             children behind whatever the referential action says"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// GeneratedVirtual
+// ---------------------------------------------------------------------------
+
+/// The seeded input and the value the case's expression makes of it. The two
+/// constants and the expression in the schema below are one unit.
+const VIRTUAL_BASE: i64 = 21;
+const VIRTUAL_DOUBLED: i64 = 42;
+
+pub(super) fn generated_virtual() -> TraitCase {
+    let schema = schema()
+        .table(
+            table("virtual_generated")
+                .pk_int(KEY)
+                .col("base", Integer, [])
+                .col("doubled", Integer, [Attr::Virtual("\"base\" * 2".into())])
+                .col(LABEL, Text, []),
+        )
+        .build()
+        .expect("the GeneratedVirtual case schema is valid");
+
+    TraitCase {
+        kind: Trait::GeneratedVirtual,
+        schema,
+        seed: |conn| {
+            conn.execute_batch(&format!(
+                "INSERT INTO \"virtual_generated\" (\"{KEY}\", \"base\", \"{LABEL}\") \
+                 VALUES (1, {VIRTUAL_BASE}, 'seeded')"
+            ))?;
+            Ok(())
+        },
+        probe: |schema, conn| {
+            let (table, column) =
+                one_column(schema, "GENERATED ALWAYS AS ... VIRTUAL", |column| {
+                    matches!(column.generated(), Some((_, Generated::Virtual)))
+                })?;
+            require_base_row(conn, &table.name, VIRTUAL_BASE)?;
+
+            let computed: Option<i64> = conn.query_row(
+                &format!(
+                    "SELECT {} FROM {} WHERE \"{KEY}\" = 1",
+                    quote(&column.name),
+                    quote(&table.name)
+                ),
+                [],
+                |row| row.get(0),
+            )?;
+            if computed != Some(VIRTUAL_DOUBLED) {
+                return Err(ProbeError::Failed(format!(
+                    "{}.{} reads {computed:?} for a base of {VIRTUAL_BASE}, not {VIRTUAL_DOUBLED}; \
+                     a virtual generated column that came back as an ordinary one stores nothing \
+                     and reads NULL",
+                    table.name, column.name
+                )));
+            }
+            Ok(())
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GeneratedStored
+// ---------------------------------------------------------------------------
+
+/// Seeded input, its computed value, and the same pair after the probe moves
+/// the base. One unit with the expression in the schema below.
+const STORED_BASE: i64 = 5;
+const STORED_TRIPLED: i64 = 15;
+const STORED_MOVED_BASE: i64 = 7;
+const STORED_MOVED_TRIPLED: i64 = 21;
+
+pub(super) fn generated_stored() -> TraitCase {
+    let schema = schema()
+        .table(
+            table("stored_generated")
+                .pk_int(KEY)
+                .col("base", Integer, [])
+                .col("tripled", Integer, [Attr::Stored("\"base\" * 3".into())])
+                .col(LABEL, Text, []),
+        )
+        .build()
+        .expect("the GeneratedStored case schema is valid");
+
+    TraitCase {
+        kind: Trait::GeneratedStored,
+        schema,
+        seed: |conn| {
+            conn.execute_batch(&format!(
+                "INSERT INTO \"stored_generated\" (\"{KEY}\", \"base\", \"{LABEL}\") \
+                 VALUES (1, {STORED_BASE}, 'seeded')"
+            ))?;
+            Ok(())
+        },
+        probe: |schema, conn| {
+            let (table, column) = one_column(schema, "GENERATED ALWAYS AS ... STORED", |column| {
+                matches!(column.generated(), Some((_, Generated::Stored)))
+            })?;
+            require_base_row(conn, &table.name, STORED_BASE)?;
+
+            let read = |conn: &Connection| -> Result<Option<i64>, ProbeError> {
+                Ok(conn.query_row(
+                    &format!(
+                        "SELECT {} FROM {} WHERE \"{KEY}\" = 1",
+                        quote(&column.name),
+                        quote(&table.name)
+                    ),
+                    [],
+                    |row| row.get(0),
+                )?)
+            };
+
+            let computed = read(conn)?;
+            if computed != Some(STORED_TRIPLED) {
+                return Err(ProbeError::Failed(format!(
+                    "{}.{} reads {computed:?} for a base of {STORED_BASE}, not {STORED_TRIPLED}",
+                    table.name, column.name
+                )));
+            }
+
+            // The assertion that separates a stored generated column from an
+            // ordinary one holding the same number. A row dump cannot tell them
+            // apart, and neither can any comparison of the stored values -- what
+            // is lost when the column comes back ordinary is the computation, so
+            // the probe moves the input and asks whether the column followed.
+            conn.execute(
+                &format!(
+                    "UPDATE {} SET \"base\" = {STORED_MOVED_BASE} WHERE \"{KEY}\" = 1",
+                    quote(&table.name)
+                ),
+                [],
+            )?;
+            let moved = read(conn)?;
+            if moved != Some(STORED_MOVED_TRIPLED) {
+                return Err(ProbeError::Failed(format!(
+                    "{}.{} still reads {moved:?} after its base moved to {STORED_MOVED_BASE}, not \
+                     {STORED_MOVED_TRIPLED}; the value was copied but the computation was not, \
+                     which is what an ordinary column holding the old result looks like",
+                    table.name, column.name
+                )));
+            }
+            Ok(())
+        },
+    }
+}
+
+/// Both generated cases seed one row and key their expectations to its base.
+fn require_base_row(conn: &Connection, table: &str, base: i64) -> Result<(), ProbeError> {
+    let seeded = count(
+        conn,
+        &format!(
+            "SELECT count(*) FROM {} WHERE \"{KEY}\" = 1 AND \"base\" = {base}",
+            quote(table)
+        ),
+    )?;
+    if seeded != 1 {
+        return Err(ProbeError::Unseeded(format!(
+            "{table} has no row 1 with a base of {base}, so the generated column has no input to \
+             have computed anything from"
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// ColumnOnConflict
+// ---------------------------------------------------------------------------
+
+/// The key the REPLACE case's seeded row already occupies.
+const OCCUPIED_KEY: &str = "occupied";
+
+pub(super) fn column_on_conflict() -> TraitCase {
+    let schema = schema()
+        .table(
+            table("replace_absorbs")
+                .pk_int(KEY)
+                .col("k", Text, [Attr::Unique, Attr::OnConflictReplace])
+                .col(LABEL, Text, []),
+        )
+        .table(
+            table("ignore_absorbs")
+                .pk_int(KEY)
+                .col("v", Text, [Attr::NotNull, Attr::OnConflictIgnore])
+                .col(LABEL, Text, []),
+        )
+        .table(
+            table("abort_throws")
+                .pk_int(KEY)
+                .col("v", Text, [Attr::NotNull, Attr::OnConflictAbort])
+                .col(LABEL, Text, []),
+        )
+        .table(
+            table("rollback_throws")
+                .pk_int(KEY)
+                .col("v", Text, [Attr::NotNull, Attr::OnConflictRollback])
+                .col(LABEL, Text, []),
+        )
+        .build()
+        .expect("the ColumnOnConflict case schema is valid");
+
+    TraitCase {
+        kind: Trait::ColumnOnConflict,
+        schema,
+        seed: |conn| {
+            conn.execute_batch(&format!(
+                "INSERT INTO \"replace_absorbs\" (\"{KEY}\", \"k\", \"{LABEL}\") \
+                   VALUES (1, '{OCCUPIED_KEY}', 'seeded');
+                 INSERT INTO \"ignore_absorbs\" (\"{KEY}\", \"v\", \"{LABEL}\") \
+                   VALUES (1, 'seeded value', 'seeded');
+                 INSERT INTO \"abort_throws\" (\"{KEY}\", \"v\", \"{LABEL}\") \
+                   VALUES (1, 'seeded value', 'seeded');
+                 INSERT INTO \"rollback_throws\" (\"{KEY}\", \"v\", \"{LABEL}\") \
+                   VALUES (1, 'seeded value', 'seeded');"
+            ))?;
+            Ok(())
+        },
+        probe: probe_column_on_conflict,
+    }
+}
+
+fn probe_column_on_conflict(schema: &Schema, conn: &Connection) -> Result<(), ProbeError> {
+    let replace = column_with_conflict(schema, OnConflict::Replace)?;
+    let ignore = column_with_conflict(schema, OnConflict::Ignore)?;
+    let abort = column_with_conflict(schema, OnConflict::Abort)?;
+    let rollback = column_with_conflict(schema, OnConflict::Rollback)?;
+
+    // Per table, not once for the case. Two of these four halves are green on
+    // an empty database if nobody checks: a NOT NULL violation throws with no
+    // prior row to conflict with, and an insert into an empty table leaves
+    // exactly the one row REPLACE promises.
+    for (table, _) in [replace, ignore, abort, rollback] {
+        let rows = count(
+            conn,
+            &format!("SELECT count(*) FROM {}", quote(&table.name)),
+        )?;
+        if rows != 1 {
+            return Err(ProbeError::Unseeded(format!(
+                "{} holds {rows} rows, and the conflict this probe provokes needs exactly the one \
+                 seeded row already occupying the key",
+                table.name
+            )));
+        }
+    }
+
+    // REPLACE absorbs: the conflicting insert lands and the row it conflicted
+    // with is gone.
+    let (table, column) = replace;
+    let inserted = conn.execute(
+        &format!(
+            "INSERT INTO {} (\"{KEY}\", {}, \"{LABEL}\") VALUES (2, '{OCCUPIED_KEY}', 'probed')",
+            quote(&table.name),
+            quote(&column.name)
+        ),
+        [],
+    );
+    if let Err(error) = inserted {
+        return Err(ProbeError::Failed(format!(
+            "the insert conflicting on {}.{} was thrown ({error}); ON CONFLICT REPLACE promises \
+             the row already occupying the key is replaced by it",
+            table.name, column.name
+        )));
+    }
+    let survivors = count(
+        conn,
+        &format!("SELECT count(*) FROM {}", quote(&table.name)),
+    )?;
+    let survivor_label = text(
+        conn,
+        &format!(
+            "SELECT \"{LABEL}\" FROM {} ORDER BY \"{KEY}\"",
+            quote(&table.name)
+        ),
+    )?;
+    if survivors != 1 || survivor_label.as_deref() != Some("probed") {
+        return Err(ProbeError::Failed(format!(
+            "{} holds {survivors} row(s) and the first is labelled {survivor_label:?} after the \
+             conflicting insert; ON CONFLICT REPLACE promises one row, the probed one",
+            table.name
+        )));
+    }
+
+    // IGNORE absorbs: the offending row is skipped and nothing is thrown.
+    let (table, column) = ignore;
+    let null_insert = conn.execute(
+        &format!(
+            "INSERT INTO {} (\"{KEY}\", {}, \"{LABEL}\") VALUES (2, NULL, 'probed')",
+            quote(&table.name),
+            quote(&column.name)
+        ),
+        [],
+    );
+    match null_insert {
+        Err(error) => {
+            return Err(ProbeError::Failed(format!(
+                "inserting NULL into {}.{} was thrown ({error}); ON CONFLICT IGNORE promises the \
+                 row is skipped and the statement succeeds",
+                table.name, column.name
+            )))
+        }
+        Ok(_) => {
+            let rows = count(
+                conn,
+                &format!("SELECT count(*) FROM {}", quote(&table.name)),
+            )?;
+            if rows != 1 {
+                return Err(ProbeError::Failed(format!(
+                    "{} holds {rows} rows after a NULL was inserted into {}; ON CONFLICT IGNORE \
+                     promises the row is skipped, and a table that grew was never enforcing NOT \
+                     NULL at all",
+                    table.name, column.name
+                )));
+            }
+        }
+    }
+
+    // ABORT throws.
+    let (table, column) = abort;
+    let null_insert = conn.execute(
+        &format!(
+            "INSERT INTO {} (\"{KEY}\", {}, \"{LABEL}\") VALUES (2, NULL, 'probed')",
+            quote(&table.name),
+            quote(&column.name)
+        ),
+        [],
+    );
+    if null_insert.is_ok() {
+        return Err(ProbeError::Failed(format!(
+            "inserting NULL into {}.{} was absorbed; ON CONFLICT ABORT promises the statement is \
+             thrown",
+            table.name, column.name
+        )));
+    }
+    let rows = count(
+        conn,
+        &format!("SELECT count(*) FROM {}", quote(&table.name)),
+    )?;
+    if rows != 1 {
+        return Err(ProbeError::Failed(format!(
+            "{} holds {rows} rows after a thrown insert; ABORT undoes the statement it threw",
+            table.name
+        )));
+    }
+
+    probe_rollback_ends_the_transaction(conn, rollback)
+}
+
+/// ROLLBACK is the one algorithm whose promise is not about the statement.
+///
+/// ABORT and ROLLBACK both throw, and a probe that asserted only "it threw"
+/// would pass on a database where ROLLBACK had been reconstructed as ABORT.
+/// What differs is reach: ABORT undoes its own statement and leaves the
+/// enclosing transaction open, ROLLBACK takes the transaction with it. So the
+/// probe opens one, does work in it, and asks whether that work survived.
+fn probe_rollback_ends_the_transaction(
+    conn: &Connection,
+    (table, column): (&Table, &Column),
+) -> Result<(), ProbeError> {
+    // Raw BEGIN rather than rusqlite's transaction guard: SQLite ends this
+    // transaction itself when ROLLBACK fires, and a guard's Drop would then try
+    // to roll back a transaction that is no longer there.
+    conn.execute_batch("BEGIN")?;
+    let observed = observe_conflict_in_transaction(conn, table, column);
+    // If SQLite left the transaction open -- which is itself the finding -- the
+    // probe must not hand the connection back inside one.
+    if !conn.is_autocommit() {
+        conn.execute_batch("ROLLBACK")?;
+    }
+    let (thrown, transaction_ended, rows) = observed?;
+
+    if !thrown {
+        return Err(ProbeError::Failed(format!(
+            "inserting NULL into {}.{} was absorbed; ON CONFLICT ROLLBACK promises the statement \
+             is thrown",
+            table.name, column.name
+        )));
+    }
+    if !transaction_ended {
+        return Err(ProbeError::Failed(format!(
+            "the transaction around the thrown insert into {}.{} was still open afterwards; that \
+             is ABORT's behaviour, and ON CONFLICT ROLLBACK promises the transaction goes too",
+            table.name, column.name
+        )));
+    }
+    if rows != 1 {
+        return Err(ProbeError::Failed(format!(
+            "{} holds {rows} rows; the row inserted before the failure should have gone with the \
+             rolled-back transaction",
+            table.name
+        )));
+    }
+    Ok(())
+}
+
+/// Inside the transaction: put a good row in, provoke the conflict, and note
+/// whether it was thrown, whether the transaction outlived it, and what is left.
+///
+/// Separate from its caller so that the caller can settle the transaction on
+/// every path, including the one where this returns early.
+fn observe_conflict_in_transaction(
+    conn: &Connection,
+    table: &Table,
+    column: &Column,
+) -> Result<(bool, bool, i64), ProbeError> {
+    conn.execute(
+        &format!(
+            "INSERT INTO {} (\"{KEY}\", {}, \"{LABEL}\") VALUES (2, 'in the transaction', 'probed')",
+            quote(&table.name),
+            quote(&column.name)
+        ),
+        [],
+    )?;
+    let thrown = conn
+        .execute(
+            &format!(
+                "INSERT INTO {} (\"{KEY}\", {}, \"{LABEL}\") VALUES (3, NULL, 'probed')",
+                quote(&table.name),
+                quote(&column.name)
+            ),
+            [],
+        )
+        .is_err();
+    let transaction_ended = conn.is_autocommit();
+    let rows = count(
+        conn,
+        &format!("SELECT count(*) FROM {}", quote(&table.name)),
+    )?;
+    Ok((thrown, transaction_ended, rows))
+}
+
+/// The column carrying a given conflict algorithm, whichever constraint it is
+/// attached to.
+fn column_with_conflict(
+    schema: &Schema,
+    algorithm: OnConflict,
+) -> Result<(&Table, &Column), ProbeError> {
+    one_column(
+        schema,
+        &format!("declared ON CONFLICT {}", algorithm.as_sql()),
+        |column| {
+            column
+                .constraints
+                .iter()
+                .any(|constraint| conflict_of(constraint) == Some(algorithm))
+        },
+    )
+}
+
+fn conflict_of(constraint: &ColumnConstraint) -> Option<OnConflict> {
+    match constraint {
+        ColumnConstraint::NotNull(algorithm) | ColumnConstraint::Unique(algorithm) => *algorithm,
+        ColumnConstraint::PrimaryKey { on_conflict, .. } => *on_conflict,
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExpressionDefault
+// ---------------------------------------------------------------------------
+
+/// `datetime('now')` renders `YYYY-MM-DD HH:MM:SS`, and this is that shape as a
+/// GLOB. Matching the shape rather than a value is the point: the probe cannot
+/// know the second it ran in, and does not need to.
+const TIMESTAMP_SHAPE: &str =
+    "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]";
+/// The arithmetic default's value, evaluated. One unit with the expression.
+const ARITHMETIC_RESULT: i64 = 5;
+
+pub(super) fn expression_default() -> TraitCase {
+    let schema = schema()
+        .table(
+            table("expression_default")
+                .pk_int(KEY)
+                .col(
+                    "made_at",
+                    Text,
+                    [Attr::Default(DefaultValue::expr("datetime('now')"))],
+                )
+                .col(
+                    "computed",
+                    Integer,
+                    [Attr::Default(DefaultValue::expr("2 + 3"))],
+                )
+                .col(LABEL, Text, []),
+        )
+        .build()
+        .expect("the ExpressionDefault case schema is valid");
+
+    TraitCase {
+        kind: Trait::ExpressionDefault,
+        schema,
+        seed: |conn| {
+            // Omitting both defaulted columns is the whole seed: the defaults
+            // fire, and the row is the one that has to survive a transformation
+            // with the value the expression gave it.
+            conn.execute_batch(&format!(
+                "INSERT INTO \"expression_default\" (\"{KEY}\", \"{LABEL}\") VALUES (1, 'seeded')"
+            ))?;
+            Ok(())
+        },
+        probe: probe_expression_default,
+    }
+}
+
+fn probe_expression_default(schema: &Schema, conn: &Connection) -> Result<(), ProbeError> {
+    let defaulted: Vec<(&Table, &Column, &str)> = schema
+        .tables
+        .iter()
+        .flat_map(|table| {
+            table.columns.iter().filter_map(move |column| {
+                column
+                    .constraints
+                    .iter()
+                    .find_map(|constraint| match constraint {
+                        ColumnConstraint::Default(DefaultValue::Expr(source)) => {
+                            Some((table, column, source.as_str()))
+                        }
+                        _ => None,
+                    })
+            })
+        })
+        .collect();
+    if defaulted.is_empty() {
+        return Err(ProbeError::Failed(
+            "the schema handed to this probe declares no DEFAULT (expression), so there is \
+             nothing to have been evaluated"
+                .to_string(),
+        ));
+    }
+
+    let table = defaulted[0].0;
+    let seeded = count(
+        conn,
+        &format!(
+            "SELECT count(*) FROM {} WHERE \"{KEY}\" = 1",
+            quote(&table.name)
+        ),
+    )?;
+    if seeded != 1 {
+        return Err(ProbeError::Unseeded(format!(
+            "{} has no row 1, so no default was ever evaluated to look at",
+            table.name
+        )));
+    }
+
+    conn.execute(
+        &format!(
+            "INSERT INTO {} (\"{KEY}\", \"{LABEL}\") VALUES (2, 'probed')",
+            quote(&table.name)
+        ),
+        [],
+    )?;
+
+    // The general assertion, and the one the trait is named for: a default that
+    // was re-rendered without its parentheses stops being an expression and
+    // becomes the literal text of itself. Comparing the stored value to the
+    // expression's own source is schema-driven and needs no knowledge of what
+    // the expression means.
+    for (table, column, source) in &defaulted {
+        let literal: i64 = conn.query_row(
+            &format!(
+                "SELECT count(*) FROM {} WHERE CAST({} AS TEXT) = ?1",
+                quote(&table.name),
+                quote(&column.name)
+            ),
+            [source],
+            |row| row.get(0),
+        )?;
+        if literal != 0 {
+            return Err(ProbeError::Failed(format!(
+                "{literal} row(s) of {}.{} hold the text {source:?}, which is the source of their \
+                 own DEFAULT; the parentheses were dropped and the expression was stored as a \
+                 literal instead of evaluated",
+                table.name, column.name
+            )));
+        }
+    }
+
+    // And the specific ones, about this case's own two columns: a timestamp is
+    // shaped like a timestamp, and arithmetic comes back as a number rather
+    // than as text that merely looks like one.
+    let shaped = count(
+        conn,
+        &format!(
+            "SELECT count(*) FROM {} WHERE \"made_at\" GLOB '{TIMESTAMP_SHAPE}'",
+            quote(&table.name)
+        ),
+    )?;
+    if shaped != 2 {
+        let seen = text(
+            conn,
+            &format!(
+                "SELECT \"made_at\" FROM {} ORDER BY \"{KEY}\" DESC",
+                quote(&table.name)
+            ),
+        )?;
+        return Err(ProbeError::Failed(format!(
+            "{shaped} of 2 rows hold a timestamp in made_at (most recent: {seen:?}); \
+             DEFAULT (datetime('now')) yields the time it was evaluated"
+        )));
+    }
+    let arithmetic = count(
+        conn,
+        &format!(
+            "SELECT count(*) FROM {} WHERE typeof(\"computed\") = 'integer' AND \"computed\" = \
+             {ARITHMETIC_RESULT}",
+            quote(&table.name)
+        ),
+    )?;
+    if arithmetic != 2 {
+        return Err(ProbeError::Failed(format!(
+            "{arithmetic} of 2 rows hold the integer {ARITHMETIC_RESULT} in computed; an \
+             evaluated arithmetic default is a number, and a stored literal is text that is not"
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TypelessColumn
+// ---------------------------------------------------------------------------
+
+pub(super) fn typeless_column() -> TraitCase {
+    let schema = schema()
+        .table(
+            table("typeless")
+                .pk_int(KEY)
+                .typeless("v", [])
+                .col(LABEL, Text, []),
+        )
+        .build()
+        .expect("the TypelessColumn case schema is valid");
+
+    TraitCase {
+        kind: Trait::TypelessColumn,
+        schema,
+        seed: |conn| {
+            // One text value and one integer value in the same column. A column
+            // resolved to TEXT stores both as text, and the difference below is
+            // gone.
+            conn.execute_batch(&format!(
+                "INSERT INTO \"typeless\" (\"{KEY}\", \"v\", \"{LABEL}\") \
+                   VALUES (1, 'a string', 'seeded'), (2, 42, 'seeded')"
+            ))?;
+            Ok(())
+        },
+        probe: probe_typeless_column,
+    }
+}
+
+fn probe_typeless_column(schema: &Schema, conn: &Connection) -> Result<(), ProbeError> {
+    let (table, column) = one_column(schema, "declared with no type at all", |column| {
+        column.decl_type.is_none()
+    })?;
+
+    let seeded = count(
+        conn,
+        &format!(
+            "SELECT count(*) FROM {} WHERE \"{KEY}\" IN (1, 2)",
+            quote(&table.name)
+        ),
+    )?;
+    if seeded != 2 {
+        return Err(ProbeError::Unseeded(format!(
+            "{} does not hold both seeded rows, and one value cannot have two types",
+            table.name
+        )));
+    }
+
+    let type_of = |key: i64| -> Result<Option<String>, ProbeError> {
+        text(
+            conn,
+            &format!(
+                "SELECT typeof({}) FROM {} WHERE \"{KEY}\" = {key}",
+                quote(&column.name),
+                quote(&table.name)
+            ),
+        )
+    };
+    let (string_row, integer_row) = (type_of(1)?, type_of(2)?);
+    if string_row.as_deref() != Some("text") || integer_row.as_deref() != Some("integer") {
+        return Err(ProbeError::Failed(format!(
+            "{}.{} reads typeof() {string_row:?} for a string and {integer_row:?} for an integer; \
+             a blank-affinity column stores each value as what it is, and one resolved to TEXT \
+             converts both",
+            table.name, column.name
+        )));
+    }
+
+    // The one PRAGMA assertion in the registry, taken deliberately.
+    //
+    // Every other probe here asserts behaviour because presence is not
+    // behaviour. This column is the case where the two come apart in the other
+    // direction: a typeless column promoted to BLOB keeps blank affinity's
+    // dynamic typing exactly, so the assertion above passes on a database where
+    // the type was invented. The promotion is invisible behaviourally on the
+    // native path and shows up only in the declared type -- so reading it is
+    // the only way to catch it, and refusing on principle would mean shipping a
+    // probe that cannot see the defect it is named for. It is an addition to
+    // the behavioural assertion above, never a replacement for it.
+    let declared = text(
+        conn,
+        &format!(
+            "SELECT type FROM pragma_table_info('{}') WHERE name = '{}'",
+            table.name.replace('\'', "''"),
+            column.name.replace('\'', "''")
+        ),
+    )?;
+    if declared.as_deref() != Some("") {
+        return Err(ProbeError::Failed(format!(
+            "{}.{} declares the type {declared:?}, and it was declared with none; a type invented \
+             for a typeless column survives every behavioural check on this path",
+            table.name, column.name
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Trigger
+// ---------------------------------------------------------------------------
+
+/// The table the trigger writes into. Named here rather than resolved: the
+/// trigger body is SQL, and forger does not parse SQL to find out what its own
+/// case wrote.
+const AUDIT: &str = "audit";
+/// Seeded before the transformation, inserted after it. The pair is what makes
+/// "fired once" separable from "fired at all" -- smugglr#336's shape.
+const BEFORE: &str = "before";
+const AFTER: &str = "after";
+
+pub(super) fn trigger() -> TraitCase {
+    let schema = schema()
+        .table(
+            table("evented")
+                .pk_int(KEY)
+                .col("note", Text, [])
+                .trigger(Trigger {
+                    name: "evented_audit".into(),
+                    timing: TriggerTiming::After,
+                    event: TriggerEvent::Insert,
+                    when: None,
+                    body: vec![format!(
+                        "INSERT INTO {} (\"note\") VALUES (new.\"note\")",
+                        quote(AUDIT)
+                    )],
+                }),
+        )
+        .table(table(AUDIT).pk_int(KEY).col("note", Text, []))
+        .build()
+        .expect("the Trigger case schema is valid");
+
+    TraitCase {
+        kind: Trait::Trigger,
+        schema,
+        seed: |conn| {
+            conn.execute_batch(&format!(
+                "INSERT INTO \"evented\" (\"{KEY}\", \"note\") VALUES (1, '{BEFORE}')"
+            ))?;
+            Ok(())
+        },
+        probe: probe_trigger,
+    }
+}
+
+fn probe_trigger(schema: &Schema, conn: &Connection) -> Result<(), ProbeError> {
+    let triggered: Vec<&Table> = schema
+        .tables
+        .iter()
+        .filter(|table| !table.triggers.is_empty())
+        .collect();
+    let [evented] = triggered[..] else {
+        return Err(ProbeError::Failed(format!(
+            "the schema handed to this probe hangs triggers off {} tables, and the probe fires \
+             one",
+            triggered.len()
+        )));
+    };
+
+    // The precondition is the seed's own row, not the trigger's side effect:
+    // the side effect is what is being asserted, and a probe that required it
+    // up front would refuse where it should fail.
+    let seeded = count(
+        conn,
+        &format!(
+            "SELECT count(*) FROM {} WHERE \"{KEY}\" = 1",
+            quote(&evented.name)
+        ),
+    )?;
+    if seeded != 1 {
+        return Err(ProbeError::Unseeded(format!(
+            "{} holds no row seeded before the transformation, so a trigger firing now could not \
+             be told apart from one that fired twice",
+            evented.name
+        )));
+    }
+
+    conn.execute(
+        &format!(
+            "INSERT INTO {} (\"{KEY}\", \"note\") VALUES (2, '{AFTER}')",
+            quote(&evented.name)
+        ),
+        [],
+    )?;
+
+    let audited: Vec<String> = conn
+        .prepare(&format!(
+            "SELECT \"note\" FROM {} ORDER BY \"{KEY}\"",
+            quote(AUDIT)
+        ))?
+        .query_map([], |row| row.get(0))?
+        .collect::<Result<_, _>>()?;
+    if audited != [BEFORE, AFTER] {
+        return Err(ProbeError::Failed(format!(
+            "{AUDIT} holds {audited:?} after one row was seeded and one inserted; the trigger's \
+             side effect is [{BEFORE:?}, {AFTER:?}]. Fewer means it did not fire -- a trigger can \
+             sit in sqlite_master and still never run. More means it fired over rows that had \
+             already been audited, which is what a rebuild's INSERT ... SELECT does when the \
+             trigger is re-created before the copy rather than after it"
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// DescendingPrimaryKey
+// ---------------------------------------------------------------------------
+
+/// Seeded keys, chosen far from the rowids SQLite will hand out (1 and 2) so
+/// that "the key is the rowid" cannot be true by coincidence.
+const DESCENDING_KEYS: [i64; 2] = [100, 200];
+/// The row the probe inserts without naming a key at all.
+const NO_KEY_GIVEN: &str = "no key given";
+
+pub(super) fn descending_primary_key() -> TraitCase {
+    let schema = schema()
+        .table(
+            table("descending_key")
+                .pk_col(KEY, Integer, SortOrder::Desc)
+                .col(LABEL, Text, []),
+        )
+        .build()
+        .expect("the DescendingPrimaryKey case schema is valid");
+
+    TraitCase {
+        kind: Trait::DescendingPrimaryKey,
+        schema,
+        seed: |conn| {
+            let [first, second] = DESCENDING_KEYS;
+            conn.execute_batch(&format!(
+                "INSERT INTO \"descending_key\" (\"{KEY}\", \"{LABEL}\") \
+                   VALUES ({first}, 'seeded'), ({second}, 'seeded')"
+            ))?;
+            Ok(())
+        },
+        probe: probe_descending_primary_key,
+    }
+}
+
+fn probe_descending_primary_key(schema: &Schema, conn: &Connection) -> Result<(), ProbeError> {
+    let (table, column) = one_column(schema, "a PRIMARY KEY declared DESC", |column| {
+        column.constraints.iter().any(|constraint| {
+            matches!(
+                constraint,
+                ColumnConstraint::PrimaryKey {
+                    order: SortOrder::Desc,
+                    ..
+                }
+            )
+        })
+    })?;
+
+    let [first, second] = DESCENDING_KEYS;
+    let seeded = count(
+        conn,
+        &format!(
+            "SELECT count(*) FROM {} WHERE {} IN ({first}, {second})",
+            quote(&table.name),
+            quote(&column.name)
+        ),
+    )?;
+    if seeded != 2 {
+        return Err(ProbeError::Unseeded(format!(
+            "{} does not hold both seeded keys, and a key that is not there cannot be compared to \
+             a rowid",
+            table.name
+        )));
+    }
+
+    // The property that actually differs. INTEGER PRIMARY KEY is the rowid
+    // under another name; INTEGER PRIMARY KEY DESC is an ordinary key with a
+    // unique index, and the table keeps a rowid of its own underneath.
+    let aliased = count(
+        conn,
+        &format!(
+            "SELECT count(*) FROM {} WHERE rowid = {}",
+            quote(&table.name),
+            quote(&column.name)
+        ),
+    )?;
+    if aliased != 0 {
+        return Err(ProbeError::Failed(format!(
+            "{} row(s) of {}.{} equal their own rowid; that is the ascending spelling, which is \
+             the rowid alias -- INTEGER PRIMARY KEY DESC is not one and was seeded with keys no \
+             rowid sequence would produce",
+            aliased, table.name, column.name
+        )));
+    }
+
+    // And the consequence of not being an alias: nothing hands out a key.
+    conn.execute(
+        &format!(
+            "INSERT INTO {} (\"{LABEL}\") VALUES ('{NO_KEY_GIVEN}')",
+            quote(&table.name)
+        ),
+        [],
+    )?;
+    let assigned = text(
+        conn,
+        &format!(
+            "SELECT typeof({}) FROM {} WHERE \"{LABEL}\" = '{NO_KEY_GIVEN}'",
+            quote(&column.name),
+            quote(&table.name)
+        ),
+    )?;
+    if assigned.as_deref() != Some("null") {
+        return Err(ProbeError::Failed(format!(
+            "inserting into {} without naming {} left a {assigned:?} there; only a rowid alias \
+             allocates a key, and a key that allocates is an ascending INTEGER PRIMARY KEY. \
+             (SQLite also leaves a non-alias key nullable, which is why this reads as NULL rather \
+             than being refused.)",
+            table.name, column.name
+        )));
+    }
+    Ok(())
+}

--- a/crates/smugglr-forger/src/registry/mod.rs
+++ b/crates/smugglr-forger/src/registry/mod.rs
@@ -1,0 +1,206 @@
+//! The trait registry: no trait without a seed and a probe, enforced by the
+//! compiler.
+//!
+//! [`TraitCase::for_trait`] matches [`Trait`] exhaustively and has no catch-all
+//! arm. Adding a variant to the enum makes this module stop compiling, and the
+//! error names the variant that has no case. That is the whole mechanism, and
+//! it is deliberately not a checked list: a list can be appended to, a
+//! placeholder can be written, an `Unsupported` marker can be added -- each of
+//! those closes the build and reopens the coverage gap, which is the same
+//! degradation shape as a validator that weakens when its input will not parse.
+//! FR-FORGER-003.
+//!
+//! # Why the three parts are one value
+//!
+//! A probe with no seed asserts nothing: an empty database is green on every
+//! behavioural assertion ever written, because there are no rows for the
+//! behaviour to happen to. A seed with no probe is inert data. And both of them
+//! need a schema that actually carries the trait. So [`TraitCase`] holds all
+//! three, its fields are not optional, and the match arm that builds one cannot
+//! be written half-finished. FR-FORGER-004.
+//!
+//! # What a probe is allowed to assert
+//!
+//! What the construct *does*, against the live database -- never that it is
+//! present. Presence is not behaviour and SQLite proves it: `CREATE TRIGGER`
+//! does not resolve the column references in a trigger body, so a trigger can
+//! sit in `sqlite_master` looking correct to any schema comparison and fail
+//! every time it fires. A probe that asserted the trigger was present would be
+//! green on a database that is now unwritable. FR-FORGER-006.
+//!
+//! One probe reads `table_info` in addition to its behavioural assertion, and
+//! says at the assertion why it is allowed to.
+//!
+//! # Why the probe takes a schema and the seed does not
+//!
+//! A seed writes rows it authored into tables it authored, so it needs nothing
+//! but a connection. A probe interrogates a database it did not build: it is
+//! handed the schema that was *promised* and asks whether the database in front
+//! of it behaves that way. That asymmetry is what makes the probe usable
+//! against a database some transformation produced -- and it is why every probe
+//! locates its target by reading the schema rather than by hard-coding it. If
+//! the schema turns out not to carry the construct the probe exists for, the
+//! probe refuses instead of passing.
+//!
+//! # Setting no pragmas, and checking the one that matters
+//!
+//! Probes configure nothing about the connection. `rusqlite`'s bundled SQLite
+//! is compiled with `SQLITE_DEFAULT_FOREIGN_KEYS=1`, so enforcement is already
+//! on -- measured, not assumed: `PRAGMA foreign_keys` reads 1 in autocommit on
+//! a fresh [`Fixture`](crate::Fixture) connection here, against SQLite 3.49.1.
+//! The `sqlite3` shell defaults it off, which is what most written-down SQLite
+//! knowledge assumes.
+//!
+//! The cascade probe reads that pragma before it asserts anything, and refuses
+//! when enforcement is off. A `DELETE` whose children survive because nobody is
+//! enforcing keys is indistinguishable, at the row counts, from a `CASCADE`
+//! that was reconstructed without its action -- so an unchecked probe would
+//! report the defect it hunts on a connection that merely had the pragma off.
+//! It reads it in autocommit, because `PRAGMA foreign_keys` is a silent no-op
+//! inside an open transaction.
+
+mod cases;
+
+use rusqlite::Connection;
+
+use crate::error::ProbeError;
+use crate::schema::{Column, Schema, Table, Trait};
+
+/// Rows a seed writes. Takes only a connection: see the module docs.
+pub type SeedFn = fn(&Connection) -> Result<(), ProbeError>;
+
+/// An assertion about what the database does, against the schema it was
+/// promised.
+pub type ProbeFn = fn(&Schema, &Connection) -> Result<(), ProbeError>;
+
+/// A trait, a schema that carries it, a seed that makes it observable, and a
+/// probe that asserts what it does.
+///
+/// The unit is added and removed whole. There is no constructor that leaves a
+/// part out.
+pub struct TraitCase {
+    /// The trait this case exists for.
+    pub kind: Trait,
+    /// A schema carrying the trait, and as little else as the behaviour allows.
+    pub schema: Schema,
+    seed: SeedFn,
+    probe: ProbeFn,
+}
+
+impl TraitCase {
+    /// The case for a trait.
+    ///
+    /// Exhaustive, with no catch-all arm. A new [`Trait`] variant fails to
+    /// compile here until it has somewhere to go, and the compiler names it.
+    pub fn for_trait(kind: Trait) -> Self {
+        match kind {
+            Trait::ForeignKeyWithAction => cases::foreign_key_with_action(),
+            Trait::GeneratedVirtual => cases::generated_virtual(),
+            Trait::GeneratedStored => cases::generated_stored(),
+            Trait::ColumnOnConflict => cases::column_on_conflict(),
+            Trait::ExpressionDefault => cases::expression_default(),
+            Trait::TypelessColumn => cases::typeless_column(),
+            Trait::Trigger => cases::trigger(),
+            Trait::DescendingPrimaryKey => cases::descending_primary_key(),
+        }
+    }
+
+    /// Put the database into the state that makes this trait's behaviour
+    /// observable. Run it after the schema is in place.
+    pub fn seed(&self, conn: &Connection) -> Result<(), ProbeError> {
+        (self.seed)(conn)
+    }
+
+    /// Assert what the trait does, against the schema this case promised.
+    pub fn probe(&self, conn: &Connection) -> Result<(), ProbeError> {
+        (self.probe)(&self.schema, conn)
+    }
+}
+
+/// Every column the predicate accepts, with the table it belongs to.
+///
+/// This is how a probe finds what it came for. Returning the pair rather than
+/// the name keeps the caller from having to search twice.
+fn columns_where(schema: &Schema, pick: impl Fn(&Column) -> bool) -> Vec<(&Table, &Column)> {
+    schema
+        .tables
+        .iter()
+        .flat_map(|table| {
+            table
+                .columns
+                .iter()
+                .filter(|column| pick(column))
+                .map(move |column| (table, column))
+        })
+        .collect()
+}
+
+/// The one column the predicate accepts, or a refusal naming what was looked
+/// for.
+///
+/// A probe that cannot find its target must not proceed: whatever it asserted
+/// next would be about some other column, and passing would mean nothing.
+pub(crate) fn one_column<'a>(
+    schema: &'a Schema,
+    looking_for: &str,
+    pick: impl Fn(&Column) -> bool,
+) -> Result<(&'a Table, &'a Column), ProbeError> {
+    let found = columns_where(schema, pick);
+    match found.len() {
+        1 => Ok(found[0]),
+        n => Err(ProbeError::Failed(format!(
+            "the schema handed to this probe declares {n} columns that are {looking_for}, \
+             and the probe asserts about exactly one"
+        ))),
+    }
+}
+
+/// `SELECT count(*)`, which is most of what a probe does.
+pub(crate) fn count(conn: &Connection, sql: &str) -> Result<i64, ProbeError> {
+    Ok(conn.query_row(sql, [], |row| row.get(0))?)
+}
+
+/// One `TEXT` value, or `None` when the row is not there or holds NULL.
+pub(crate) fn text(conn: &Connection, sql: &str) -> Result<Option<String>, ProbeError> {
+    let mut statement = conn.prepare(sql)?;
+    let mut rows = statement.query([])?;
+    match rows.next()? {
+        Some(row) => Ok(row.get(0)?),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The match in `for_trait` is exhaustive, but nothing in the type system
+    /// says an arm returns the case it was asked for. This does.
+    #[test]
+    fn every_case_is_the_case_it_was_asked_for() {
+        for kind in Trait::ALL {
+            assert_eq!(TraitCase::for_trait(kind).kind, kind);
+        }
+    }
+
+    /// `Trait::ALL` is scaffolding rather than enforcement, so the one thing it
+    /// must not do is list a variant twice and look complete while missing one.
+    #[test]
+    fn all_lists_each_variant_once() {
+        let mut sorted = Trait::ALL;
+        sorted.sort();
+        let mut deduped = sorted.to_vec();
+        deduped.dedup();
+        assert_eq!(deduped.len(), Trait::ALL.len());
+    }
+
+    /// Every case's schema has to be one SQLite would accept, or the case can
+    /// never be stood up at all.
+    #[test]
+    fn every_case_carries_a_valid_schema() {
+        for kind in Trait::ALL {
+            let case = TraitCase::for_trait(kind);
+            assert_eq!(case.schema.validate(), Ok(()), "{kind:?}");
+        }
+    }
+}

--- a/crates/smugglr-forger/src/schema/ddl.rs
+++ b/crates/smugglr-forger/src/schema/ddl.rs
@@ -222,7 +222,11 @@ fn conflict_clause(on_conflict: &Option<super::OnConflict>) -> String {
 
 /// Quote an identifier. Doubling an embedded quote is what keeps a column
 /// named `a"b` from ending the identifier early.
-fn quote(name: &str) -> String {
+///
+/// `pub(crate)` because probes build their SQL from names they read out of a
+/// [`Schema`], and a probe that quoted identifiers its own way would be a
+/// second implementation of this rule waiting to disagree with the first.
+pub(crate) fn quote(name: &str) -> String {
     format!("\"{}\"", name.replace('"', "\"\""))
 }
 

--- a/crates/smugglr-forger/src/schema/mod.rs
+++ b/crates/smugglr-forger/src/schema/mod.rs
@@ -291,6 +291,26 @@ pub enum Trait {
     DescendingPrimaryKey,
 }
 
+impl Trait {
+    /// Every variant, for iterating.
+    ///
+    /// Scaffolding, not enforcement: nothing stops a new variant from being
+    /// left out of this array. What cannot be left out is the seed and the
+    /// probe -- [`TraitCase::for_trait`](crate::registry::TraitCase::for_trait)
+    /// matches exhaustively, so a variant with no case fails to compile
+    /// whether or not it is listed here.
+    pub const ALL: [Trait; 8] = [
+        Trait::ForeignKeyWithAction,
+        Trait::GeneratedVirtual,
+        Trait::GeneratedStored,
+        Trait::ColumnOnConflict,
+        Trait::ExpressionDefault,
+        Trait::TypelessColumn,
+        Trait::Trigger,
+        Trait::DescendingPrimaryKey,
+    ];
+}
+
 impl Schema {
     /// Reject anything SQLite would reject. See [`validate`].
     pub fn validate(&self) -> Result<(), crate::error::ValidationError> {

--- a/crates/smugglr-forger/tests/every_trait_seeds_and_probes.rs
+++ b/crates/smugglr-forger/tests/every_trait_seeds_and_probes.rs
@@ -1,0 +1,48 @@
+//! Every trait's case stands up, seeds, and passes its own probe -- and every
+//! probe refuses a database nobody seeded.
+//!
+//! The second half is the one that matters. An empty database is green on every
+//! behavioural assertion ever written, because there are no rows for the
+//! behaviour to happen to; a probe that passes there is measuring nothing and
+//! would go on measuring nothing after the construct it guards was lost.
+
+use smugglr_forger::error::ProbeError;
+use smugglr_forger::fixture::{Backing, Fixture, Route};
+use smugglr_forger::registry::TraitCase;
+use smugglr_forger::schema::Trait;
+
+fn stood_up(case: &TraitCase) -> Fixture {
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    fixture
+        .bring_to(Route::Schema(&case.schema))
+        .unwrap_or_else(|error| panic!("{:?}: {error}", case.kind));
+    fixture
+}
+
+#[test]
+fn every_trait_passes_its_own_probe_once_seeded() {
+    for kind in Trait::ALL {
+        let case = TraitCase::for_trait(kind);
+        let fixture = stood_up(&case);
+        case.seed(fixture.conn())
+            .unwrap_or_else(|error| panic!("{kind:?} seed: {error}"));
+        case.probe(fixture.conn())
+            .unwrap_or_else(|error| panic!("{kind:?} probe: {error}"));
+    }
+}
+
+#[test]
+fn every_probe_refuses_an_unseeded_database() {
+    for kind in Trait::ALL {
+        let case = TraitCase::for_trait(kind);
+        let fixture = stood_up(&case);
+
+        // The schema is in place and correct. Only the rows are missing, which
+        // is exactly the state in which a badly written probe reports health.
+        let outcome = case.probe(fixture.conn());
+        assert!(
+            matches!(outcome, Err(ProbeError::Unseeded(_))),
+            "{kind:?} probed an unseeded database and reported {outcome:?}"
+        );
+    }
+}

--- a/crates/smugglr-forger/tests/probes_are_non_vacuous.rs
+++ b/crates/smugglr-forger/tests/probes_are_non_vacuous.rs
@@ -1,0 +1,375 @@
+//! Break the mechanism each probe guards, and watch the probe fail.
+//!
+//! A probe that passes against a deliberately broken schema is worse than no
+//! probe: it is a green check that is a statement about nothing, and it will go
+//! on being green for as long as the defect it was written for keeps arriving.
+//! So every probe in the registry is run here against a database built from a
+//! schema with its own trait taken away, and is required to fail.
+//!
+//! # How the break is expressed
+//!
+//! By rendering DDL, not by patching a database. Each break takes the case's
+//! own schema, removes or swaps exactly the one thing the trait is named for,
+//! and stands a fixture up from `Route::Ddl` -- which is what a transformation
+//! that lost the construct would have produced. The probe is then handed the
+//! schema that was *promised*, unbroken, and asked whether the database in
+//! front of it behaves that way. That is the differential shape in miniature,
+//! and forger can build it without knowing what a transformation is.
+//!
+//! A few breaks are not schema edits at all. A rebuild that re-creates a
+//! trigger before copying rows into the new table produces a schema that is
+//! correct in every particular and a database that has audited the same row
+//! twice, so that break is expressed as the statements the rebuild would have
+//! run. `after_seed` is for those.
+//!
+//! # Why some breaks are swaps rather than removals
+//!
+//! `ON CONFLICT ABORT` is SQLite's default. Dropping the clause changes the
+//! DDL and changes nothing else, so the ABORT half is broken by swapping the
+//! algorithm instead -- the defect it can actually suffer is being reconstructed
+//! as a different algorithm, not being reconstructed as nothing.
+
+use smugglr_forger::error::ProbeError;
+use smugglr_forger::fixture::{Backing, Fixture, Route};
+use smugglr_forger::registry::TraitCase;
+use smugglr_forger::schema::{
+    Column, ColumnConstraint, ColumnType, DefaultValue, OnConflict, Schema, SortOrder,
+    TableConstraint, Trait,
+};
+
+/// One deliberately damaged world, and what was damaged about it.
+struct Break {
+    /// What was taken away, in the words the report will use.
+    what: &'static str,
+    /// The schema as a transformation that lost it would have left it.
+    schema: Schema,
+    /// Statements run after the seed, for breaks that live in what a rebuild
+    /// did rather than in what it declared.
+    after_seed: Vec<String>,
+}
+
+impl Break {
+    fn schema(what: &'static str, schema: Schema) -> Self {
+        Break {
+            what,
+            schema,
+            after_seed: Vec::new(),
+        }
+    }
+
+    fn then(mut self, statements: &[&str]) -> Self {
+        self.after_seed = statements.iter().map(|s| s.to_string()).collect();
+        self
+    }
+}
+
+#[test]
+fn every_probe_fails_when_the_mechanism_it_guards_is_broken() {
+    for kind in Trait::ALL {
+        let case = TraitCase::for_trait(kind);
+        let breaks = breaks(kind);
+        assert!(
+            !breaks.is_empty(),
+            "{kind:?} has no break, so its probe has never been shown to fail"
+        );
+
+        for broken in breaks {
+            let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+            fixture
+                .bring_to(Route::Ddl(&broken.schema.to_ddl()))
+                .unwrap_or_else(|error| panic!("{kind:?} / {}: {error}", broken.what));
+            case.seed(fixture.conn())
+                .unwrap_or_else(|error| panic!("{kind:?} / {}: seed: {error}", broken.what));
+            for statement in &broken.after_seed {
+                fixture
+                    .conn()
+                    .execute_batch(statement)
+                    .unwrap_or_else(|error| panic!("{kind:?} / {}: {error}", broken.what));
+            }
+
+            // The promise is the case's own schema; the database is the broken
+            // one. Nothing else about the probe changes.
+            let outcome = case.probe(fixture.conn());
+            match outcome {
+                Err(ProbeError::Failed(message)) => {
+                    println!("{kind:?} -- broke: {}\n  said: {message}\n", broken.what);
+                }
+                other => panic!(
+                    "{kind:?} probe did not report a failure with {} broken; it said {other:?}",
+                    broken.what
+                ),
+            }
+        }
+    }
+}
+
+/// The break table.
+///
+/// Exhaustive over [`Trait`] and free of a catch-all arm, exactly like the
+/// registry it tests: a new trait cannot be added without someone writing down
+/// how to break it and watching the probe notice.
+fn breaks(kind: Trait) -> Vec<Break> {
+    let schema = || TraitCase::for_trait(kind).schema;
+    match kind {
+        Trait::ForeignKeyWithAction => {
+            let mut dropped_action = schema();
+            foreign_key_mut(&mut dropped_action, "cascade_child").on_delete = None;
+
+            let mut dropped_key = schema();
+            table_mut(&mut dropped_key, "restrict_child")
+                .constraints
+                .retain(|c| !matches!(c, TableConstraint::ForeignKey(_)));
+
+            vec![
+                // smugglr#341's shape: the rebuild reads five of the eight
+                // columns pragma foreign_key_list hands it, and the referential
+                // action is in one of the three it does not.
+                Break::schema(
+                    "ON DELETE CASCADE, leaving the key with the NO ACTION default",
+                    dropped_action,
+                ),
+                Break::schema(
+                    "the RESTRICT child's foreign key, dropped whole",
+                    dropped_key,
+                ),
+            ]
+        }
+
+        Trait::GeneratedVirtual => {
+            let mut ordinary = schema();
+            drop_generated(&mut ordinary, "virtual_generated", "doubled");
+            vec![Break::schema(
+                "GENERATED ALWAYS AS (...) VIRTUAL, re-created as an ordinary column",
+                ordinary,
+            )]
+        }
+
+        Trait::GeneratedStored => {
+            let mut ordinary = schema();
+            drop_generated(&mut ordinary, "stored_generated", "tripled");
+            vec![Break::schema(
+                "GENERATED ALWAYS AS (...) STORED, re-created as an ordinary column holding the \
+                 value a rebuild would have copied into it",
+                ordinary,
+            )
+            // Without this the break is caught by the first read and the
+            // interesting half is never reached. With it, the column holds
+            // exactly what a row dump would show and differs only in that it
+            // has stopped computing -- which is the whole defect.
+            .then(&["UPDATE \"stored_generated\" SET \"tripled\" = \"base\" * 3"])]
+        }
+
+        Trait::ColumnOnConflict => {
+            let mut no_replace = schema();
+            drop_conflict(&mut no_replace, "replace_absorbs", "k");
+            let mut no_ignore = schema();
+            drop_conflict(&mut no_ignore, "ignore_absorbs", "v");
+            let mut no_rollback = schema();
+            drop_conflict(&mut no_rollback, "rollback_throws", "v");
+            let mut abort_swapped = schema();
+            set_conflict(&mut abort_swapped, "abort_throws", "v", OnConflict::Ignore);
+
+            vec![
+                Break::schema("ON CONFLICT REPLACE, leaving a plain UNIQUE", no_replace),
+                Break::schema("ON CONFLICT IGNORE, leaving a plain NOT NULL", no_ignore),
+                Break::schema(
+                    "ON CONFLICT ROLLBACK, leaving a plain NOT NULL -- which throws exactly like \
+                     ROLLBACK and differs only in what happens to the transaction",
+                    no_rollback,
+                ),
+                // Not a removal: ABORT is the default, so a dropped clause is
+                // behaviourally the same table. What ABORT can lose is its
+                // identity among the other four.
+                Break::schema("ON CONFLICT ABORT, swapped for IGNORE", abort_swapped),
+            ]
+        }
+
+        Trait::ExpressionDefault => {
+            let mut literal_timestamp = schema();
+            set_default(
+                &mut literal_timestamp,
+                "expression_default",
+                "made_at",
+                DefaultValue::text("datetime('now')"),
+            );
+            let mut literal_arithmetic = schema();
+            set_default(
+                &mut literal_arithmetic,
+                "expression_default",
+                "computed",
+                DefaultValue::text("2 + 3"),
+            );
+            // The two above are caught by the probe's first assertion, which
+            // compares the stored value to the source of its own default. That
+            // leaves the two assertions behind it -- the timestamp's shape and
+            // the arithmetic's type -- never run in the failing direction, and
+            // an assertion never seen to fail is an assertion nobody has
+            // checked. These two break the expression into a *different*
+            // expression: it still evaluates, so the first assertion passes and
+            // each of the other two is reached alone.
+            let mut date_only = schema();
+            set_default(
+                &mut date_only,
+                "expression_default",
+                "made_at",
+                DefaultValue::expr("date('now')"),
+            );
+            let mut concatenated = schema();
+            set_default(
+                &mut concatenated,
+                "expression_default",
+                "computed",
+                DefaultValue::expr("'2' || '+' || '3'"),
+            );
+
+            vec![
+                Break::schema(
+                    "the parentheses around DEFAULT (datetime('now')), making it the literal text \
+                     of itself",
+                    literal_timestamp,
+                ),
+                Break::schema(
+                    "the parentheses around DEFAULT (2 + 3), making it the literal text of itself",
+                    literal_arithmetic,
+                ),
+                Break::schema(
+                    "the time out of DEFAULT (datetime('now')), leaving an expression that still \
+                     evaluates and no longer yields a timestamp",
+                    date_only,
+                ),
+                Break::schema(
+                    "the arithmetic in DEFAULT (2 + 3), leaving string concatenation that still \
+                     evaluates and yields text that merely looks like a number",
+                    concatenated,
+                ),
+            ]
+        }
+
+        Trait::TypelessColumn => {
+            let mut resolved = schema();
+            column_mut(&mut resolved, "typeless", "v").decl_type = Some(ColumnType::Text);
+            let mut promoted = schema();
+            column_mut(&mut promoted, "typeless", "v").decl_type = Some(ColumnType::Blob);
+            vec![
+                Break::schema(
+                    "the blank type, resolved to TEXT -- which converts both values and destroys \
+                     the dynamic typing",
+                    resolved,
+                ),
+                // smugglr#344's promotion. Everything behavioural about it is
+                // identical on this path: BLOB affinity converts nothing, so
+                // typeof() still reads text and integer. Only the declared type
+                // gives it away, which is why this probe reads one.
+                Break::schema(
+                    "the blank type, promoted to BLOB -- invisible to every behavioural assertion \
+                     here",
+                    promoted,
+                ),
+            ]
+        }
+
+        Trait::Trigger => {
+            let mut no_trigger = schema();
+            table_mut(&mut no_trigger, "evented").triggers.clear();
+            vec![
+                Break::schema("the trigger, dropped with the table it hung off", no_trigger),
+                // The schema is untouched and correct. What is broken is the
+                // order a rebuild did things in: re-creating the trigger before
+                // copying the rows in makes the copy re-fire it over rows that
+                // had already been audited. smugglr#336's ["before", "after"].
+                Break::schema("nothing in the schema -- a rebuild re-fired the trigger over the rows it copied", schema())
+                    .then(&[
+                        "DROP TRIGGER \"evented_audit\";
+                         CREATE TABLE \"evented_new\" (\"id\" INTEGER PRIMARY KEY, \"note\" TEXT);
+                         CREATE TRIGGER \"evented_audit\" AFTER INSERT ON \"evented_new\"
+                         FOR EACH ROW BEGIN
+                           INSERT INTO \"audit\" (\"note\") VALUES (new.\"note\");
+                         END;
+                         INSERT INTO \"evented_new\" SELECT * FROM \"evented\";
+                         DROP TABLE \"evented\";
+                         ALTER TABLE \"evented_new\" RENAME TO \"evented\";",
+                    ]),
+            ]
+        }
+
+        Trait::DescendingPrimaryKey => {
+            let mut ascending = schema();
+            for constraint in &mut column_mut(&mut ascending, "descending_key", "id").constraints {
+                if let ColumnConstraint::PrimaryKey { order, .. } = constraint {
+                    *order = SortOrder::Asc;
+                }
+            }
+            vec![Break::schema(
+                "DESC on the key, making it the ascending spelling -- which is the rowid alias",
+                ascending,
+            )]
+        }
+    }
+}
+
+// --- model surgery, so the breaks read as the edits they are ----------------
+
+fn table_mut<'a>(schema: &'a mut Schema, name: &str) -> &'a mut smugglr_forger::schema::Table {
+    schema
+        .tables
+        .iter_mut()
+        .find(|table| table.name == name)
+        .unwrap_or_else(|| panic!("the case schema has a table called {name}"))
+}
+
+fn column_mut<'a>(schema: &'a mut Schema, table: &str, column: &str) -> &'a mut Column {
+    table_mut(schema, table)
+        .columns
+        .iter_mut()
+        .find(|c| c.name == column)
+        .unwrap_or_else(|| panic!("the case schema has a column called {table}.{column}"))
+}
+
+fn foreign_key_mut<'a>(
+    schema: &'a mut Schema,
+    table: &str,
+) -> &'a mut smugglr_forger::schema::ForeignKey {
+    table_mut(schema, table)
+        .constraints
+        .iter_mut()
+        .find_map(|constraint| match constraint {
+            TableConstraint::ForeignKey(fk) => Some(fk),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("{table} declares a foreign key"))
+}
+
+fn drop_generated(schema: &mut Schema, table: &str, column: &str) {
+    column_mut(schema, table, column)
+        .constraints
+        .retain(|c| !matches!(c, ColumnConstraint::Generated { .. }));
+}
+
+fn drop_conflict(schema: &mut Schema, table: &str, column: &str) {
+    set_conflict_slot(schema, table, column, None);
+}
+
+fn set_conflict(schema: &mut Schema, table: &str, column: &str, algorithm: OnConflict) {
+    set_conflict_slot(schema, table, column, Some(algorithm));
+}
+
+fn set_conflict_slot(
+    schema: &mut Schema,
+    table: &str,
+    column: &str,
+    algorithm: Option<OnConflict>,
+) {
+    for constraint in &mut column_mut(schema, table, column).constraints {
+        if let ColumnConstraint::NotNull(slot) | ColumnConstraint::Unique(slot) = constraint {
+            *slot = algorithm;
+        }
+    }
+}
+
+fn set_default(schema: &mut Schema, table: &str, column: &str, value: DefaultValue) {
+    for constraint in &mut column_mut(schema, table, column).constraints {
+        if let ColumnConstraint::Default(slot) = constraint {
+            *slot = value.clone();
+        }
+    }
+}


### PR DESCRIPTION
Closes #354. Closes #356. They land together because exhaustive dispatch does not compile until every probe exists -- the registry and its contents are one change by construction, which is the point of FR-FORGER-003.

Eight traits, each with a seed and a behavioural probe, plus seventeen deliberate breaks proving every probe fails when the thing it guards is removed.

## Acceptance criteria mapping

### Adding a Trait variant without extending the seed and probe matches fails to compile, and the error names the variant

`TraitCase { kind, schema, seed, probe }` with non-optional fields, built by one exhaustive match in `registry/mod.rs:95`. Three separate matches (schema, seed, probe) were rejected deliberately: that shape lets a case exist half-finished across three sittings, which is the exact gap this requirement closes.

Evidence: a ninth variant was added and the build run. `error[E0004]: non-exhaustive patterns: schema::Trait::PartialIndex not covered`, pointing at `registry/mod.rs:96`.

Worth a reviewer's attention: rustc's own `help` suggests adding a wildcard arm or `todo!()`, **both of which this requirement forbids.** The compiler's advice is actively wrong for this match, and anyone extending it will be told to do the prohibited thing by the tool.

### No catch-all arm exists in seed or probe dispatch

There is one dispatch rather than two, and it carries no wildcard arm. The structural choice matters more than the absence of a `_` pattern: because `TraitCase` bundles schema, seed and probe into one non-optional value returned by one match, there is no place for a partial arm to hide. A design with separate schema, seed and probe matches could satisfy "no catch-all" in each while still letting a trait exist with two of the three filled in, which is the failure this requirement is actually guarding against.

Evidence: the `E0004` failure above is itself the proof -- a wildcard arm would have made that build succeed rather than error, so the compile failure demonstrates the absence more strongly than inspection could. `registry/mod.rs:95` is the single match; `registry/cases.rs` holds the eight arms' bodies, one function per trait, so an arm cannot quietly become a shared fallback.

### Each trait's seed puts the database into a state where the trait's behaviour is observable

Seeds take only `&Connection`; probes take `&Schema, &Connection` and resolve their target *from the schema* -- the generated column, the `DESC` key, the child whose foreign key declares CASCADE -- refusing if it is absent. That asymmetry is what makes the non-vacuity suite possible: a probe can be handed the *promised* schema against a *broken* database.

Evidence, one line each: CASCADE seeds two parents with children under both CASCADE and RESTRICT; GeneratedStored seeds base 5, expects 15, then moves the base to 7 and expects 21; ColumnOnConflict seeds a row in each of four tables, one per algorithm; TypelessColumn seeds `'a string'` and `42` into the same column; Trigger seeds one row before so the probe can assert exactly `["before","after"]`.

### A probe run against an unseeded database fails or is refused rather than passing vacuously

Every probe refuses with `ProbeError::Unseeded`, checked **per table rather than per case**. That granularity is not fussiness: two of the four `ON CONFLICT` halves are genuinely green on an empty database -- a NOT NULL violation throws with no prior row, and an insert into an empty table leaves exactly the one row REPLACE promises. A per-case check would have passed both.

### The seed leaves something checkable on the far side of a transformation

Partially satisfied and stated as such rather than claimed. The seeds are built to survive and be compared afterwards, but no transformation runs in this PR, so the criterion's DROP COLUMN framing is not exercised. It is exercised by #355, where a transformation first appears.

Evidence that the seeds carry checkable state across a change: `tests/probes_are_non_vacuous.rs` re-renders each case's schema in a modified form and runs the *unmodified* probe against it -- which is structurally the same demand the criterion makes, with a re-render standing in for a transformation. GeneratedStored's probe moves the base from 5 to 7 and reads the stored column afterwards; Trigger's asserts the audit table holds exactly `["before","after"]`, one row seeded before and one inserted after; TypelessColumn's reads two differently-typed rows back. Each of those is a value that survives an operation and is compared on the far side.

## Not done

- **The differential oracle (#355), execution accounting (#357), failure formatting (#358), fixture serialization (#361).** Absent, not stubbed.
- **No dependency on smugglr.** `scripts/check-forger-boundary.py` still passes; forger names no smugglr crate.
- **`Trait::ALL` is not compiler-enforced.** A variant omitted from that array compiles and is silently skipped by both integration tests. Exposure is bounded -- it cannot ship un-probed, because `for_trait` and the break table still fail to compile -- and the doc says plainly that the array is scaffolding rather than the guarantee. Flagged rather than hidden.

## Seventeen breaks, and what the probes actually said

Each break re-renders the case's own schema with the trait stripped or swapped, stands the fixture up through `Route::Ddl`, and runs the unmodified probe. A selection:

- **CASCADE dropped** -- `deleting keeper.id = 1 was refused (FOREIGN KEY constraint failed) ... which leaves NO ACTION`
- **STORED made ordinary and back-filled** -- `still reads Some(15) after its base moved to 7 ... the value was copied but the computation was not`
- **`DEFAULT (…)` parentheses dropped** -- `2 row(s) ... hold the text "datetime('now')", which is the source of their own DEFAULT`
- **ROLLBACK downgraded to plain NOT NULL** -- `the transaction ... was still open afterwards; that is ABORT's behaviour`
- **Trigger re-fired by a rebuild** (schema untouched, only the rebuild's statement order changed) -- `audit holds ["before", "before", "after"]`
- **`DESC` made ascending** -- `2 row(s) of descending_key.id equal their own rowid; that is the ascending spelling, which is the rowid alias`

The break table is itself a second exhaustive match over `Trait`, so a new variant cannot ship without someone writing down how to break it and watching the probe notice.

**The strongest single result: typeless promoted to `BLOB` fired the PRAGMA assertion and nothing else.** The behavioural assertion passed cleanly. That is the empirical justification for the one PRAGMA exception in this PR -- smugglr#344's promotion is invisible behaviourally on the native path and shows only in the declared type. The exception was granted on reasoning; it is now supported by a measurement.

## Four findings

**RESTRICT is behaviourally indistinguishable from a dropped action on this path.** Measured: with foreign keys enforced and constraints immediate, both `RESTRICT` and no action refuse the delete. The discriminator is `DEFERRABLE INITIALLY DEFERRED` -- RESTRICT still fires immediately while NO ACTION waits for commit -- and **the schema model has no `deferrable` field.** A model gap rather than a probe flaw, and the reason that break had to drop the whole key.

**`ON CONFLICT ABORT` is SQLite's default**, so removing the clause yields a behaviourally identical table. Its break is a swap to IGNORE rather than a removal, commented as the different kind of break it is.

**FR-FORGER-004's REPLACE wording is ambiguous and covers two mechanisms.** "A NULL in one specific column and a row already occupying that key" reads as one scenario. REPLACE was implemented as a UNIQUE-key conflict; the NULL went to the IGNORE/ABORT/ROLLBACK halves. The other reading -- `NOT NULL ... ON CONFLICT REPLACE`, where SQLite substitutes the column default and falls back to ABORT when there is none -- is a genuinely different mechanism and is uncovered. Worth a decision.

**Short-circuited secondary assertions.** Both original ExpressionDefault breaks tripped the same first assertion, so the GLOB and typeof guards were never observed failing. Two further breaks were added that turn the expression into a *different but still-evaluating* one -- `date('now')` and `'2' || '+' || '3'` -- so each secondary assertion now fails alone. The same pattern exists more weakly elsewhere and is named rather than silently accepted.

## Measured, not assumed

`PRAGMA foreign_keys` reads **1** in autocommit on a fresh `Fixture` connection (rusqlite 0.34, bundled SQLite 3.49.1) -- unlike the `sqlite3` shell, where it defaults off. Probes set no pragmas. The cascade probe reads the value in autocommit before asserting and refuses when enforcement is off, because a DELETE whose children survive for lack of enforcement is indistinguishable at the row counts from a CASCADE reconstructed without its action. The RESTRICT half asserts the end state -- parent present, child intact -- rather than which statement raised, so it reports on the referential action rather than on the transaction shape it happens to run in.

## Commit scope note

legion's commit validator rejects a two-issue subject, so the commit reads `feat(#354)`. Both `Closes #354` and `Closes #356` are in this body, so #356 closes on merge.