### PR TITLE
feat(#361): forger -- a failing case becomes a checked-in regression fixture

### DIFF
--- a/crates/smugglr-forger/Cargo.toml
+++ b/crates/smugglr-forger/Cargo.toml
@@ -27,13 +27,21 @@ rusqlite = { version = "0.34", features = ["bundled"] }
 # now and the file format costs nothing later.
 serde = { version = "1", features = ["derive"] }
 
+# Reading and writing committed regression fixtures is part of the library
+# rather than of its tests: the corpus runner is one caller of it, and a
+# consumer that records its own failing schema is another.
+serde_json = "1"
+
 # File-backed fixtures. The TempDir is owned by the fixture so removal cannot
 # outrun the connection close.
 tempfile = "3"
 
 thiserror = "2"
 
-[dev-dependencies]
-# Proves the model round-trips through a real serde format. Not needed to build
-# the crate -- reading and writing fixture files is FR-FORGER-009.
-serde_json = "1"
+[[test]]
+# The corpus runner brings its own main. It has to report the corpus size and
+# the time it took on every run, and libtest captures the output of a passing
+# test -- a report that only appears under `--nocapture` is a report nobody
+# reads, which is the whole thing this reporting exists to prevent.
+name = "corpus_runs"
+harness = false

--- a/crates/smugglr-forger/src/corpus.rs
+++ b/crates/smugglr-forger/src/corpus.rs
@@ -1,0 +1,305 @@
+//! Pinning a failure to disk, so a defect found once is checked thereafter.
+//!
+//! A defect found by hand is a story about a run nobody else can reproduce
+//! until the schema that produced it is written down. [`Regression`] is that
+//! writing-down: the schema as the transformation left it, the trait it was
+//! supposed to carry, and the failure its probe reported, in one JSON file
+//! that the ordinary test suite picks up because it is in the corpus
+//! directory. FR-FORGER-009.
+//!
+//! # Why JSON here when the authoring format is a builder
+//!
+//! A fixture is machine-written and machine-read. It is produced by
+//! serializing a value that already failed, and consumed by a runner that
+//! stands it back up -- no human types one from scratch, and the invariant
+//! enforcement and completion that make
+//! [`builder`](crate::schema::builder) worth its weight buy nothing on a
+//! path where the schema is copied rather than composed. The builder stays
+//! the authoring format for the same reason: it is human-written and needs
+//! both. One format doing both jobs is where this gets bad.
+//!
+//! It follows that the fixture carries its prose in a field. A JSONC comment
+//! would need a parser that keeps comments to survive being rewritten, and a
+//! comment cannot be queried -- so [`Regression::provenance`] is data, is
+//! required, and is refused empty. A fixture that cannot say what it is has
+//! lost the only part of it a person reads.
+//!
+//! # Why the recorded schema is stood up as DDL
+//!
+//! [`Route::Ddl`], never [`Route::Schema`]. What is recorded is what some
+//! transformation *produced*, and a transformation that mangled a schema is
+//! under no obligation to have produced one forger's own grammar would
+//! accept. Validating it on the way in would refuse exactly the worst
+//! defects -- the ones that leave a schema forger can see is wrong. The
+//! promise, unbroken, comes from the registry instead: the probe is handed
+//! [`TraitCase::schema`] and asked whether the database in front of it
+//! behaves that way. That asymmetry is the same one
+//! `tests/probes_are_non_vacuous.rs` documents.
+//!
+//! # Why the expected failure is matched exactly
+//!
+//! A substring match admits the empty string, and a fixture that matches
+//! every failure is green on a defect it was never about. There is no
+//! threshold between "some of the message" and "a matcher that asserts
+//! nothing" that is not arbitrary, so the match is equality and the field is
+//! refused empty. The cost is real and worth naming: when FR-FORGER-008
+//! reformats what a probe says, every fixture recording that message has to
+//! be re-recorded. Re-recording is mechanical; a matcher nobody can see
+//! through is not.
+//!
+//! # Why only a failure can be recorded
+//!
+//! [`Regression::run`] accepts one outcome: [`ProbeError::Failed`] carrying
+//! the recorded message. A pass means the defect is not reproducing and the
+//! fixture is measuring nothing; [`ProbeError::Unseeded`] means the probe
+//! could not have observed anything either way, which is not evidence of
+//! anything at all and must never be counted as the finding. Both are
+//! reported as the fixture failing, and the report says which happened.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::error::{ForgeError, ProbeError};
+use crate::fixture::{Backing, Fixture, Route};
+use crate::registry::TraitCase;
+use crate::schema::{Schema, Trait};
+
+/// The file extension a fixture is written with. Anything else in the corpus
+/// directory -- a README describing the format, an editor's leavings -- is
+/// not a fixture and is skipped rather than failed on.
+pub const FIXTURE_EXTENSION: &str = "json";
+
+/// A failure, written down.
+///
+/// Every field but [`after_seed`](Self::after_seed) is required, and the file
+/// is parsed with unknown fields refused: a fixture is hand-editable, and a
+/// misspelled key that parsed would leave a file testing something other than
+/// what it appears to.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Regression {
+    /// What this fixture is, in the words of whoever pinned it -- the issue it
+    /// reproduces, the run it was shrunk from, the defect shape it stands for.
+    /// Required, and refused empty: see the module docs.
+    pub provenance: String,
+
+    /// The trait the recorded schema was supposed to carry. It selects the
+    /// registry case that supplies the seed, the probe, and the unbroken
+    /// schema the probe is handed as the promise.
+    #[serde(rename = "trait")]
+    pub kind: Trait,
+
+    /// The schema as the transformation left it. Stood up as rendered DDL,
+    /// unvalidated -- see the module docs.
+    pub schema: Schema,
+
+    /// Statements run after the seed, for defects that live in what a rebuild
+    /// *did* rather than in what it declared. A rebuild that re-creates a
+    /// trigger before copying rows into the new table produces a schema
+    /// correct in every particular and a database that audited the same row
+    /// twice, and there is no schema edit that expresses it.
+    #[serde(default)]
+    pub after_seed: Vec<String>,
+
+    /// The probe's message, verbatim. Matched by equality, refused empty.
+    pub expected_failure: String,
+}
+
+impl Regression {
+    /// Serialize, pretty-printed and newline-terminated so a committed
+    /// fixture diffs by line rather than as one wall.
+    pub fn to_json(&self) -> String {
+        let mut json = serde_json::to_string_pretty(self)
+            // Every field is a plain owned value with a derived impl and no
+            // map keys but the struct's own, so there is nothing here that
+            // can fail to serialize.
+            .expect("a Regression serializes");
+        json.push('\n');
+        json
+    }
+
+    /// Parse one, refusing a fixture that could not assert anything.
+    ///
+    /// Both refusals are on the trimmed field: whitespace is not provenance
+    /// and no probe has ever reported a message made of spaces, so a fixture
+    /// carrying either is one whose author meant to fill it in.
+    pub fn from_json(json: &str) -> Result<Self, CorpusError> {
+        let regression: Regression = serde_json::from_str(json).map_err(CorpusError::Parse)?;
+        if regression.provenance.trim().is_empty() {
+            return Err(CorpusError::NoProvenance);
+        }
+        if regression.expected_failure.trim().is_empty() {
+            return Err(CorpusError::NoExpectedFailure);
+        }
+        Ok(regression)
+    }
+
+    /// Read one from disk.
+    pub fn load(path: &Path) -> Result<Self, CorpusError> {
+        let json = fs::read_to_string(path).map_err(CorpusError::Read)?;
+        Regression::from_json(&json)
+    }
+
+    /// Stand the recorded schema up in memory, seed it, and require the probe
+    /// to report the recorded failure.
+    ///
+    /// [`Backing::Memory`], because a fixture that has to reach the filesystem
+    /// to reproduce is not something the recorded fields can express, and a
+    /// corpus running on files would pay for a temp directory per fixture at
+    /// exactly the size where the runtime report starts to matter.
+    ///
+    /// Ok means the defect still reproduces, which is what a regression
+    /// fixture is for. Every other outcome is an error naming what happened
+    /// instead -- including the probe passing, which means the fixture has
+    /// stopped being about anything.
+    pub fn run(&self) -> Result<(), CorpusError> {
+        let case = TraitCase::for_trait(self.kind);
+
+        let mut fixture = Fixture::new(Backing::Memory)?;
+        fixture.bring_to(Route::Ddl(&self.schema.to_ddl()))?;
+        case.seed(fixture.conn()).map_err(CorpusError::Seed)?;
+        for statement in &self.after_seed {
+            fixture
+                .conn()
+                .execute_batch(statement)
+                .map_err(|source| CorpusError::AfterSeed {
+                    statement: statement.clone(),
+                    source,
+                })?;
+        }
+
+        match case.probe(fixture.conn()) {
+            Err(ProbeError::Failed(reported)) if reported == self.expected_failure => Ok(()),
+            Err(ProbeError::Failed(reported)) => Err(CorpusError::DifferentFailure {
+                expected: self.expected_failure.clone(),
+                reported,
+            }),
+            Ok(()) => Err(CorpusError::NoFailure),
+            Err(other) => Err(CorpusError::NotAFinding(other)),
+        }
+    }
+}
+
+/// One fixture and the file it came from.
+pub struct Entry {
+    /// The file, for naming it in a report.
+    pub path: PathBuf,
+    pub regression: Regression,
+}
+
+impl Entry {
+    /// The filename, which is how a fixture is referred to in a report.
+    pub fn name(&self) -> String {
+        match self.path.file_name() {
+            Some(name) => name.to_string_lossy().into_owned(),
+            None => self.path.display().to_string(),
+        }
+    }
+}
+
+/// Every fixture in a directory, sorted by filename.
+///
+/// Sorted because `read_dir` hands them back in whatever order the filesystem
+/// keeps, and a report whose lines move between machines is one nobody can
+/// diff. Files that are not `.json` are skipped, so the directory can hold a
+/// README about the format; a `.json` that does not parse is an error, never
+/// a skip.
+pub fn load_dir(dir: &Path) -> Result<Vec<Entry>, AtPath> {
+    let at_dir = |source| AtPath {
+        path: dir.to_path_buf(),
+        error: CorpusError::Read(source),
+    };
+
+    let mut paths = Vec::new();
+    for entry in fs::read_dir(dir).map_err(at_dir)? {
+        let path = entry.map_err(at_dir)?.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some(FIXTURE_EXTENSION) {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+
+    paths
+        .into_iter()
+        .map(|path| match Regression::load(&path) {
+            Ok(regression) => Ok(Entry { path, regression }),
+            Err(error) => Err(AtPath { path, error }),
+        })
+        .collect()
+}
+
+/// A corpus error with the file it happened to.
+///
+/// Kept separate from [`CorpusError`] rather than threading a path through
+/// every variant: [`Regression::from_json`] and [`Regression::run`] have no
+/// file to name, and a path field that is sometimes meaningless is a field
+/// every caller has to reason about.
+#[derive(Debug, Error)]
+#[error("{}: {error}", .path.display())]
+pub struct AtPath {
+    pub path: PathBuf,
+    #[source]
+    pub error: CorpusError,
+}
+
+/// What can go wrong reading or running a committed fixture.
+///
+/// This lives here rather than in [`error`](crate::error) because it is about
+/// files on disk, which the other three error types deliberately know nothing
+/// about: [`ValidationError`](crate::error::ValidationError) is a statement
+/// about a schema, [`ForgeError`] about a run, [`ProbeError`] about what a
+/// database did. A fixture that will not parse is none of those.
+#[derive(Debug, Error)]
+pub enum CorpusError {
+    #[error("reading the fixture: {0}")]
+    Read(#[source] std::io::Error),
+
+    #[error("the fixture is not the JSON a Regression parses from: {0}")]
+    Parse(#[source] serde_json::Error),
+
+    #[error(
+        "the fixture records no provenance, so nothing in it says what defect it stands for \
+         or where it came from"
+    )]
+    NoProvenance,
+
+    #[error(
+        "the fixture records no expected failure, so it would be satisfied by any failure \
+         at all and is a guard against nothing"
+    )]
+    NoExpectedFailure,
+
+    #[error("standing the recorded schema up: {0}")]
+    Forge(#[from] ForgeError),
+
+    #[error("seeding the recorded schema: {0}")]
+    Seed(#[source] ProbeError),
+
+    #[error("running a post-seed statement ({statement}): {source}")]
+    AfterSeed {
+        statement: String,
+        #[source]
+        source: rusqlite::Error,
+    },
+
+    #[error(
+        "the probe reported a different failure.\n    recorded: {expected}\n    reported: {reported}"
+    )]
+    DifferentFailure { expected: String, reported: String },
+
+    #[error(
+        "the probe passed, so the defect this fixture pins is no longer reproducing -- either \
+         it was fixed, in which case say so and remove the fixture, or the fixture has stopped \
+         being about it"
+    )]
+    NoFailure,
+
+    #[error(
+        "the probe reported no finding either way ({0}), so this fixture reproduced nothing -- \
+         a probe that could not observe its subject is not evidence about it"
+    )]
+    NotAFinding(#[source] ProbeError),
+}

--- a/crates/smugglr-forger/src/lib.rs
+++ b/crates/smugglr-forger/src/lib.rs
@@ -25,6 +25,8 @@
 //!   connection, tear it down reliably including on panic.
 //! * [`registry`] -- one [`Trait`], one schema carrying it, one seed and one
 //!   probe, matched exhaustively so a trait without a probe does not compile.
+//! * [`corpus`] -- a failure written down as JSON and committed, so a defect
+//!   found once runs thereafter as an ordinary test input.
 //!
 //! ```
 //! use smugglr_forger::fixture::{Backing, Fixture, Route};
@@ -45,11 +47,13 @@
 //! fixture.bring_to(Route::Schema(&target)).unwrap();
 //! ```
 
+pub mod corpus;
 pub mod error;
 pub mod fixture;
 pub mod registry;
 pub mod schema;
 
+pub use corpus::Regression;
 pub use error::{BoxError, ForgeError, ProbeError, ValidationError};
 pub use fixture::{Backing, Fixture, Route};
 pub use registry::TraitCase;

--- a/crates/smugglr-forger/tests/a_failure_survives_the_round_trip.rs
+++ b/crates/smugglr-forger/tests/a_failure_survives_the_round_trip.rs
@@ -1,0 +1,194 @@
+//! Break a schema, watch a probe fail, send it through JSON, and require the
+//! same failure out the other side.
+//!
+//! # Why equality is not the test
+//!
+//! A schema that serializes and deserializes to something equal is necessary
+//! and nowhere near sufficient. What a regression fixture promises is that the
+//! *failure* survives -- and a schema can compare equal while the thing that
+//! reproduces the defect lives somewhere the fixture never carried: in the
+//! statements a rebuild ran, in the trait whose probe is supposed to look at
+//! it, in the message that says which of a probe's several assertions fired.
+//! So the round trip here is measured at the far end, by running the
+//! deserialized fixture and comparing what its probe said to what the live
+//! one said. The equality assertion is kept as well, one test down, because
+//! when both fail together the narrower one says where.
+//!
+//! # The failure being reproduced
+//!
+//! smugglr#341's shape: a rebuild reads five of the eight columns
+//! `pragma foreign_key_list` hands it, and the referential action is in one of
+//! the three it does not, so `ON DELETE CASCADE` comes back as the `NO ACTION`
+//! default. Nothing about it is visible at the row counts on the day of the
+//! migration -- the children are still there, which is exactly what a rebuild
+//! that kept them would look like.
+
+use smugglr_forger::corpus::{CorpusError, Regression};
+use smugglr_forger::error::ProbeError;
+use smugglr_forger::fixture::{Backing, Fixture, Route};
+use smugglr_forger::registry::TraitCase;
+use smugglr_forger::schema::{Schema, TableConstraint, Trait};
+
+/// The registry case's schema with `ON DELETE CASCADE` taken off the cascading
+/// child -- what the rebuild in smugglr#341 produced.
+fn cascade_lost() -> Schema {
+    let mut schema = TraitCase::for_trait(Trait::ForeignKeyWithAction).schema;
+    let foreign_key = schema
+        .tables
+        .iter_mut()
+        .find(|table| table.name == "cascade_child")
+        .expect("the case schema has a cascade_child table")
+        .constraints
+        .iter_mut()
+        .find_map(|constraint| match constraint {
+            TableConstraint::ForeignKey(fk) => Some(fk),
+            _ => None,
+        })
+        .expect("cascade_child declares a foreign key");
+    foreign_key.on_delete = None;
+    schema
+}
+
+/// Run the broken schema the way `tests/probes_are_non_vacuous.rs` does, with
+/// nothing serialized anywhere, and return what the probe said.
+fn live_failure(schema: &Schema, kind: Trait) -> String {
+    let case = TraitCase::for_trait(kind);
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    fixture
+        .bring_to(Route::Ddl(&schema.to_ddl()))
+        .expect("the broken schema still renders DDL SQLite accepts");
+    case.seed(fixture.conn()).expect("seed");
+    match case.probe(fixture.conn()) {
+        Err(ProbeError::Failed(message)) => message,
+        other => panic!("the break did not make the probe fail; it said {other:?}"),
+    }
+}
+
+fn recorded(schema: Schema, kind: Trait, failure: String) -> Regression {
+    Regression {
+        provenance: "the round-trip test's own fixture, built in memory".into(),
+        kind,
+        schema,
+        after_seed: Vec::new(),
+        expected_failure: failure,
+    }
+}
+
+#[test]
+fn a_failure_recorded_as_json_reproduces_itself_when_read_back() {
+    let schema = cascade_lost();
+    let failure = live_failure(&schema, Trait::ForeignKeyWithAction);
+    assert!(
+        !failure.is_empty(),
+        "a probe that fails with an empty message records nothing"
+    );
+
+    let json = recorded(schema, Trait::ForeignKeyWithAction, failure.clone()).to_json();
+    let read_back = Regression::from_json(&json).expect("the fixture parses");
+
+    // The whole requirement: not that the value survived, but that running
+    // what came back out reproduces the failure that went in. `run` accepts
+    // only a `ProbeError::Failed` whose message matches, so this passing is
+    // the message having survived byte for byte.
+    read_back
+        .run()
+        .unwrap_or_else(|error| panic!("the recorded failure did not reproduce: {error}"));
+    assert_eq!(read_back.expected_failure, failure);
+}
+
+#[test]
+fn the_schema_itself_survives_the_round_trip() {
+    let schema = cascade_lost();
+    let fixture = recorded(schema.clone(), Trait::ForeignKeyWithAction, "any".into());
+    let read_back = Regression::from_json(&fixture.to_json()).expect("the fixture parses");
+
+    assert_eq!(read_back.schema, schema);
+    assert_eq!(read_back.schema.to_ddl(), schema.to_ddl());
+    assert_eq!(read_back, fixture);
+}
+
+#[test]
+fn a_fixture_whose_defect_stopped_reproducing_is_a_failure() {
+    // The unbroken case schema: the cascade is intact, so the probe passes and
+    // the fixture is no longer about anything. A corpus that reported this as
+    // green would keep a fixture that has quietly stopped asserting.
+    let intact = TraitCase::for_trait(Trait::ForeignKeyWithAction).schema;
+    let fixture = recorded(
+        intact,
+        Trait::ForeignKeyWithAction,
+        live_failure(&cascade_lost(), Trait::ForeignKeyWithAction),
+    );
+
+    assert!(matches!(fixture.run(), Err(CorpusError::NoFailure)));
+}
+
+#[test]
+fn a_fixture_reproducing_some_other_failure_is_a_failure() {
+    // Same break, same probe, a message from a different assertion. Running it
+    // has to notice, or the recorded message is decoration and every fixture
+    // in the corpus asserts only that something somewhere went wrong.
+    let fixture = recorded(
+        cascade_lost(),
+        Trait::ForeignKeyWithAction,
+        "some other thing the probe never said".into(),
+    );
+
+    match fixture.run() {
+        Err(CorpusError::DifferentFailure { reported, .. }) => {
+            assert_eq!(
+                reported,
+                live_failure(&cascade_lost(), Trait::ForeignKeyWithAction)
+            );
+        }
+        other => panic!("a mismatched message was not reported as one: {other:?}"),
+    }
+}
+
+#[test]
+fn a_probe_that_could_not_observe_anything_is_not_the_failure() {
+    // The trigger case, seeded and then emptied. The probe reports `Unseeded`
+    // rather than `Failed` -- and a fixture that accepted it would be a
+    // committed guard reproducing nothing at all, which is the one outcome
+    // that must never read as a finding.
+    let case = TraitCase::for_trait(Trait::Trigger);
+    let fixture = Regression {
+        provenance: "a trigger fixture whose rows never arrive".into(),
+        kind: Trait::Trigger,
+        schema: case.schema,
+        after_seed: vec!["DELETE FROM \"audit\"; DELETE FROM \"evented\";".into()],
+        expected_failure: "nothing to observe: the audit table is empty".into(),
+    };
+
+    assert!(matches!(fixture.run(), Err(CorpusError::NotAFinding(_))));
+}
+
+#[test]
+fn a_fixture_that_asserts_nothing_is_refused_at_the_door() {
+    let empty_message = recorded(cascade_lost(), Trait::ForeignKeyWithAction, String::new());
+    assert!(matches!(
+        Regression::from_json(&empty_message.to_json()),
+        Err(CorpusError::NoExpectedFailure)
+    ));
+
+    let mut anonymous = recorded(cascade_lost(), Trait::ForeignKeyWithAction, "said".into());
+    anonymous.provenance = "   ".into();
+    assert!(matches!(
+        Regression::from_json(&anonymous.to_json()),
+        Err(CorpusError::NoProvenance)
+    ));
+}
+
+#[test]
+fn a_misspelled_key_is_refused_rather_than_ignored() {
+    // A fixture is hand-editable. `after_seeds` silently ignored would leave a
+    // file that looks like it runs statements after the seed and does not, and
+    // the fixture would be testing something other than what it says.
+    let json = recorded(cascade_lost(), Trait::ForeignKeyWithAction, "said".into())
+        .to_json()
+        .replace("\"after_seed\"", "\"after_seeds\"");
+
+    assert!(matches!(
+        Regression::from_json(&json),
+        Err(CorpusError::Parse(_))
+    ));
+}

--- a/crates/smugglr-forger/tests/corpus/336-a-rebuild-refired-a-trigger-over-copied-rows.json
+++ b/crates/smugglr-forger/tests/corpus/336-a-rebuild-refired-a-trigger-over-copied-rows.json
@@ -1,0 +1,76 @@
+{
+  "provenance": "smugglr#336. A rebuild re-created the trigger before copying rows into the new table, so the INSERT ... SELECT re-fired it over rows that had already been audited. The schema is correct in every particular -- what is wrong is the order the rebuild did things in, which is why this fixture's break lives in after_seed and its schema is the unmodified case. Recorded 2026-08-14 from the Trigger case.",
+  "trait": "Trigger",
+  "schema": {
+    "tables": [
+      {
+        "name": "evented",
+        "columns": [
+          {
+            "name": "id",
+            "decl_type": "Integer",
+            "constraints": [
+              {
+                "PrimaryKey": {
+                  "order": "Asc",
+                  "autoincrement": false,
+                  "on_conflict": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "note",
+            "decl_type": "Text",
+            "constraints": []
+          }
+        ],
+        "constraints": [],
+        "without_rowid": false,
+        "strict": false,
+        "triggers": [
+          {
+            "name": "evented_audit",
+            "timing": "After",
+            "event": "Insert",
+            "when": null,
+            "body": [
+              "INSERT INTO \"audit\" (\"note\") VALUES (new.\"note\")"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "audit",
+        "columns": [
+          {
+            "name": "id",
+            "decl_type": "Integer",
+            "constraints": [
+              {
+                "PrimaryKey": {
+                  "order": "Asc",
+                  "autoincrement": false,
+                  "on_conflict": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "note",
+            "decl_type": "Text",
+            "constraints": []
+          }
+        ],
+        "constraints": [],
+        "without_rowid": false,
+        "strict": false,
+        "triggers": []
+      }
+    ]
+  },
+  "after_seed": [
+    "DROP TRIGGER \"evented_audit\";\nCREATE TABLE \"evented_new\" (\"id\" INTEGER PRIMARY KEY, \"note\" TEXT);\nCREATE TRIGGER \"evented_audit\" AFTER INSERT ON \"evented_new\"\nFOR EACH ROW BEGIN\n  INSERT INTO \"audit\" (\"note\") VALUES (new.\"note\");\nEND;\nINSERT INTO \"evented_new\" SELECT * FROM \"evented\";\nDROP TABLE \"evented\";\nALTER TABLE \"evented_new\" RENAME TO \"evented\";"
+  ],
+  "expected_failure": "audit holds [\"before\", \"before\", \"after\"] after one row was seeded and one inserted; the trigger's side effect is [\"before\", \"after\"]. Fewer means it did not fire -- a trigger can sit in sqlite_master and still never run. More means it fired over rows that had already been audited, which is what a rebuild's INSERT ... SELECT does when the trigger is re-created before the copy rather than after it"
+}

--- a/crates/smugglr-forger/tests/corpus/341-a-rebuild-dropped-on-delete-cascade.json
+++ b/crates/smugglr-forger/tests/corpus/341-a-rebuild-dropped-on-delete-cascade.json
@@ -1,0 +1,129 @@
+{
+  "provenance": "smugglr#341. A rebuild reads five of the eight columns pragma foreign_key_list hands it, and the referential action is in one of the three it does not, so ON DELETE CASCADE comes back as the NO ACTION default. Nothing about it shows at the row counts on the day of the migration: the children are still there, which is what a rebuild that kept them looks like. Recorded 2026-08-14 from the ForeignKeyWithAction case with the action dropped.",
+  "trait": "ForeignKeyWithAction",
+  "schema": {
+    "tables": [
+      {
+        "name": "keeper",
+        "columns": [
+          {
+            "name": "id",
+            "decl_type": "Integer",
+            "constraints": [
+              {
+                "PrimaryKey": {
+                  "order": "Asc",
+                  "autoincrement": false,
+                  "on_conflict": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "label",
+            "decl_type": "Text",
+            "constraints": []
+          }
+        ],
+        "constraints": [],
+        "without_rowid": false,
+        "strict": false,
+        "triggers": []
+      },
+      {
+        "name": "cascade_child",
+        "columns": [
+          {
+            "name": "id",
+            "decl_type": "Integer",
+            "constraints": [
+              {
+                "PrimaryKey": {
+                  "order": "Asc",
+                  "autoincrement": false,
+                  "on_conflict": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "keeper_id",
+            "decl_type": "Integer",
+            "constraints": []
+          },
+          {
+            "name": "label",
+            "decl_type": "Text",
+            "constraints": []
+          }
+        ],
+        "constraints": [
+          {
+            "ForeignKey": {
+              "columns": [
+                "keeper_id"
+              ],
+              "parent_table": "keeper",
+              "parent_columns": [
+                "id"
+              ],
+              "on_delete": null,
+              "on_update": null
+            }
+          }
+        ],
+        "without_rowid": false,
+        "strict": false,
+        "triggers": []
+      },
+      {
+        "name": "restrict_child",
+        "columns": [
+          {
+            "name": "id",
+            "decl_type": "Integer",
+            "constraints": [
+              {
+                "PrimaryKey": {
+                  "order": "Asc",
+                  "autoincrement": false,
+                  "on_conflict": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "keeper_id",
+            "decl_type": "Integer",
+            "constraints": []
+          },
+          {
+            "name": "label",
+            "decl_type": "Text",
+            "constraints": []
+          }
+        ],
+        "constraints": [
+          {
+            "ForeignKey": {
+              "columns": [
+                "keeper_id"
+              ],
+              "parent_table": "keeper",
+              "parent_columns": [
+                "id"
+              ],
+              "on_delete": "Restrict",
+              "on_update": null
+            }
+          }
+        ],
+        "without_rowid": false,
+        "strict": false,
+        "triggers": []
+      }
+    ]
+  },
+  "after_seed": [],
+  "expected_failure": "deleting keeper.id = 1 was refused (FOREIGN KEY constraint failed), and a child declared ON DELETE CASCADE does not refuse it -- the action was reconstructed as something else, or dropped, which leaves NO ACTION"
+}

--- a/crates/smugglr-forger/tests/corpus/README.md
+++ b/crates/smugglr-forger/tests/corpus/README.md
@@ -1,0 +1,63 @@
+# The regression corpus
+
+Every `.json` file in this directory is a failure somebody found, written down.
+`tests/corpus_runs.rs` walks the directory on every `cargo test`, stands each
+one back up, and requires the probe to report the same failure it reported the
+day it was pinned. Adding a fixture is dropping a file in here. There is no
+list to append to and no code to change, because the moment a fixture is worth
+committing is the moment somebody is mid-debug and has the least patience for
+either.
+
+Anything that is not a `.json` file -- this README, an editor's leavings -- is
+skipped. A `.json` file that does not parse is a failure, never a skip.
+
+## The fields
+
+| field | |
+| --- | --- |
+| `provenance` | What this is, in the words of whoever pinned it: the issue it reproduces, the run it was shrunk from, the defect shape it stands for. Required, and refused empty. It is a field rather than a comment so that it survives being rewritten and can be read by something other than a person. |
+| `trait` | A `Trait` variant. It selects the registry case that supplies the seed, the probe, and the unbroken schema the probe is handed as the promise. |
+| `schema` | The schema as the transformation left it. Stood up as rendered DDL and deliberately not validated -- what is recorded is what something *produced*, and a transformation that mangled a schema is under no obligation to have produced one forger's own grammar accepts. |
+| `after_seed` | Optional. Statements run after the seed, for defects that live in what a rebuild *did* rather than in what it declared. `336-a-rebuild-refired-a-trigger-over-copied-rows.json` is the shape: its schema is correct in every particular and its database audited the same row twice. |
+| `expected_failure` | The probe's message, verbatim. Matched by equality. |
+
+Unknown keys are refused. A file is hand-editable, and `after_seeds` silently
+ignored would leave one that looks like it runs statements after the seed and
+does not.
+
+## Writing one
+
+Do not type a fixture from scratch. Build the failing `Schema` in Rust, run it,
+take the message the probe actually reported, and serialize the whole thing:
+
+```rust
+let regression = Regression {
+    provenance: "smugglr#NNN. What went wrong, and where this came from.".into(),
+    kind: Trait::ForeignKeyWithAction,
+    schema: the_schema_that_failed,
+    after_seed: Vec::new(),
+    expected_failure: what_the_probe_said,
+};
+std::fs::write(path, regression.to_json())?;
+```
+
+`expected_failure` is matched exactly, which means that when FR-FORGER-008
+reformats what a probe says, every fixture recording that message has to be
+re-recorded. That is a real cost and it is the one worth paying: a substring
+match admits the empty string, and a fixture that matches every failure is
+green on a defect it was never about.
+
+## When a fixture stops failing
+
+The runner reports it, and the fixture is not simply deleted. Either the defect
+was fixed -- in which case say so in the commit and remove the fixture, since a
+guard against something that cannot happen is runtime nobody is buying anything
+with -- or the fixture has drifted off the thing it was about, which is a
+different problem and a worse one.
+
+## Size and runtime
+
+The runner prints the count and the total on every run. A corpus that only
+grows becomes a slow suite people skip locally and reviewers stop reading. The
+pruning policy is an open question and nothing here settles it; the number
+being visible before it bites is the minimum.

--- a/crates/smugglr-forger/tests/corpus_runs.rs
+++ b/crates/smugglr-forger/tests/corpus_runs.rs
@@ -1,0 +1,127 @@
+//! Run every committed fixture, and say how many there are and how long they
+//! took.
+//!
+//! # Why this target brings its own main
+//!
+//! `harness = false`. The corpus has to report its size and its runtime on
+//! every ordinary run, and libtest captures the output of a passing test --
+//! under the default harness the report would appear only under
+//! `--nocapture`, which is to say only when someone already suspected
+//! something. A corpus that only grows becomes a slow suite people skip
+//! locally and reviewers stop reading, and the report is what makes that
+//! visible before it bites.
+//!
+//! The cost is that this binary is responsible for its own exit status, which
+//! it takes seriously in three places: a fixture that fails, a corpus
+//! directory that cannot be read, and a corpus that is empty. The last one is
+//! the one worth naming -- a runner that finds no fixtures and prints "0
+//! fixtures" in green is a mechanism that has quietly become a no-op, and
+//! nothing about the output would tell anyone.
+//!
+//! Arguments are ignored rather than parsed. `cargo test -- --nocapture` and
+//! any `--skip` a CI job passes reach this binary too, and a runner that
+//! refused an argument it did not recognize would break the command that runs
+//! the suite.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+use smugglr_forger::corpus;
+
+/// The corpus, relative to the crate. From `CARGO_MANIFEST_DIR` rather than
+/// the working directory, which cargo sets to the workspace root for a
+/// workspace-wide run and to the crate for a crate-scoped one.
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/corpus")
+}
+
+fn main() -> ExitCode {
+    let dir = corpus_dir();
+    let fixtures = match corpus::load_dir(&dir) {
+        Ok(fixtures) => fixtures,
+        Err(error) => {
+            // Nothing ran, so there is no count and no total to print. A
+            // fixture that will not parse takes the whole corpus down rather
+            // than being skipped past: the file is there because somebody
+            // pinned a defect with it, and running the rest and reporting a
+            // clean two-of-three is how a guard goes missing quietly.
+            println!("forger corpus: could not be loaded, and nothing ran.\n  {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if fixtures.is_empty() {
+        println!(
+            "forger corpus: no fixtures in {} -- the corpus runner is asserting nothing.\n\
+             A defect that was pinned here and has gone missing takes its guard with it, so \
+             an empty corpus is a failure rather than a fast pass.",
+            dir.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    println!(
+        "forger corpus: {} fixtures in {}",
+        fixtures.len(),
+        dir.display()
+    );
+
+    // Widest name rather than a fixed column: a fixture's filename is prose
+    // and the next one is as long as it needs to be.
+    let width = fixtures
+        .iter()
+        .map(|entry| entry.name().chars().count())
+        .max()
+        .unwrap_or_default();
+
+    // The clock starts after the files are read: what this number is for is
+    // watching the cost of *running* the corpus grow, and parsing is bounded
+    // by the same count already printed above.
+    let mut failures = Vec::new();
+    let started = Instant::now();
+    for entry in &fixtures {
+        let at = Instant::now();
+        let outcome = entry.regression.run();
+        let took = at.elapsed();
+
+        let verdict = if outcome.is_ok() { "ok  " } else { "FAIL" };
+        println!(
+            "  {verdict} {name:<width$} {took:>8}  {kind:?}",
+            name = entry.name(),
+            took = millis(took),
+            kind = entry.regression.kind
+        );
+        if let Err(error) = outcome {
+            failures.push((entry, error));
+        }
+    }
+    let elapsed = started.elapsed();
+
+    for (entry, error) in &failures {
+        println!(
+            "\n{} does not reproduce.\n  provenance: {}\n  {error}",
+            entry.name(),
+            entry.regression.provenance
+        );
+    }
+
+    println!(
+        "\nforger corpus: {} fixtures, {} failing, {} total",
+        fixtures.len(),
+        failures.len(),
+        millis(elapsed)
+    );
+
+    if failures.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+/// Milliseconds to one decimal. Whole seconds would round every fixture to
+/// zero, which is the number the report exists to watch grow.
+fn millis(duration: Duration) -> String {
+    format!("{:.1}ms", duration.as_secs_f64() * 1000.0)
+}


### PR DESCRIPTION
Closes #361. Implements FR-FORGER-009.

A found defect becomes a permanent guard rather than a story about a run nobody can reproduce. Two real fixtures ship with it, both machine-written from live failing runs rather than hand-typed.

## Acceptance criteria mapping

### A failing Schema round-trips through JSON and reproduces the same failure

The requirement says *reproduces the same failure*, not *deserializes to an equal value*, and those are different tests. The headline test takes the `ForeignKeyWithAction` case schema, sets `on_delete = None` on the child (smugglr#341's shape), stands it up, seeds, runs the probe live and captures the message; then builds a `Regression` carrying that message, serializes, deserializes, and calls `run()`. `run()` accepts exactly one outcome -- `ProbeError::Failed` whose message equals the recorded one -- so the test passing *is* the failure having reproduced byte for byte. Value equality is asserted separately in a narrower test, kept so that when both fail the narrower one localises the cause.

`expected_failure` is matched by **equality, not substring**. A substring matcher admits the empty string, which is green against every failure, and there is no non-arbitrary line between "some of the message" and "asserts nothing". The cost is real and named in both the module docs and the corpus README: when #358 reformats probe output, every fixture quoting it must be re-recorded.

Evidence: `tests/a_failure_survives_the_round_trip.rs`, 7 tests. The reproduced failure reads `deleting keeper.id = 1 was refused (FOREIGN KEY constraint failed), and a child declared ON DELETE CASCADE does not refuse it -- the action was reconstructed as something else, or dropped, which leaves NO ACTION`. Four further tests pin what `run()` must refuse: a probe that passed (`NoFailure` -- the fixture has stopped being about anything), one that failed differently (`DifferentFailure`, proving the recorded message is not decoration), one that could not observe anything (`NotAFinding`, wrapping `ProbeError::Unseeded`, so an unseeded probe never reads as the finding), and empty `provenance`/`expected_failure` refused at parse.

### Committed fixtures run as part of the ordinary suite with no special invocation

`corpus::load_dir` reads `tests/corpus/`, keeps `.json` only so the README can live beside the fixtures, and sorts by path -- `read_dir` order is filesystem-dependent and an unsorted report is undiffable. The directory path comes from `env!("CARGO_MANIFEST_DIR")` rather than CWD, because cargo sets CWD to the workspace root for a workspace-wide run. Adding a fixture is dropping a file in: no code change, no list to append to, which matters because the friction would otherwise land at exactly the moment someone is mid-debug.

A `.json` that will not parse takes the whole run down rather than being skipped. The file is there because somebody pinned a defect with it, and reporting a clean two-of-three is how a guard goes missing quietly.

Evidence: `tests/corpus_runs.rs` runs under a plain `cargo test --workspace` with no flags; verbatim output is in the section below. The README sitting in the corpus directory while the runner reports two fixtures rather than three is itself the proof that the extension filter works.

### Corpus size and total runtime are reported, so growth is visible before it becomes a problem

Reported per fixture as well as in total, so growth can be attributed to a file rather than only observed in aggregate. The runner is `harness = false` -- **the first `[[test]]` block and the first `harness = false` target anywhere in this workspace**, so a reviewer should look at it rather than assume an established pattern. The reason is specific: libtest captures the output of a *passing* test, so under the default harness this report would appear only under `--nocapture`, meaning only when someone already suspected something. Verified empirically both ways.

Evidence, verbatim from an unmodified `cargo test --workspace`:

```
forger corpus: 2 fixtures in .../crates/smugglr-forger/tests/corpus
  ok   336-a-rebuild-refired-a-trigger-over-copied-rows.json    0.6ms  Trigger
  ok   341-a-rebuild-dropped-on-delete-cascade.json             0.2ms  ForeignKeyWithAction

forger corpus: 2 fixtures, 0 failing, 0.9ms total
```

Three exit-1 paths, each verified by running it rather than reasoning about it: a failing fixture prints `FAIL` with the provenance and both messages; a corpus that will not load names the file and runs nothing; and **an empty corpus exits 1**, because a runner that finds no fixtures and prints a green zero is a mechanism that has quietly become a no-op. That last one is FR-FORGER-007's lesson applied before #357 exists to require it.

## Not done

- **The pruning policy remains open**, deliberately. This makes growth visible; it does not decide what to do about it.
- **No dependency on smugglr.** `scripts/check-forger-boundary.py` passes.
- `registry/` and `fixture.rs` untouched, per the collision note with #355 which is in flight on the same crate.

## One design choice worth a reviewer's attention

A recorded schema is stood up through `Route::Ddl(&schema.to_ddl())`, never `Route::Schema`. What a fixture records is what a transformation *produced*, and a transformation that mangled a schema is under no obligation to have produced one forger's own grammar accepts. Validating on the way in would refuse exactly the worst defects. The unbroken schema the probe is handed as its promise comes from the registry instead -- the same asymmetry `probes_are_non_vacuous.rs` already documents.

## The two seed fixtures

Both were serialized from a live failing run, not written by hand.

- `341-a-rebuild-dropped-on-delete-cascade.json` -- the rebuild reads five of the eight columns `pragma foreign_key_list` returns, and the referential action is in one of the three it does not, so `ON DELETE CASCADE` comes back as the `NO ACTION` default. Nothing shows at the row counts on the day of the migration.
- `336-a-rebuild-refired-a-trigger-over-copied-rows.json` -- the rebuild re-created the trigger before copying rows, so the `INSERT ... SELECT` re-fired it over rows already audited. The schema is correct in every particular; the entire defect lives in `after_seed`, which is what exercises that field end to end where 341 leaves it empty.

## Defect found, reported not fixed

**`deny_unknown_fields` guards the envelope only.** `Regression` refuses unknown keys, but `Table`, `Column`, `Trigger`, `ForeignKey`, `IndexedColumn` and the rest in `schema/mod.rs` do not. A hand-edited fixture writing `"trigger"` for `"triggers"`, or `"decl_types"` for `"decl_type"`, parses cleanly and silently drops the field -- leaving a committed fixture that tests something other than what it reads as, which is exactly what a regression corpus cannot afford.

`a_misspelled_key_is_refused_rather_than_ignored` proves the envelope is guarded and, by contrast, marks precisely what is not. The fix is roughly twelve `#[serde(deny_unknown_fields)]` attributes in `schema/mod.rs` -- outside this PR's stated scope and in a file #355 may be touching. Filed separately.

## Sequencing note

The `Cargo.toml` change -- `serde_json` promoted from dev-dependencies to dependencies, since a persistence layer is library surface rather than test-only, plus the new `[[test]]` block -- is the one place this branch can conflict with #355 on the same crate.