### PR TITLE
feat(#355): forger -- the differential oracle, compared behaviourally against a schema the implementation did not build

### DIFF
--- a/crates/smugglr-forger/src/lib.rs
+++ b/crates/smugglr-forger/src/lib.rs
@@ -25,6 +25,9 @@
 //!   connection, tear it down reliably including on panic.
 //! * [`registry`] -- one [`Trait`], one schema carrying it, one seed and one
 //!   probe, matched exhaustively so a trait without a probe does not compile.
+//! * [`oracle`] -- the differential comparison: seed and transform one arm,
+//!   build the other from scratch, hold both to the same promise and report
+//!   where they part company.
 //!
 //! ```
 //! use smugglr_forger::fixture::{Backing, Fixture, Route};
@@ -47,10 +50,12 @@
 
 pub mod error;
 pub mod fixture;
+pub mod oracle;
 pub mod registry;
 pub mod schema;
 
 pub use error::{BoxError, ForgeError, ProbeError, ValidationError};
 pub use fixture::{Backing, Fixture, Route};
+pub use oracle::{differential, Arm, Divergence, Outcome, Report, TraitOutcome};
 pub use registry::TraitCase;
 pub use schema::{Schema, Trait};

--- a/crates/smugglr-forger/src/oracle.rs
+++ b/crates/smugglr-forger/src/oracle.rs
@@ -1,0 +1,394 @@
+//! The differential oracle: hold a transformed database and a from-scratch one
+//! to the same promise, and report where they part company.
+//!
+//! [`differential`] stands up two arms. One starts from the caller's *start*
+//! schema, is seeded, and then has the caller's transformation run over it. The
+//! other is built from the caller's *target* schema by plain DDL and seeded the
+//! same way. Both are then held to the same promise -- the target schema -- and
+//! asked the same questions, in the same order, by the registry's probes.
+//! Anything the two arms answer differently is a divergence.
+//!
+//! The value is in who wrote the second arm. A check written from the same
+//! premises as the transformation reproduces the transformation's blind spots;
+//! a `CREATE TABLE` SQLite executed from a schema nobody transformed does not.
+//! FR-FORGER-005.
+//!
+//! # Two comparisons that look obvious and are both wrong
+//!
+//! **Comparing `PRAGMA table_info`.** `table_info` does not return generated
+//! columns at all, so a verifier built on it is structurally incapable of
+//! seeing one dropped -- checker and checked would share exactly one blind
+//! spot, and the suite would be green on that defect forever. That blindness is
+//! the reason this oracle exists, so the oracle introduces no PRAGMA
+//! introspection of its own. It inherits two deliberate exceptions through the
+//! probes it runs, and neither is schema introspection by the oracle:
+//! [`Trait::ForeignKeyWithAction`]'s probe reads `PRAGMA foreign_keys` as a
+//! precondition on the connection, and [`Trait::TypelessColumn`]'s probe reads
+//! `pragma_table_info` because a typeless column promoted to `BLOB` is
+//! invisible to every behavioural assertion. Both are documented at their
+//! assertions in [`registry`](crate::registry).
+//!
+//! **Comparing `sqlite_master.sql`.** The transformed arm has been through a
+//! rebuild, and `ALTER TABLE ... RENAME TO` rewrites the stored `CREATE` text
+//! -- re-quoting it and moving things around -- while the from-scratch arm's
+//! text is pristine. Two semantically identical schemas therefore diverge
+//! textually on every single run, which is a verifier that reports drift always
+//! and means nothing. The same finding is written down in
+//! `docs/plans/migrate-sequencing.md` about why drift detection cannot hash
+//! `sqlite_master` text.
+//!
+//! So the comparison is behavioural: run the probes and compare their
+//! outcomes. That is what #354 and #356 had to land first for.
+//!
+//! # The one thing compared that is not behaviour
+//!
+//! The set of user table *names*, from `sqlite_master`. Not the `sql` column
+//! and not a PRAGMA -- just the names, which survive a rename intact and so do
+//! not false-positive on a rebuild.
+//!
+//! Names only, and tables only. For a trigger or an index, presence is
+//! actively misleading: `CREATE TRIGGER` does not resolve the column references
+//! in a trigger body, so a trigger can sit in `sqlite_master` looking correct
+//! and fail every time it fires -- which is why the registry probes what a
+//! trigger *does*. A table is the other case. Its absence is unambiguous, it is
+//! the precondition for every probe that touches it, and no behavioural
+//! question can be asked of a table that is not there.
+//!
+//! # Seeding happens before the transformation, not after
+//!
+//! In the transformed arm the seed runs on the start schema and the
+//! transformation runs over the seeded database. Reversing that would leave the
+//! transformation copying empty tables, and a rebuild that copies nothing
+//! copies it perfectly.
+//!
+//! This is not only about data survival being observable in general. Several
+//! probes in the registry are *unwritable* against a database seeded
+//! afterwards. [`Trait::Trigger`]'s case seeds one row before and inserts one
+//! after precisely so that "fired once" is separable from "fired again over the
+//! rows the rebuild copied" -- smugglr#336's shape -- and that distinction
+//! needs a row that predates the transformation. [`Trait::GeneratedStored`]'s
+//! probe moves a base value that was stored before the transformation and asks
+//! whether the column followed, which is the only way to tell a stored
+//! generated column from an ordinary one holding the same number. And the
+//! `Unseeded` preconditions throughout the registry are written on the
+//! assumption that the rows were there first.
+//!
+//! # A failed transformation is not a divergence
+//!
+//! They are different signals and they leave by different doors. A
+//! transformation that returns an error makes [`differential`] return
+//! `Err(`[`ForgeError::Transform`]`)`, and no [`Report`] is produced at all. A
+//! divergence lives inside `Ok(Report)`. A caller can therefore never mistake
+//! "the migration refused to run" for "the migration ran and changed meaning",
+//! which is the distinction [`ForgeError::Transform`] exists as its own variant
+//! to keep.
+//!
+//! # What the caller has to hold up
+//!
+//! The start schema must carry the traits too. The seeds are the registry's,
+//! and they insert into the registry's tables; a start schema missing a case's
+//! tables makes that case's seed refuse in the transformed arm while it
+//! succeeds in the from-scratch arm, and the honest report of that is a
+//! divergence saying nothing was there to observe. That is a true statement
+//! about the two arms and an uninteresting one, so callers exercising every
+//! trait should hand in a start schema built from the same cases as the target.
+
+use std::collections::BTreeSet;
+
+use rusqlite::Connection;
+
+use crate::error::{BoxError, ForgeError, ProbeError};
+use crate::fixture::{Backing, Fixture, Route};
+use crate::registry::TraitCase;
+use crate::schema::{Schema, Trait};
+
+/// Which of the two arms something was observed in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Arm {
+    /// Built from the start schema, seeded, then transformed by the caller.
+    Transformed,
+    /// Built from the target schema by plain DDL, then seeded.
+    FromScratch,
+}
+
+/// What one probe said about one arm.
+///
+/// The seed folds in here rather than being reported separately: whatever went
+/// wrong seeding, the consequence for the probe behind it is the same one --
+/// there is nothing there to observe, and an unseeded probe is vacuous. The
+/// message keeps the original error so a missing table still reads as one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// The database did what the target schema said it does.
+    Held,
+    /// The construct did not behave. This is a finding.
+    Broke(String),
+    /// The seed did not take, or the probe's precondition did not hold, so the
+    /// assertion under it would have been vacuous. Never a pass: an empty
+    /// database is green on every behavioural assertion ever written.
+    NothingToObserve(String),
+    /// SQLite refused a statement the seed or the probe did not expect it to.
+    /// Most often the arm no longer has a table or column the target schema
+    /// promises.
+    Erred(String),
+}
+
+impl Outcome {
+    /// Same *kind* of outcome, ignoring the message.
+    ///
+    /// The messages carry row counts, values and SQLite's own wording, and two
+    /// arms that both broke may well word it differently while agreeing
+    /// perfectly about what the database did. The kind is the behavioural fact;
+    /// the message is for the human reading the report.
+    fn same_kind(&self, other: &Outcome) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}
+
+/// One trait, as each arm answered for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraitOutcome {
+    pub kind: Trait,
+    pub transformed: Outcome,
+    pub from_scratch: Outcome,
+}
+
+impl TraitOutcome {
+    /// Whether the two arms answered differently.
+    pub fn diverged(&self) -> bool {
+        !self.transformed.same_kind(&self.from_scratch)
+    }
+}
+
+/// One way the two arms disagreed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Divergence {
+    /// A trait behaved one way in the transformed arm and another in the arm
+    /// built from scratch.
+    Trait(TraitOutcome),
+    /// A table exists in one arm and not the other, after the caller's
+    /// exclusion set was applied.
+    Table { name: String, present_in: Arm },
+}
+
+/// Everything both arms said, and the tables each of them had.
+///
+/// The whole record is kept rather than only the disagreements, because "both
+/// arms broke identically" is not a divergence and is still something a caller
+/// needs to see -- it means the from-scratch arm is not a sound baseline, and
+/// the comparison underneath it proves nothing. Rendering any of this is
+/// FR-FORGER-008's problem, not this module's.
+#[derive(Debug, Clone)]
+pub struct Report {
+    /// One record per [`Trait`], in [`Trait::ALL`] order.
+    pub traits: Vec<TraitOutcome>,
+    /// User tables in the transformed arm, after exclusion.
+    pub transformed_tables: BTreeSet<String>,
+    /// User tables in the from-scratch arm, after exclusion.
+    pub from_scratch_tables: BTreeSet<String>,
+}
+
+impl Report {
+    /// Every way the arms disagreed, traits first and in [`Trait::ALL`] order,
+    /// then tables by name.
+    pub fn divergences(&self) -> Vec<Divergence> {
+        let mut found: Vec<Divergence> = self
+            .traits
+            .iter()
+            .filter(|outcome| outcome.diverged())
+            .cloned()
+            .map(Divergence::Trait)
+            .collect();
+        for name in self
+            .transformed_tables
+            .difference(&self.from_scratch_tables)
+        {
+            found.push(Divergence::Table {
+                name: name.clone(),
+                present_in: Arm::Transformed,
+            });
+        }
+        for name in self
+            .from_scratch_tables
+            .difference(&self.transformed_tables)
+        {
+            found.push(Divergence::Table {
+                name: name.clone(),
+                present_in: Arm::FromScratch,
+            });
+        }
+        found
+    }
+
+    /// Whether the arms disagreed at all.
+    pub fn diverged(&self) -> bool {
+        !self.divergences().is_empty()
+    }
+
+    /// What both arms said about one trait.
+    pub fn for_trait(&self, kind: Trait) -> &TraitOutcome {
+        self.traits
+            .iter()
+            .find(|outcome| outcome.kind == kind)
+            .expect("every trait is recorded")
+    }
+}
+
+/// Run the caller's transformation against a schema built from scratch, and
+/// report where the two disagree.
+///
+/// * `backing` -- forger cannot know whether the transformation touches the
+///   filesystem, and a rebuild that swaps files needs a real one, so the caller
+///   chooses. See [`Backing`].
+/// * `start` -- the schema the transformed arm begins at. It must carry the
+///   traits, or their seeds have nowhere to write; see the module docs.
+/// * `target` -- the schema the transformation claims to arrive at. It is built
+///   from scratch to make the second arm, *and* it is the promise both arms are
+///   held to: every probe is handed this schema and asked whether the database
+///   in front of it behaves that way. Neither arm is ever judged against the
+///   schema it happens to have been built from.
+/// * `transform` -- exactly [`Route::Transform`]'s shape. `&mut Connection`
+///   because opening a transaction needs one; the error boxed and type-erased
+///   because forger cannot name the caller's error type and will not learn to.
+/// * `ignore_tables` -- table names to leave out of the inventory comparison.
+///   A caller parameter rather than a list forger maintains: the two arms
+///   differ by construction on the consumer's own bookkeeping (smugglr's
+///   migration ledger exists in the transformed arm and not in the other), and
+///   the engine is what knows which tables those are. Anywhere the requirement
+///   says "reuse the engine's X", forger accepts X from the caller instead --
+///   that is what keeps the dependency direction one-way (FR-FORGER-011). Any
+///   iterable of string-likes, so a caller can pass its own `&[&str]`, `Vec` or
+///   set without forger naming the type. SQLite's own reserved `sqlite_%`
+///   objects are filtered separately and unconditionally, because that
+///   namespace is SQLite's rather than any consumer's.
+///
+/// Returns `Err(`[`ForgeError::Transform`]`)` and no report at all when the
+/// transformation itself fails -- see the module docs on why that is kept apart
+/// from a divergence.
+pub fn differential(
+    backing: Backing,
+    start: &Schema,
+    target: &Schema,
+    transform: &mut dyn FnMut(&mut Connection) -> Result<(), BoxError>,
+    ignore_tables: impl IntoIterator<Item = impl AsRef<str>>,
+) -> Result<Report, ForgeError> {
+    let ignore: BTreeSet<String> = ignore_tables
+        .into_iter()
+        .map(|name| name.as_ref().to_ascii_lowercase())
+        .collect();
+
+    // Built once and shared by both arms, so the two are seeded and probed by
+    // the same functions rather than by two constructions of them.
+    let cases: Vec<TraitCase> = Trait::ALL.into_iter().map(TraitCase::for_trait).collect();
+
+    // Arm A. Seed, then transform: the transformation has to be handed a
+    // populated database or the rows it loses are rows that were never there.
+    let mut transformed = Fixture::new(backing)?;
+    transformed.bring_to(Route::Schema(start))?;
+    let seeded_transformed = seed_all(&cases, transformed.conn());
+    transformed.bring_to(Route::Transform(transform))?;
+
+    // Arm B. The schema nobody transformed.
+    let mut from_scratch = Fixture::new(backing)?;
+    from_scratch.bring_to(Route::Schema(target))?;
+    let seeded_from_scratch = seed_all(&cases, from_scratch.conn());
+
+    // Before the probes, because probes write: they delete parents, move a
+    // generated column's base and provoke conflicting inserts. Sampling the
+    // inventory first means both arms are sampled at the same point in their
+    // lives.
+    let transformed_tables = user_tables(transformed.conn(), &ignore)?;
+    let from_scratch_tables = user_tables(from_scratch.conn(), &ignore)?;
+
+    // One order, `Trait::ALL`'s, on both arms. Probes mutate, so the order they
+    // run in is part of what each one observes, and two arms probed in
+    // different orders are not the same question asked twice.
+    let mut traits = Vec::with_capacity(cases.len());
+    for (index, case) in cases.iter().enumerate() {
+        traits.push(TraitOutcome {
+            kind: case.kind,
+            transformed: observe(
+                case,
+                target,
+                transformed.conn(),
+                seeded_transformed[index].as_deref(),
+            ),
+            from_scratch: observe(
+                case,
+                target,
+                from_scratch.conn(),
+                seeded_from_scratch[index].as_deref(),
+            ),
+        });
+    }
+
+    Ok(Report {
+        traits,
+        transformed_tables,
+        from_scratch_tables,
+    })
+}
+
+/// Seed every case, keeping what went wrong rather than stopping.
+///
+/// One case failing to seed says nothing about the other seven, and an arm that
+/// gave up part way through would be compared against an arm that did not.
+/// `None` at an index means that case seeded cleanly.
+fn seed_all(cases: &[TraitCase], conn: &Connection) -> Vec<Option<String>> {
+    cases
+        .iter()
+        .map(|case| case.seed(conn).err().map(|error| error.to_string()))
+        .collect()
+}
+
+/// What one probe says about one arm, with a failed seed short-circuiting it.
+fn observe(
+    case: &TraitCase,
+    promised: &Schema,
+    conn: &Connection,
+    seed_failure: Option<&str>,
+) -> Outcome {
+    if let Some(failure) = seed_failure {
+        return Outcome::NothingToObserve(format!("the seed did not take: {failure}"));
+    }
+    match case.probe_against(promised, conn) {
+        Ok(()) => Outcome::Held,
+        Err(ProbeError::Failed(message)) => Outcome::Broke(message),
+        Err(ProbeError::Unseeded(message)) => Outcome::NothingToObserve(message),
+        Err(ProbeError::Sqlite(error)) => Outcome::Erred(error.to_string()),
+    }
+}
+
+/// The user tables in a database, by name, minus what the caller excluded.
+///
+/// `name` and not `sql`: the text is rewritten by the rename at the end of a
+/// rebuild and would differ between the arms every run, while the name it
+/// settles on is the name it started with.
+///
+/// Matching is on the ASCII-lowercased name because that is how SQLite compares
+/// identifiers, so a caller excluding `_smugglr_migrations` excludes it however
+/// the statement that created it was capitalised.
+fn user_tables(
+    conn: &Connection,
+    ignore: &BTreeSet<String>,
+) -> Result<BTreeSet<String>, ForgeError> {
+    let mut statement =
+        conn.prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")?;
+    let names = statement.query_map([], |row| row.get::<_, String>(0))?;
+
+    let mut kept = BTreeSet::new();
+    for name in names {
+        let name = name?;
+        let folded = name.to_ascii_lowercase();
+        // `sqlite_` is SQLite's reserved namespace, not any consumer's --
+        // `sqlite_sequence` appears the moment a table declares AUTOINCREMENT,
+        // in whichever arm declared it first. Filtering it here rather than
+        // expecting every caller to list it keeps the caller's set about the
+        // caller's own tables.
+        if folded.starts_with("sqlite_") || ignore.contains(&folded) {
+            continue;
+        }
+        kept.insert(name);
+    }
+    Ok(kept)
+}

--- a/crates/smugglr-forger/src/registry/mod.rs
+++ b/crates/smugglr-forger/src/registry/mod.rs
@@ -113,7 +113,20 @@ impl TraitCase {
 
     /// Assert what the trait does, against the schema this case promised.
     pub fn probe(&self, conn: &Connection) -> Result<(), ProbeError> {
-        (self.probe)(&self.schema, conn)
+        self.probe_against(&self.schema, conn)
+    }
+
+    /// Assert what the trait does, against a schema the caller promises.
+    ///
+    /// The asymmetry described above is what makes this useful rather than
+    /// merely available: a probe interrogates a database it did not build, so
+    /// the schema it is handed is the promise, not a description of what is
+    /// there. A differential oracle needs exactly that -- both of its arms are
+    /// held to the *target* schema, and neither is judged against the schema it
+    /// happens to have been built from. [`probe`](Self::probe) is this with the
+    /// case's own schema as the promise.
+    pub fn probe_against(&self, promised: &Schema, conn: &Connection) -> Result<(), ProbeError> {
+        (self.probe)(promised, conn)
     }
 }
 

--- a/crates/smugglr-forger/tests/the_oracle_catches_a_silent_drop.rs
+++ b/crates/smugglr-forger/tests/the_oracle_catches_a_silent_drop.rs
@@ -1,0 +1,461 @@
+//! Drop one construct on purpose, and watch the oracle say which one.
+//!
+//! This is the harness proving itself, and it is the same discipline the probe
+//! suite applies with its seventeen breaks. A differential oracle that reports
+//! nothing is indistinguishable from one that cannot see, so each of the four
+//! constructs the requirement names is deliberately lost by a transformation
+//! here and the oracle is required to notice -- and to notice *that one*.
+//!
+//! # Why the transformations copy rows
+//!
+//! Every break below is a rebuild that carries the rows across. If it did not,
+//! the transformed arm would come back empty, every probe would report nothing
+//! to observe, and the oracle would flag a divergence -- for data loss, not for
+//! the construct that was dropped. The test would be green and the mechanism
+//! unproven. So each transformation copies, the assertions name the outcome
+//! kind rather than merely asking whether *something* diverged, and every other
+//! trait is required to have held in both arms.
+//!
+//! # Why the from-scratch arm is asserted sound
+//!
+//! Two arms that broke identically do not diverge. "No divergence" is therefore
+//! also what a bad schema or a mislocated probe produces, so before any
+//! comparison is trusted the arm nobody transformed is required to have held on
+//! all eight traits. That check lives here rather than in [`Report`] -- what a
+//! failure report should say is FR-FORGER-008's problem.
+
+use rusqlite::Connection;
+
+use smugglr_forger::error::BoxError;
+use smugglr_forger::fixture::{Backing, Fixture, Route};
+use smugglr_forger::oracle::{differential, Arm, Divergence, Outcome, Report};
+use smugglr_forger::registry::TraitCase;
+use smugglr_forger::schema::{Schema, Trait};
+
+/// smugglr's migration ledger, which exists in the transformed arm and not in
+/// the other. Written here as the literal a *caller* would pass, because that
+/// is the correction the requirement carries: forger takes the exclusion set as
+/// a parameter and never imports it. smugglr's own tests pass
+/// `config::default_exclude_tables()`, which contains this name; forger does not
+/// know the function exists.
+const LEDGER: &str = "_smugglr_migrations";
+
+/// What a migration engine writes around the work: its own bookkeeping table,
+/// with a row in it. Nothing about the user schema changes.
+const RECORDS_A_MIGRATION: &str = r#"
+    CREATE TABLE "_smugglr_migrations" ("version" TEXT PRIMARY KEY, "applied_at" TEXT);
+    INSERT INTO "_smugglr_migrations" ("version", "applied_at") VALUES ('0001', '2026-01-01');
+"#;
+
+// ---------------------------------------------------------------------------
+// The four deliberate drops
+// ---------------------------------------------------------------------------
+
+/// smugglr#341's shape: the rebuild reconstructs the foreign key and leaves the
+/// referential action behind, which turns a cascade into the `NO ACTION`
+/// default. Nothing about the row counts changes on the day of the migration.
+#[test]
+fn dropping_a_referential_action_diverges() {
+    let report = run(
+        r#"
+        CREATE TABLE "cascade_child_new" (
+            "id" INTEGER PRIMARY KEY,
+            "keeper_id" INTEGER,
+            "label" TEXT,
+            FOREIGN KEY ("keeper_id") REFERENCES "keeper" ("id")
+        );
+        INSERT INTO "cascade_child_new" ("id", "keeper_id", "label")
+            SELECT "id", "keeper_id", "label" FROM "cascade_child";
+        DROP TABLE "cascade_child";
+        ALTER TABLE "cascade_child_new" RENAME TO "cascade_child";
+        "#,
+        &[LEDGER],
+    );
+
+    assert_baseline_is_sound(&report);
+    assert_broke(&report, Trait::ForeignKeyWithAction);
+    assert_only_these_diverged(&report, &[Trait::ForeignKeyWithAction]);
+}
+
+/// The rebuild enumerates the columns to copy from `PRAGMA table_info`, which
+/// never returns a generated column at all -- so both of them are lost, and
+/// they are lost in the two different ways this crate exists to tell apart.
+///
+/// The virtual column simply is not in the new table, and the probe's read of
+/// it comes back as a value it cannot use. (Not, note, as "no such column":
+/// SQLite falls back to reading an unresolved double-quoted identifier as a
+/// string literal, so `SELECT "doubled"` yields the text `doubled` for every
+/// row and it is the *type* that gives the absence away. That fallback is
+/// recorded as a hazard for the registry, not worked around here.)
+///
+/// The stored one is worse: a rebuild that had the column name from somewhere
+/// would re-create it as an ordinary column and copy the number into it, which
+/// is byte-identical in a row dump and has stopped computing. Only moving the
+/// base and re-reading catches that, and this asserts both shapes in one run.
+#[test]
+fn dropping_a_generated_column_diverges() {
+    let report = run(
+        r#"
+        CREATE TABLE "virtual_generated_new" ("id" INTEGER PRIMARY KEY, "base" INTEGER, "label" TEXT);
+        INSERT INTO "virtual_generated_new" ("id", "base", "label")
+            SELECT "id", "base", "label" FROM "virtual_generated";
+        DROP TABLE "virtual_generated";
+        ALTER TABLE "virtual_generated_new" RENAME TO "virtual_generated";
+
+        CREATE TABLE "stored_generated_new" ("id" INTEGER PRIMARY KEY, "base" INTEGER, "tripled" INTEGER, "label" TEXT);
+        INSERT INTO "stored_generated_new" ("id", "base", "tripled", "label")
+            SELECT "id", "base", "tripled", "label" FROM "stored_generated";
+        DROP TABLE "stored_generated";
+        ALTER TABLE "stored_generated_new" RENAME TO "stored_generated";
+        "#,
+        &[LEDGER],
+    );
+
+    assert_baseline_is_sound(&report);
+    // Not "it diverged": which arm said what, and in which of the two ways.
+    assert_erred(&report, Trait::GeneratedVirtual);
+    assert_broke(&report, Trait::GeneratedStored);
+    assert_only_these_diverged(&report, &[Trait::GeneratedVirtual, Trait::GeneratedStored]);
+}
+
+/// The conflict algorithm comes off the constraint and the constraint stays.
+/// The table still refuses duplicates -- it just throws where it used to
+/// absorb, which is a data outcome rather than a schema difference.
+#[test]
+fn dropping_an_on_conflict_clause_diverges() {
+    let report = run(
+        r#"
+        CREATE TABLE "replace_absorbs_new" ("id" INTEGER PRIMARY KEY, "k" TEXT UNIQUE, "label" TEXT);
+        INSERT INTO "replace_absorbs_new" ("id", "k", "label")
+            SELECT "id", "k", "label" FROM "replace_absorbs";
+        DROP TABLE "replace_absorbs";
+        ALTER TABLE "replace_absorbs_new" RENAME TO "replace_absorbs";
+        "#,
+        &[LEDGER],
+    );
+
+    assert_baseline_is_sound(&report);
+    assert_broke(&report, Trait::ColumnOnConflict);
+    assert_only_these_diverged(&report, &[Trait::ColumnOnConflict]);
+}
+
+/// smugglr#344's shape, in its behaviourally visible half: the rebuild invents
+/// `TEXT` for a column that was declared with no type at all. The copy itself
+/// does the damage -- `TEXT` affinity converts the integer on the way in -- so
+/// this is caught by the probe's `typeof()` assertion and does not lean on the
+/// declared-type read the typeless probe also takes.
+#[test]
+fn resolving_a_typeless_declaration_diverges() {
+    let report = run(
+        r#"
+        CREATE TABLE "typeless_new" ("id" INTEGER PRIMARY KEY, "v" TEXT, "label" TEXT);
+        INSERT INTO "typeless_new" ("id", "v", "label")
+            SELECT "id", "v", "label" FROM "typeless";
+        DROP TABLE "typeless";
+        ALTER TABLE "typeless_new" RENAME TO "typeless";
+        "#,
+        &[LEDGER],
+    );
+
+    assert_baseline_is_sound(&report);
+    assert_broke(&report, Trait::TypelessColumn);
+    assert_only_these_diverged(&report, &[Trait::TypelessColumn]);
+}
+
+// ---------------------------------------------------------------------------
+// The quiet direction
+// ---------------------------------------------------------------------------
+
+/// A transformation that changes nothing about the user schema, over a schema
+/// carrying all eight traits, is silent.
+#[test]
+fn a_transformation_that_preserves_everything_diverges_nowhere() {
+    let report = run(RECORDS_A_MIGRATION, &[LEDGER]);
+
+    assert_baseline_is_sound(&report);
+    for outcome in &report.traits {
+        assert_eq!(
+            outcome.transformed,
+            Outcome::Held,
+            "{:?} did not hold in the transformed arm",
+            outcome.kind
+        );
+    }
+    assert_eq!(report.divergences(), Vec::new());
+}
+
+/// The reason the comparison is behavioural rather than textual, demonstrated
+/// rather than asserted in a comment.
+///
+/// A faithful rebuild -- same columns, same blank type, rows carried across --
+/// leaves a database that behaves identically and whose stored `CREATE` text
+/// does not match the from-scratch arm's, because `ALTER TABLE ... RENAME TO`
+/// rewrites the text it renames through. A verifier comparing
+/// `sqlite_master.sql` would report drift here, on a transformation that lost
+/// nothing. The oracle reports nothing.
+#[test]
+fn a_faithful_rebuild_is_silent_even_though_its_stored_ddl_text_differs() {
+    const FAITHFUL: &str = r#"
+        CREATE TABLE "typeless_new" ("id" INTEGER PRIMARY KEY, "v", "label" TEXT);
+        INSERT INTO "typeless_new" ("id", "v", "label") SELECT "id", "v", "label" FROM "typeless";
+        DROP TABLE "typeless";
+        ALTER TABLE "typeless_new" RENAME TO "typeless";
+    "#;
+
+    assert_ne!(
+        stored_ddl_after(Some(FAITHFUL), "typeless"),
+        stored_ddl_after(None, "typeless"),
+        "this test's premise is that the two arms' stored text differs; if it \
+         stopped differing the test below has stopped saying anything"
+    );
+
+    let report = run(FAITHFUL, &[LEDGER]);
+    assert_baseline_is_sound(&report);
+    assert_eq!(report.divergences(), Vec::new());
+}
+
+// ---------------------------------------------------------------------------
+// The exclusion set is the caller's
+// ---------------------------------------------------------------------------
+
+/// One transformation, one forger, two exclusion sets, two verdicts.
+///
+/// The ledger exists in the transformed arm by construction and never in the
+/// other, so without the caller's set every comparison would report it -- the
+/// trap the requirement names. With it, the same run is silent. Nothing in
+/// forger changed between the two halves of this test, which is the property
+/// being asserted: the set is a parameter, so the engine that owns the list
+/// owns the behaviour.
+#[test]
+fn the_exclusion_set_is_a_caller_parameter_and_changing_it_changes_the_verdict() {
+    let excluded_by_nobody = run(RECORDS_A_MIGRATION, &[]);
+    assert_baseline_is_sound(&excluded_by_nobody);
+    assert!(excluded_by_nobody.diverged());
+    assert_eq!(
+        excluded_by_nobody.divergences(),
+        vec![Divergence::Table {
+            name: LEDGER.to_string(),
+            present_in: Arm::Transformed,
+        }]
+    );
+
+    let excluded_by_the_caller = run(RECORDS_A_MIGRATION, &[LEDGER]);
+    assert_baseline_is_sound(&excluded_by_the_caller);
+    assert!(!excluded_by_the_caller.diverged());
+    assert_eq!(excluded_by_the_caller.divergences(), Vec::new());
+}
+
+/// The set is not special-cased to the ledger. Any name the caller hands in is
+/// left out of the comparison, which is what "one list, owned by the engine"
+/// means in practice.
+///
+/// And it is left out of the *inventory* only. The exclusion set answers "whose
+/// table is this", not "does any of this matter": a caller who hides a table
+/// still hears about everything that table's absence changed, because the
+/// probes are not filtered by it and never should be. Here the audit table the
+/// trigger writes into is dropped, so hiding the name silences the inventory
+/// and the trigger still reports.
+#[test]
+fn the_exclusion_set_hides_a_table_from_the_inventory_and_not_from_the_probes() {
+    const DROPS_A_TABLE: &str = r#"DROP TABLE "audit";"#;
+
+    let visible = run(DROPS_A_TABLE, &[LEDGER]);
+    assert_baseline_is_sound(&visible);
+    assert!(visible.divergences().contains(&Divergence::Table {
+        name: "audit".to_string(),
+        present_in: Arm::FromScratch,
+    }));
+
+    let hidden = run(DROPS_A_TABLE, &[LEDGER, "audit"]);
+    assert_baseline_is_sound(&hidden);
+    assert!(
+        !hidden
+            .divergences()
+            .iter()
+            .any(|divergence| matches!(divergence, Divergence::Table { .. })),
+        "the caller named this table, so the inventory should not mention it: {:?}",
+        hidden.divergences()
+    );
+    // The trigger's side effect had nowhere to land, and that is behaviour
+    // rather than inventory, so excluding the name did not excuse it.
+    assert_erred(&hidden, Trait::Trigger);
+    assert_only_these_diverged(&hidden, &[Trait::Trigger]);
+}
+
+// ---------------------------------------------------------------------------
+// A failed transformation is not a divergence
+// ---------------------------------------------------------------------------
+
+/// The distinction `ForgeError::Transform` exists to keep, asserted at the
+/// oracle's own boundary: a transformation that fails leaves by the `Err` door
+/// and produces no report at all, so no caller can read "the migration refused
+/// to run" as "the migration ran and changed meaning".
+#[test]
+fn a_transformation_that_fails_is_reported_as_a_failure_and_not_as_a_divergence() {
+    let schema = every_trait();
+    let mut transform =
+        |_: &mut Connection| -> Result<(), BoxError> { Err("the migration refused to run".into()) };
+
+    let outcome = differential(Backing::Memory, &schema, &schema, &mut transform, [LEDGER]);
+
+    match outcome {
+        Err(smugglr_forger::ForgeError::Transform(error)) => {
+            assert_eq!(error.to_string(), "the migration refused to run");
+        }
+        other => panic!(
+            "a failing transformation must surface as ForgeError::Transform, not as a report; \
+             got {other:?}"
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The schema every case is run against
+// ---------------------------------------------------------------------------
+
+/// The eight case schemas, unioned into one that exercises every supported
+/// trait.
+///
+/// The cases name their tables distinctly, so this is a concatenation rather
+/// than a merge -- and each probe still finds its own construct by reading the
+/// schema, which is the property that lets one schema carry all eight.
+fn every_trait() -> Schema {
+    let mut all = Schema::default();
+    for kind in Trait::ALL {
+        all.tables.extend(TraitCase::for_trait(kind).schema.tables);
+    }
+    all.validate()
+        .expect("the union of the case schemas is one SQLite would accept");
+    all
+}
+
+#[test]
+fn the_union_of_every_case_schema_is_one_sqlite_accepts() {
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    fixture
+        .bring_to(Route::Schema(&every_trait()))
+        .expect("the union renders to DDL SQLite accepts");
+}
+
+// ---------------------------------------------------------------------------
+// Driving the oracle
+// ---------------------------------------------------------------------------
+
+/// Run one transformation over the every-trait schema, claiming to arrive back
+/// at it.
+///
+/// Start and target are the same schema on purpose: these are transformations
+/// that *say* they preserve everything, and the question the oracle answers is
+/// whether they did.
+fn run(statements: &str, ignore_tables: &[&str]) -> Report {
+    let schema = every_trait();
+    let mut transform = |conn: &mut Connection| -> Result<(), BoxError> {
+        conn.execute_batch(statements)?;
+        Ok(())
+    };
+    differential(
+        Backing::Memory,
+        &schema,
+        &schema,
+        &mut transform,
+        ignore_tables.iter().copied(),
+    )
+    .expect("the transformation runs")
+}
+
+/// The `CREATE` text SQLite stored for a table, after optionally running a
+/// transformation over the every-trait schema.
+///
+/// This is the comparison the oracle refuses to make, built here only to show
+/// that refusing it was right.
+fn stored_ddl_after(statements: Option<&str>, table: &str) -> String {
+    let mut fixture = Fixture::new(Backing::Memory).expect("fixture");
+    fixture
+        .bring_to(Route::Schema(&every_trait()))
+        .expect("the schema stands up");
+    if let Some(statements) = statements {
+        fixture
+            .conn()
+            .execute_batch(statements)
+            .expect("the transformation runs");
+    }
+    fixture
+        .conn()
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [table],
+            |row| row.get(0),
+        )
+        .expect("the table is there")
+}
+
+// ---------------------------------------------------------------------------
+// Assertions
+// ---------------------------------------------------------------------------
+
+/// The arm nobody transformed held on every trait.
+///
+/// Without this, "no divergence" is also what two identically broken arms
+/// produce, and every comparison in this file would be an agreement between two
+/// wrong answers.
+fn assert_baseline_is_sound(report: &Report) {
+    for outcome in &report.traits {
+        assert_eq!(
+            outcome.from_scratch,
+            Outcome::Held,
+            "{:?} did not hold in the arm built from scratch, so nothing compared against it \
+             means anything",
+            outcome.kind
+        );
+    }
+}
+
+/// The transformed arm ran the probe and the probe failed -- the construct is
+/// there and no longer behaves. Not "something diverged": a probe that reported
+/// nothing to observe would also diverge from a held baseline, and that is what
+/// a transformation losing the *rows* looks like rather than the construct.
+fn assert_broke(report: &Report, kind: Trait) {
+    let outcome = report.for_trait(kind);
+    assert!(
+        matches!(outcome.transformed, Outcome::Broke(_)),
+        "{kind:?} should have failed its probe in the transformed arm; it said {:?}",
+        outcome.transformed
+    );
+}
+
+/// The transformed arm no longer has something the target schema promises, so
+/// SQLite refused the probe's statement outright.
+fn assert_erred(report: &Report, kind: Trait) {
+    let outcome = report.for_trait(kind);
+    assert!(
+        matches!(outcome.transformed, Outcome::Erred(_)),
+        "{kind:?} should have met a statement SQLite refused in the transformed arm; it said {:?}",
+        outcome.transformed
+    );
+}
+
+/// Exactly these traits diverged, and no table did.
+///
+/// The second half matters as much as the first: a rebuild that dropped a table
+/// on its way past would show up in the inventory, and a test asserting only
+/// "the trait diverged" would pass while the transformation had also destroyed
+/// something nobody was looking at.
+fn assert_only_these_diverged(report: &Report, expected: &[Trait]) {
+    let mut diverged: Vec<Trait> = report
+        .traits
+        .iter()
+        .filter(|outcome| outcome.diverged())
+        .map(|outcome| outcome.kind)
+        .collect();
+    diverged.sort();
+    let mut expected = expected.to_vec();
+    expected.sort();
+    assert_eq!(diverged, expected, "traits that diverged");
+
+    let tables: Vec<Divergence> = report
+        .divergences()
+        .into_iter()
+        .filter(|divergence| matches!(divergence, Divergence::Table { .. }))
+        .collect();
+    assert!(tables.is_empty(), "tables also diverged: {tables:?}");
+}


### PR DESCRIPTION
Closes #355. Implements FR-FORGER-005, as amended by the two corrections recorded on that issue.

Builds the target schema two ways -- by the caller's transformation and from scratch -- and compares by running the registry's probe set against both arms.

## Acceptance criteria mapping

### A transformation that silently drops a referential action, a generated column, an ON CONFLICT clause or a typeless declaration produces a divergence

Four deliberate drops, each a rebuild that **copies its rows**. That detail is load-bearing: without it arm A comes back empty, every probe reports nothing to observe, and the oracle flags a divergence for data loss rather than for the dropped construct -- a green test over an unproven mechanism. Each test asserts the **outcome kind** rather than merely that something diverged, because a probe reporting `NothingToObserve` also diverges from a held baseline and that is what losing rows looks like, not losing a construct.

Evidence: `tests/the_oracle_catches_a_silent_drop.rs`. `ON DELETE CASCADE` dropped gives `Broke` -- *"deleting keeper.id = 1 was refused (FOREIGN KEY constraint failed) ... the action was reconstructed as something else, or dropped, which leaves NO ACTION"*. Stored generated column dropped gives *"stored_generated.tripled still reads Some(15) after its base moved to 7, not 21; the value was copied but the computation was not"*. `ON CONFLICT REPLACE` dropped gives *"the insert conflicting on replace_absorbs.k was thrown (UNIQUE constraint failed)"*. The typeless drop is caught behaviourally by `typeof()` rather than by the inherited PRAGMA read. Every test additionally requires all other traits to have held in both arms and, via `assert_baseline_is_sound`, the from-scratch arm to have held on all eight -- without that last check, "no divergence" is also what two identically broken arms produce.

### A transformation that preserves everything produces no divergence on a schema exercising every supported trait

The passing case runs a real transformation -- a migration engine writing its own ledger -- over a schema unioning all eight case schemas, rather than a no-op, so the silent verdict means something.

Evidence: `a_transformation_that_preserves_everything_diverges_nowhere` asserts all eight traits `Held` in *both* arms plus an empty divergence list.

### The ledger table is excluded by the caller-supplied set

The original wording said to reuse `config::default_exclude_tables`. That lives in `smugglr-core`, which forger must never depend on, so the set became a parameter -- one list, still owned by the engine, supplied at the call. This is correction 1 on the issue.

`ignore_tables: impl IntoIterator<Item = impl AsRef<str>>` accepts `default_exclude_tables()`'s `Vec<String>`, a `&[&str]`, or a set, without forger naming any of smugglr's types. Filtering the `sqlite_%` namespace is separate and unconditional, since that namespace is SQLite's rather than any consumer's.

Probe outcomes alone would have left the set inert -- no probe touches the ledger -- so the oracle compares one non-behavioural thing: the set of user table **names** from `sqlite_master`. Names rather than `.sql`, because a name survives `RENAME TO`. Tables rather than triggers, because a trigger's presence is actively misleading while a table's absence is unambiguous and is the precondition for every probe touching it. Matching is on the ASCII-lowercased name, which is how SQLite compares identifiers.

Evidence: `the_exclusion_set_is_a_caller_parameter_and_changing_it_changes_the_verdict` passes a set containing the ledger and the oracle stays silent about `_smugglr_migrations`, which arm A carries and arm B does not.

### Adding a table to that set changes the oracle's behaviour with no forger code change

The same test runs the same transformation twice, changing nothing but the argument. That is the whole criterion: the set is data flowing in, not a constant compiled into forger, so a consumer can extend it without touching this crate.

Evidence: with an empty set the run reports `Divergence::Table { name: "_smugglr_migrations", present_in: Transformed }`; with the ledger in the set the same run is silent. No forger code differs between the halves. A second test pins the property that matters more -- `the_exclusion_set_hides_a_table_from_the_inventory_and_not_from_the_probes` drops the audit table the trigger writes into and asserts both halves: no `Divergence::Table`, and `Trait::Trigger` still reported in the transformed arm. A caller must not be able to silence a real behavioural finding by naming a table.

### The oracle performs no PRAGMA-based schema introspection

The oracle issues no PRAGMA at all. It reads `SELECT name FROM sqlite_master` -- not a PRAGMA, and not the `sql` column. Two exceptions are inherited through the probes and named in the module docs rather than worked around: `PRAGMA foreign_keys` as a connection precondition in the cascade probe, and `pragma_table_info` in the typeless probe, which is the documented exception from #364.

Evidence: `a_faithful_rebuild_is_silent_even_though_its_stored_ddl_text_differs` demonstrates the rejected text route rather than asserting it in a comment -- same table, semantically identical, differing only in whitespace, oracle silent. The test guards its own premise by asserting the two texts differ *before* asserting silence, with a message saying that if they stop differing the test has stopped saying anything.

## Not done

- **Execution accounting (#357), failure legibility (#358), known-defect validation (#359), coverage boundary (#360).** Absent, not stubbed.
- **No dependency on smugglr.** `scripts/check-forger-boundary.py` passes.
- One speculative API was removed before commit -- `Outcome::held()`, a `matches!` wrapper with no caller.

## Three orderings that are load-bearing, each stated at its line

**Seed before transform in arm A.** Data survival being observable is the weaker half of the argument. The stronger half is that several probes are unwritable otherwise: the Trigger case's before/after pair exists to separate "fired once" from "fired again over the rows the rebuild copied" (smugglr#336), which needs a row predating the transform; the stored-generated probe moves a base stored before the transform, which is the only way to tell a stored generated column from an ordinary one holding the same number.

**The table inventory is sampled before any probe runs**, because probes write -- they delete parents, move a generated column's base, provoke conflicting inserts.

**Probes run in `Trait::ALL` order on both arms**, since two arms probed in different orders are not the same question asked twice.

## A transformation error is not a divergence, and the type enforces it

A failing transformation propagates as `Err(ForgeError::Transform)` and **no `Report` is produced at all**; divergences exist only inside `Ok(Report)`. Asserted by matching the variant rather than checking `is_err()`.

## Design note for review

Outcome comparison is on the **discriminant**, not the message, because messages carry row counts and SQLite's own wording and two arms agreeing about what the database did may word it differently. The consequence: "both arms broke identically" is not a divergence. That is correct -- it means the baseline is unsound rather than that the transform lost something -- but it makes `assert_baseline_is_sound` load-bearing, and it currently lives in the tests rather than in `Report`. Left there deliberately; what a failure report should say is #358's problem.

## Defect found, filed as #366

**SQLite's double-quoted-string fallback lets a probe report a confident wrong diagnosis.** Every probe locates its column and queries it as `"name"`. When that identifier does not resolve, SQLite falls back to reading it as a *string literal* rather than erroring -- so on a database where the column was dropped, `SELECT "doubled" FROM ...` succeeds and returns the text `doubled` per row.

The virtual-generated probe was saved only by asking rusqlite for an `Option<i64>` -- a type check, not an assertion anyone wrote. Two probes are exposed worse because they ask for text: `probe_typeless_column` reads `typeof("v")`, and if `v` were dropped, `typeof('v')` reads `text`, so the probe emits a specific, well-worded diagnosis about affinity resolution for a column that is simply gone.

The failure mode is not odd error text. It is a confident wrong diagnosis sending a reader to hunt an affinity bug in a rebuild that actually dropped a column -- precisely the class forger exists to catch, arriving inside forger. Fix is a build flag (`SQLITE_DQS=0`), out of scope here. The generated-column test carries a doc comment recording that its verdict rests on the requested Rust type rather than on SQLite refusing.

## Second finding, unfiled

`crates/smugglr-core/src/config.rs:449` hardcodes `"_smugglr_migrations"` rather than referencing `migrate::ledger::LEDGER_TABLE` (`ledger.rs:43`). Doc comments on both sides point at each other, presumably because `config` is not native-gated and `ledger` is. Renaming the ledger needs both edits and nothing in the type system catches a miss.