### PR TITLE
fix(#368): every schema type refuses unknown fields, so a misspelled fixture key cannot parse clean

### DIFF
--- a/crates/smugglr-forger/src/schema/mod.rs
+++ b/crates/smugglr-forger/src/schema/mod.rs
@@ -10,6 +10,37 @@
 //! model can hold a generated primary key; SQLite cannot. [`validate`] is
 //! where that gap is closed, and [`builder`] closes part of it earlier, in the
 //! type system. See the module docs there for which invariants land where.
+//!
+//! # Why every type here refuses unknown fields
+//!
+//! A schema reaches this model from a hand-edited regression fixture, and a
+//! misspelled key that serde ignored -- `"decl_types"` for `"decl_type"`,
+//! `"trigger"` for `"triggers"` -- would parse cleanly and drop the field. The
+//! fixture would then sit in the corpus, run green, and appear to guard a
+//! defect it no longer carries, which is the one failure a regression corpus
+//! cannot tolerate: a fixture that has quietly stopped testing its defect is
+//! indistinguishable from one that still does, and the misspelling is
+//! invisible in review because the reader sees the key they expected.
+//!
+//! So `deny_unknown_fields` is on every container, including the enums whose
+//! variants carry no named fields today and where it is therefore inert. The
+//! point is that a variant gaining a named field later must not open the gap
+//! again, and remembering to add the attribute at that moment is exactly the
+//! kind of thing nobody remembers. It composes with the `#[serde(default)]`
+//! fields below rather than fighting them: `default` says a field that *is*
+//! declared may be omitted, while this refuses keys that are not fields at
+//! all.
+//!
+//! Where it earns its keep is the optional fields, and not only the ones
+//! marked `#[serde(default)]`. Serde supplies `None` for any missing
+//! `Option` field whether or not the attribute is written, so a misspelled
+//! `decl_type` or `on_conflict` used to deserialize to a column with no type
+//! and a key with no conflict algorithm -- both of which are traits with
+//! probes of their own, so the fixture would still stand up and still run,
+//! reporting on a different defect than the one it reads as declaring. A
+//! required field of a non-optional type was already caught, but as "missing
+//! field", which names the key the author meant rather than the one they
+//! typed.
 
 pub mod builder;
 pub mod ddl;
@@ -22,11 +53,13 @@ use serde::{Deserialize, Serialize};
 /// Not `Eq`, because a `REAL` default is an `f64`. `PartialEq` is what the
 /// "authored and literal compare equal" property needs.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Schema {
     pub tables: Vec<Table>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Table {
     pub name: String,
     pub columns: Vec<Column>,
@@ -48,6 +81,7 @@ pub struct Table {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Column {
     pub name: String,
     /// `None` is a typeless column -- legal SQLite, blank affinity, and a
@@ -59,6 +93,7 @@ pub struct Column {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum ColumnType {
     Integer,
     Text,
@@ -86,6 +121,7 @@ impl ColumnType {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum ColumnConstraint {
     PrimaryKey {
         order: SortOrder,
@@ -108,6 +144,7 @@ pub enum ColumnConstraint {
 /// that can carry one holds it inline rather than the column holding a
 /// separate list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum OnConflict {
     Rollback,
     Abort,
@@ -129,6 +166,7 @@ impl OnConflict {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum SortOrder {
     #[default]
     Asc,
@@ -136,12 +174,14 @@ pub enum SortOrder {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum Generated {
     Virtual,
     Stored,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum DefaultValue {
     Null,
     Integer(i64),
@@ -165,6 +205,7 @@ impl DefaultValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum TableConstraint {
     PrimaryKey {
         columns: Vec<IndexedColumn>,
@@ -179,6 +220,7 @@ pub enum TableConstraint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct IndexedColumn {
     pub name: String,
     #[serde(default)]
@@ -195,6 +237,7 @@ impl IndexedColumn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ForeignKey {
     pub columns: Vec<String>,
     pub parent_table: String,
@@ -206,6 +249,7 @@ pub struct ForeignKey {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum ReferentialAction {
     NoAction,
     Restrict,
@@ -227,6 +271,7 @@ impl ReferentialAction {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Trigger {
     pub name: String,
     pub timing: TriggerTiming,
@@ -239,12 +284,14 @@ pub struct Trigger {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum TriggerTiming {
     Before,
     After,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum TriggerEvent {
     Insert,
     Delete,
@@ -260,6 +307,7 @@ pub enum TriggerEvent {
 /// because the model is where a feature is named; wiring each one to a seed
 /// and a probe, and dispatching over them exhaustively, is FR-FORGER-003.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum Trait {
     /// A foreign key carrying `ON DELETE`/`ON UPDATE`. A rebuild that
     /// re-declares the key without its action silently turns a cascade into a

--- a/crates/smugglr-forger/tests/a_failure_survives_the_round_trip.rs
+++ b/crates/smugglr-forger/tests/a_failure_survives_the_round_trip.rs
@@ -192,3 +192,86 @@ fn a_misspelled_key_is_refused_rather_than_ignored() {
         Err(CorpusError::Parse(_))
     ));
 }
+
+/// Misspell one key in a fixture's JSON and hand the result back to the parser,
+/// requiring that what comes back is a refusal naming that key.
+///
+/// Two things are checked that a bare `Err(Parse(_))` would not. The
+/// misspelling has to have landed -- a `.replace` matching nothing leaves valid
+/// JSON, and the assertion would then be about a file nobody edited. And the
+/// refusal has to be *about* the key, because a parse error from some unrelated
+/// cause would satisfy `Err(Parse(_))` while the test read as though it had
+/// proved the field was guarded. That is the same defect shape this whole
+/// mechanism exists to refuse, one level up.
+fn refuses_the_misspelling(schema: Schema, kind: Trait, correct: &str, misspelled: &str) {
+    let json = recorded(schema, kind, "said".into()).to_json();
+    assert!(
+        json.contains(&format!("\"{correct}\"")),
+        "the serialized fixture has no {correct} key to misspell, so this test edits nothing"
+    );
+    let edited = json.replace(&format!("\"{correct}\""), &format!("\"{misspelled}\""));
+
+    match Regression::from_json(&edited) {
+        Err(CorpusError::Parse(source)) => {
+            let said = source.to_string();
+            assert!(
+                said.contains(&format!("unknown field `{misspelled}`")),
+                "the fixture was refused, but not for the misspelled key -- serde said {said:?}"
+            );
+        }
+        Ok(_) => panic!(
+            "{misspelled} parsed as though it were {correct}; the field was dropped and the \
+             fixture now tests something other than what it reads as"
+        ),
+        Err(other) => panic!("{misspelled} was refused for the wrong reason: {other}"),
+    }
+}
+
+#[test]
+fn a_misspelled_key_on_a_nested_schema_type_is_refused() {
+    // `decl_types` for `decl_type`. Dropped silently, the column becomes
+    // typeless -- which is a trait of its own with its own probe, so the
+    // fixture would still stand up, still run, and be about a different
+    // defect than the one its JSON reads as declaring.
+    refuses_the_misspelling(
+        cascade_lost(),
+        Trait::ForeignKeyWithAction,
+        "decl_type",
+        "decl_types",
+    );
+
+    // `trigger` for `triggers`, the other misspelling that is one character
+    // from the real key. Dropped, the table renders without its trigger and
+    // the Trigger case's probe reports a defect nobody introduced.
+    refuses_the_misspelling(
+        TraitCase::for_trait(Trait::Trigger).schema,
+        Trait::Trigger,
+        "triggers",
+        "trigger",
+    );
+}
+
+#[test]
+fn a_misspelled_key_inside_an_enum_variant_is_refused() {
+    // The nesting that container-level `deny_unknown_fields` has to reach
+    // *through* a variant to guard: `on_conflict` is a field of
+    // `ColumnConstraint::PrimaryKey`, not of any struct. If serde's attribute
+    // stopped at the enum, every struct variant in the model would still be an
+    // open door, and this is the only test that would notice.
+    //
+    // `on_conflict` rather than its siblings, and this is the part worth
+    // reading twice. Serde supplies `None` for a missing `Option` field
+    // whether or not anyone wrote `#[serde(default)]`, so this is the one
+    // field of the variant a misspelling drops in silence -- `autoincrement`
+    // is a `bool` and comes back as "missing field" on its own. Which is to
+    // say the attribute is load-bearing exactly where the model is optional,
+    // and `on_conflict` going missing is not a small loss: it is the whole of
+    // `Trait::ColumnOnConflict`, and it changes what an INSERT does to rows
+    // that are already there.
+    refuses_the_misspelling(
+        cascade_lost(),
+        Trait::ForeignKeyWithAction,
+        "on_conflict",
+        "on_conflcit",
+    );
+}


### PR DESCRIPTION
Closes #368.

`deny_unknown_fields` guarded the fixture envelope but not the schema types inside it, so a misspelled key in a committed fixture parsed cleanly, dropped the field, and left a test of something other than what it reads as.

## Acceptance criteria mapping

### Every serializable type in schema/mod.rs refuses unknown fields

Seventeen types, not the "roughly twelve" the issue estimated -- six structs (`Schema`, `Table`, `Column`, `IndexedColumn`, `ForeignKey`, `Trigger`) and eleven enums. The attribute bites on eight of them: the six structs plus `ColumnConstraint` and `TableConstraint`, the only enums carrying struct variants. It is inert on the other nine today and is applied anyway, per the issue's own rationale -- a unit variant gaining a named field later must not silently reopen the gap, and nobody remembers to add the attribute at that moment. The module doc says which are inert and why, so a reviewer does not read nine no-op attributes as noise.

Completeness is argued by construction rather than by counting. The serde reachability closure from `Regression` is entirely inside `schema/mod.rs`: `Schema.tables` -> `Table` -> `{Column, TableConstraint, Trigger}`; `Column` -> `{ColumnType, ColumnConstraint}`; `ColumnConstraint` -> `{SortOrder, OnConflict, DefaultValue, Generated}`; `TableConstraint` -> `{IndexedColumn, OnConflict, ForeignKey}`; `ForeignKey` -> `ReferentialAction`; `Trigger` -> `{TriggerTiming, TriggerEvent}`. Every non-primitive lands on one of the seventeen, and `builder.rs`, `ddl.rs` and `validate.rs` declare no serializable types at all. There is no layer below this one for the gap to reappear in.

Evidence: all seventeen compiled on the first pass; none had to be skipped. No `#[serde(flatten)]` exists anywhere in the file, so the compile-time conflict with `deny_unknown_fields` was never hit -- verified by reading the file rather than assumed. `#[serde(default)]` appears on nine fields and is orthogonal: `default` says a declared field may be omitted, `deny_unknown_fields` refuses keys that are not fields at all.

### A test proves it for a nested type, not only the envelope

Two tests: one for a misspelled key on a nested struct (`Column`), one for a misspelled key inside an enum struct-variant (`ColumnConstraint::PrimaryKey`). Both assert the serde message contains ``unknown field `<misspelled>` `` rather than merely that parsing failed -- see the finding below for why that distinction is the whole point.

Evidence: `tests/a_failure_survives_the_round_trip.rs`. The tests were added to the existing round-trip file rather than a new one because they are the other half of the envelope test they pair with, and splitting the pair across files is how the two stop being read together. The helper panics if its `.replace` matched nothing, so a future rename of a schema field turns these tests red rather than leaving them asserting against an unedited fixture.

### Verify non-vacuous by removing an attribute and confirming the test fails

Two attributes were removed and restored rather than one, because the two exercise different serde machinery: a plain struct field and a field inside an externally-tagged enum's struct variant. Confirming the struct case alone would have left the enum case resting on an assumption -- that container-level `deny_unknown_fields` reaches through into struct-variant field lists. That was the single fact capable of changing the shape of this fix, so it was tested directly rather than taken from documentation.

Evidence: removing `Column`'s attribute failed `a_misspelled_key_on_a_nested_schema_type_is_refused` with `decl_types parsed as though it were decl_type; the field was dropped and the fixture now tests something other than what it reads as`. Removing `ColumnConstraint`'s failed `a_misspelled_key_inside_an_enum_variant_is_refused` with `on_conflcit parsed as though it were on_conflict`. Both restored; every gate run below was made after restoration, and the file carries exactly seventeen attributes.

### Both committed fixtures still load and still reproduce their recorded failures

Evidence: `forger corpus: 2 fixtures, 0 failing, 3.9ms total`, with both `336-a-rebuild-refired-a-trigger-over-copied-rows.json` and `341-a-rebuild-dropped-on-delete-cascade.json` reported `ok`. That `ok` is byte-exact message equality, not a soft pass -- `Regression::run` accepts only `Err(ProbeError::Failed(reported))` where `reported == self.expected_failure`.

No round-trip defect was surfaced, and structurally none was possible: with no `rename`, no `skip_serializing`/`skip_deserializing` and no `flatten` in the file, serialization can only emit names that are fields, so tightening the reader cannot refuse what the writer produces. The two green fixtures are corroboration of that argument rather than the proof of it.

## The finding worth more than the fix

**The natural way to write this test would have been vacuous, in exactly the shape this issue is about.**

The first enum-variant test misspelled `autoincrement`, a required `bool`. With `ColumnConstraint`'s attribute removed, that test *still* errored -- as ``missing field `autoincrement` `` -- because a required non-`Option` field cannot be silently absent. So an assertion of `matches!(Err(CorpusError::Parse(_)))` would have passed with the guard gone.

The real gap is **`Option` fields**, where serde supplies `None` for a missing key whether or not `#[serde(default)]` is written. Retargeting to `on_conflict` produced a genuine silent drop. Both tests now assert on the serde message text for that reason.

This matters beyond the test: `on_conflict` going missing *is* the whole of `Trait::ColumnOnConflict`, and it changes what an `INSERT` does to rows that are already there.

## Follow-on, filed separately

`matches!(Err(CorpusError::Parse(_)))` is precisely how the pre-existing envelope test `a_misspelled_key_is_refused_rather_than_ignored` is written. By the argument above, that test may pass with `Regression`'s own attribute removed -- which would make the test that motivated this entire issue vacuous itself. Not changed here, because it is out of this PR's stated scope and deserves its own verification rather than a drive-by edit.

## Not done

- `corpus.rs`, `oracle.rs` and `registry/` untouched -- no collision with PR #369, which is open on the same crate.
- Two files, additions only, 131 lines.

## One correction made during review

The first commit message said "eight enums are inert." That was wrong -- `Trait` is also all unit variants, making it nine; eight is the count of *live* containers. Caught in self-review, commit message and articulation amended, quality gate re-run on the new sha. Worth stating plainly given that the entire subject of this fix is an artifact whose prose says something other than what it is.