### PR TITLE
feat(#357): forger reports what it executed, and says what broke in words

### DIFF
--- a/crates/smugglr-forger/Cargo.toml
+++ b/crates/smugglr-forger/Cargo.toml
@@ -45,3 +45,10 @@ thiserror = "2"
 # reads, which is the whole thing this reporting exists to prevent.
 name = "corpus_runs"
 harness = false
+
+[[test]]
+# Same reason, and it is the requirement rather than a nicety here: FR-FORGER-007
+# asks for the schemas exercised and the probes executed to be reported on a
+# *passing* run, which under the default harness is a report printed into a void.
+name = "execution_census"
+harness = false

--- a/crates/smugglr-forger/src/census.rs
+++ b/crates/smugglr-forger/src/census.rs
@@ -1,0 +1,940 @@
+//! What a run actually executed, counted and written down.
+//!
+//! An exit code cannot tell "ran and passed" apart from "ran nothing", and the
+//! exit code is all anyone reads. A harness that can report success on zero
+//! probes is worse than no harness, because it certifies. FR-FORGER-007.
+//!
+//! This workspace has shipped that failure four times, by four unrelated
+//! mechanisms: a CI job that never runs `wasm-pack test`, a host clippy run
+//! that reports clean on a crate `cfg`'d out of existence, a workspace member
+//! outside `default-members` and therefore outside every default-scoped job,
+//! and libtest capturing the stdout of a passing test. Four layers, one
+//! outcome. So the count is not decoration: it is the only thing that
+//! distinguishes the two states.
+//!
+//! # The three phases, and why the third one is the whole point
+//!
+//! A counter that counts its own loop is the same defect in a new costume:
+//! [`Trait::ALL`] is a fixed-size array, so a loop over it cannot produce zero,
+//! and a probe stubbed to `Ok(())` would still be counted once per pass. So
+//! [`Census::take`] runs each probe three times and judges the answers:
+//!
+//! * **case** -- the trait's own schema, seeded, probed. It must hold.
+//! * **differential** -- the union of all eight case schemas, run through
+//!   [`differential`] with a transformation that changes nothing. Both arms
+//!   must hold and nothing may diverge.
+//! * **empty** -- the same probe, against a database with nothing in it at all.
+//!   It must **not** hold.
+//!
+//! The empty phase is the liveness check, and it works because of the property
+//! this crate is built on: an empty database is green on every behavioural
+//! assertion ever written, so a probe that reports "held" against one is not
+//! asserting anything. A probe stubbed out, short-circuited or emptied passes
+//! the first two phases and fails this one, by name.
+//!
+//! # What the baseline catches that nothing else does
+//!
+//! [`Trait::ALL`] is documented as scaffolding rather than enforcement, and
+//! every existing guard in this crate iterates it -- so dropping a variant from
+//! that array makes all of them exercise less and stay green, which is the
+//! coverage gap arriving from inside. A [`Baseline`] is keyed by trait name and
+//! requires every recorded trait to appear, so a variant that stops being
+//! exercised is a named failure rather than a smaller green number.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::error::{BoxError, ForgeError};
+use crate::failure::{reads, Finding};
+use crate::fixture::{Backing, Fixture, Route};
+use crate::oracle::{differential, Divergence, Outcome, Report};
+use crate::registry::TraitCase;
+use crate::schema::{Schema, Trait};
+
+/// Which of the three phases an observation came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Phase {
+    /// The trait's own case schema, stood up and seeded.
+    Case,
+    /// The differential's transformed arm.
+    Transformed,
+    /// The differential's arm built from scratch.
+    FromScratch,
+    /// A database with nothing in it. The probe must refuse.
+    Empty,
+}
+
+impl Phase {
+    /// The name used in the run report. Fixed width is the caller's problem.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Phase::Case => "case",
+            Phase::Transformed => "transformed",
+            Phase::FromScratch => "from-scratch",
+            Phase::Empty => "empty",
+        }
+    }
+}
+
+impl fmt::Display for Phase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One probe, run once, and what it said.
+#[derive(Debug, Clone)]
+pub struct Observation {
+    pub kind: Trait,
+    pub phase: Phase,
+    pub outcome: Outcome,
+}
+
+/// One trait's share of a run.
+#[derive(Debug, Clone)]
+pub struct TraitTally {
+    pub kind: Trait,
+    /// Databases stood up from a schema carrying this trait.
+    pub schemas: usize,
+    /// Probes executed for it, across every phase.
+    pub probes: usize,
+    /// What each of them said, in the order they ran.
+    pub observations: Vec<Observation>,
+}
+
+/// Everything one run executed.
+///
+/// Built by [`take`](Self::take) and read by whoever reports it. The tallies
+/// are derived from the observations rather than from [`Trait::ALL`], on
+/// purpose: the census reports what was observed, and a trait that stopped
+/// being exercised has to be able to show up as absent.
+#[derive(Debug, Clone)]
+pub struct Census {
+    observations: Vec<Observation>,
+    schemas: BTreeMap<Trait, usize>,
+    schemas_exercised: usize,
+    differential: Report,
+}
+
+impl Census {
+    /// Run every phase and record what happened.
+    ///
+    /// `backing` is the caller's, for the reason [`differential`] takes one:
+    /// forger cannot know whether a consumer's work touches the filesystem.
+    pub fn take(backing: Backing) -> Result<Census, ForgeError> {
+        let mut observations = Vec::new();
+        let mut schemas: BTreeMap<Trait, usize> = BTreeMap::new();
+        let mut schemas_exercised = 0usize;
+
+        // Phase one: each case on its own, which is the smallest database each
+        // probe can say anything about.
+        for kind in Trait::ALL {
+            let case = TraitCase::for_trait(kind);
+            let mut fixture = Fixture::new(backing)?;
+            fixture.bring_to(Route::Schema(&case.schema))?;
+            schemas_exercised += 1;
+            *schemas.entry(kind).or_default() += 1;
+
+            let outcome = match case.seed(fixture.conn()) {
+                Ok(()) => Outcome::of(case.probe(fixture.conn())),
+                Err(error) => Outcome::NothingToObserve(format!("the seed did not take: {error}")),
+            };
+            observations.push(Observation {
+                kind,
+                phase: Phase::Case,
+                outcome,
+            });
+        }
+
+        // Phase two: the oracle itself, over a schema carrying all eight, with
+        // a transformation that changes nothing. Both arms are stood up from a
+        // schema, so both count.
+        let union = every_trait_schema();
+        let mut unchanged = |_: &mut Connection| -> Result<(), BoxError> { Ok(()) };
+        let differential = differential(
+            backing,
+            &union,
+            &union,
+            &mut unchanged,
+            std::iter::empty::<&str>(),
+        )?;
+        schemas_exercised += 2;
+        for outcome in &differential.traits {
+            *schemas.entry(outcome.kind).or_default() += 2;
+            observations.push(Observation {
+                kind: outcome.kind,
+                phase: Phase::Transformed,
+                outcome: outcome.transformed.clone(),
+            });
+            observations.push(Observation {
+                kind: outcome.kind,
+                phase: Phase::FromScratch,
+                outcome: outcome.from_scratch.clone(),
+            });
+        }
+
+        // Phase three: the floor. No schema, no rows, nothing -- and every
+        // probe is required to notice. See the module docs.
+        for kind in Trait::ALL {
+            let case = TraitCase::for_trait(kind);
+            let fixture = Fixture::new(backing)?;
+            observations.push(Observation {
+                kind,
+                phase: Phase::Empty,
+                outcome: Outcome::of(case.probe_against(&case.schema, fixture.conn())),
+            });
+        }
+
+        Ok(Census {
+            observations,
+            schemas,
+            schemas_exercised,
+            differential,
+        })
+    }
+
+    /// Every probe that ran, in the order it ran.
+    pub fn observations(&self) -> &[Observation] {
+        &self.observations
+    }
+
+    /// Databases stood up from a schema. The empty-database phase is not one of
+    /// them, which is the point of it.
+    pub fn schemas_exercised(&self) -> usize {
+        self.schemas_exercised
+    }
+
+    /// Probes executed, across every trait and phase.
+    pub fn probes(&self) -> usize {
+        self.observations.len()
+    }
+
+    /// What the oracle said, for the soundness verdict and the divergences.
+    pub fn differential(&self) -> &Report {
+        &self.differential
+    }
+
+    /// The run broken down by trait, in [`Trait`] order.
+    pub fn tallies(&self) -> Vec<TraitTally> {
+        let mut by_trait: BTreeMap<Trait, Vec<Observation>> = BTreeMap::new();
+        for observation in &self.observations {
+            by_trait
+                .entry(observation.kind)
+                .or_default()
+                .push(observation.clone());
+        }
+        by_trait
+            .into_iter()
+            .map(|(kind, observations)| TraitTally {
+                kind,
+                schemas: self.schemas.get(&kind).copied().unwrap_or_default(),
+                probes: observations.len(),
+                observations,
+            })
+            .collect()
+    }
+
+    /// Everything about this run that should stop a build.
+    ///
+    /// The order is the order a reader needs it in: nothing ran at all, then
+    /// the baseline being unsound (which makes every comparison meaningless),
+    /// then probes that are not asserting, then what actually diverged.
+    pub fn anomalies(&self) -> Vec<Anomaly> {
+        if self.observations.is_empty() {
+            return vec![Anomaly::NothingRan];
+        }
+
+        let mut found = Vec::new();
+        for outcome in self.differential.unsound_baseline() {
+            found.push(Anomaly::BaselineUnsound {
+                kind: outcome.kind,
+                outcome: outcome.from_scratch.clone(),
+            });
+        }
+        for observation in &self.observations {
+            match observation.phase {
+                Phase::Empty if observation.outcome == Outcome::Held => {
+                    found.push(Anomaly::GreenOnAnEmptyDatabase {
+                        kind: observation.kind,
+                    })
+                }
+                Phase::Case if observation.outcome != Outcome::Held => {
+                    found.push(Anomaly::CaseDidNotHold {
+                        kind: observation.kind,
+                        outcome: observation.outcome.clone(),
+                    })
+                }
+                Phase::Transformed if observation.outcome != Outcome::Held => {
+                    found.push(Anomaly::TransformedDidNotHold {
+                        kind: observation.kind,
+                        outcome: observation.outcome.clone(),
+                    })
+                }
+                _ => {}
+            }
+        }
+        for divergence in self.differential.divergences() {
+            found.push(Anomaly::Diverged(divergence));
+        }
+        found
+    }
+}
+
+/// The union of every case schema: one schema carrying all eight traits.
+///
+/// The cases name their tables distinctly, so this is a concatenation rather
+/// than a merge, and each probe still finds its own construct by reading the
+/// schema.
+pub fn every_trait_schema() -> Schema {
+    let mut all = Schema::default();
+    for kind in Trait::ALL {
+        all.tables.extend(TraitCase::for_trait(kind).schema.tables);
+    }
+    all.validate()
+        .expect("the union of the case schemas is one SQLite would accept");
+    all
+}
+
+// ---------------------------------------------------------------------------
+// Anomalies
+// ---------------------------------------------------------------------------
+
+/// Something about a run that should stop a build.
+#[derive(Debug, Clone)]
+pub enum Anomaly {
+    /// No probe ran at all. Not reachable from a healthy [`Census::take`] --
+    /// which is exactly why it is a value the type can hold and a test can
+    /// construct, rather than a branch in somebody's `main`.
+    NothingRan,
+    /// A probe reported that a database with nothing in it behaves the way the
+    /// schema says. It does not; the probe has stopped asserting.
+    GreenOnAnEmptyDatabase { kind: Trait },
+    /// The trait's own case, seeded and probed, did not hold. Nothing was
+    /// transformed here, so this is the case itself being wrong.
+    CaseDidNotHold { kind: Trait, outcome: Outcome },
+    /// The arm built from the target schema and never transformed did not hold.
+    BaselineUnsound { kind: Trait, outcome: Outcome },
+    /// The transformed arm did not hold, under a transformation that changes
+    /// nothing.
+    TransformedDidNotHold { kind: Trait, outcome: Outcome },
+    /// The two arms answered differently, under a transformation that changes
+    /// nothing.
+    Diverged(Divergence),
+}
+
+impl Anomaly {
+    /// The anomaly as a [`Finding`], where it is about one trait.
+    pub fn finding(&self) -> Option<Finding> {
+        match self {
+            Anomaly::NothingRan => None,
+            Anomaly::Diverged(divergence) => match divergence {
+                Divergence::Trait(outcome) => Some(Finding {
+                    kind: outcome.kind,
+                    headline: "the two arms answered differently, and nothing was changed between \
+                               them."
+                        .to_string(),
+                    before: format!(
+                        "the arm built from scratch: {}",
+                        reads(&outcome.from_scratch)
+                    ),
+                    after: format!(
+                        "the arm a do-nothing transformation ran over: {}",
+                        reads(&outcome.transformed)
+                    ),
+                    consequence:
+                        "the two arms of the oracle disagree with no transformation between them, \
+                         so the oracle is measuring itself rather than anything a caller does."
+                            .to_string(),
+                }),
+                Divergence::Table { .. } => None,
+            },
+            Anomaly::GreenOnAnEmptyDatabase { kind } => Some(Finding {
+                kind: *kind,
+                headline: "its probe reports that an empty database behaves correctly.".to_string(),
+                before: "on a database carrying the trait, seeded: the probe held, which is what \
+                         it is supposed to say."
+                    .to_string(),
+                after: "on a database with no tables, no rows and no schema at all: the probe \
+                        held again."
+                    .to_string(),
+                consequence:
+                    "nothing can behave correctly with nothing in it, so this probe is asserting \
+                     nothing and every green it has reported is a statement about nothing. Look \
+                     for an assertion that was removed, short-circuited, or left returning Ok."
+                        .to_string(),
+            }),
+            Anomaly::CaseDidNotHold { kind, outcome } => Some(Finding {
+                kind: *kind,
+                headline: "its own case does not hold, before any transformation is involved."
+                    .to_string(),
+                before: "the registry's schema for this trait, stood up by plain CREATE TABLE and \
+                         seeded: that is all that happened."
+                    .to_string(),
+                after: reads(outcome),
+                consequence:
+                    "the case, the seed or the probe is wrong about SQLite. Nothing measured \
+                     against this trait means anything until it holds here."
+                        .to_string(),
+            }),
+            Anomaly::BaselineUnsound { kind, outcome } => Some(Finding {
+                kind: *kind,
+                headline: "the arm nobody transformed did not hold.".to_string(),
+                before: "the union of every case schema, stood up by plain CREATE TABLE and \
+                         seeded, with no transformation anywhere near it."
+                    .to_string(),
+                after: reads(outcome),
+                consequence:
+                    "the comparison has no sound side. Two arms that break the same way do not \
+                     diverge, so this run could report clean while losing everything."
+                        .to_string(),
+            }),
+            Anomaly::TransformedDidNotHold { kind, outcome } => Some(Finding {
+                kind: *kind,
+                headline: "it did not hold after a transformation that changes nothing."
+                    .to_string(),
+                before: "the union of every case schema, seeded, then handed to a closure that \
+                         returns immediately without touching the connection."
+                    .to_string(),
+                after: reads(outcome),
+                consequence:
+                    "seeding and probing the same database twice gave two answers, so something \
+                     in the harness is order-dependent rather than deterministic."
+                        .to_string(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for Anomaly {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Anomaly::NothingRan => f.write_str(
+                "  no probe ran at all.\n\n    A census with no observations in it is a harness \
+                 that has become a no-op, and\n    nothing about a green exit code would say so. \
+                 Check that the trait registry\n    is still being iterated and that the run \
+                 reached the phases below it.\n",
+            ),
+            // A table present in one arm and not the other is not about a
+            // trait, so it has no finding and gets the oracle's rendering.
+            Anomaly::Diverged(divergence @ Divergence::Table { .. }) => {
+                f.write_str(&crate::failure::render_divergence(divergence))
+            }
+            trait_shaped => f.write_str(
+                &trait_shaped
+                    .finding()
+                    .expect("every other anomaly is about one trait")
+                    .render(),
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The baseline
+// ---------------------------------------------------------------------------
+
+/// What a recorded baseline says about itself, written into the file so the
+/// file explains its own maintenance.
+pub const BASELINE_NOTE: &str = "The floor under forger's execution accounting (FR-FORGER-007). \
+     Each entry is the number of probes that trait executed on the run that recorded this file, \
+     and the census fails when a trait executes fewer -- or stops being executed at all. Raise \
+     it deliberately: run the census with FORGER_RECORD_BASELINE=1 and commit the rewritten file \
+     in the same change as the work that earned the new number. Lowering an entry is how coverage \
+     leaves without anyone noticing, so a decrease is reported as a decrease.";
+
+/// The recorded floor: how many probes each trait executed, last time somebody
+/// said so on purpose.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Baseline {
+    /// What this file is and how it is raised, in the file rather than in a
+    /// comment JSON cannot carry.
+    pub note: String,
+    /// One entry per trait, in [`Trait`] order.
+    pub traits: Vec<BaselineEntry>,
+}
+
+/// One trait's floor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BaselineEntry {
+    #[serde(rename = "trait")]
+    pub kind: Trait,
+    pub probes: usize,
+}
+
+impl Baseline {
+    /// The baseline a run would record: exactly what it executed.
+    pub fn of(census: &Census) -> Baseline {
+        Baseline {
+            note: BASELINE_NOTE.to_string(),
+            traits: census
+                .tallies()
+                .into_iter()
+                .map(|tally| BaselineEntry {
+                    kind: tally.kind,
+                    probes: tally.probes,
+                })
+                .collect(),
+        }
+    }
+
+    /// Serialize, pretty-printed and newline-terminated so a committed baseline
+    /// diffs by line rather than as one wall. The same choice
+    /// [`Regression`](crate::corpus::Regression) makes, for the same reason.
+    pub fn to_json(&self) -> String {
+        let mut json = serde_json::to_string_pretty(self)
+            // Plain owned fields with derived impls and no map keys.
+            .expect("a Baseline serializes");
+        json.push('\n');
+        json
+    }
+
+    /// Read one from disk.
+    ///
+    /// A missing file is its own refusal rather than an empty baseline. An
+    /// absent floor that read as zero would let a run with no probes in it pass
+    /// the one check written to prevent exactly that.
+    pub fn load(path: &Path) -> Result<Baseline, BaselineError> {
+        let json = match fs::read_to_string(path) {
+            Ok(json) => json,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(BaselineError::Absent {
+                    path: path.to_path_buf(),
+                })
+            }
+            Err(error) => return Err(BaselineError::Read(error)),
+        };
+        serde_json::from_str(&json).map_err(BaselineError::Parse)
+    }
+
+    /// Write one to disk.
+    pub fn store(&self, path: &Path) -> Result<(), BaselineError> {
+        fs::write(path, self.to_json()).map_err(BaselineError::Write)
+    }
+
+    /// Every way the run fell short of the floor.
+    ///
+    /// An empty result is the only thing that should let a build through.
+    pub fn compare(&self, census: &Census) -> Vec<Shortfall> {
+        if census.probes() == 0 {
+            // Everything else would be noise under this one.
+            return vec![Shortfall::NothingRan];
+        }
+        if self.traits.is_empty() {
+            return vec![Shortfall::NoFloorRecorded];
+        }
+
+        let mut found = Vec::new();
+        let mut recorded: BTreeMap<Trait, usize> = BTreeMap::new();
+        for entry in &self.traits {
+            if recorded.insert(entry.kind, entry.probes).is_some() {
+                found.push(Shortfall::RecordedTwice { kind: entry.kind });
+            }
+        }
+
+        let executed: BTreeMap<Trait, usize> = census
+            .tallies()
+            .into_iter()
+            .map(|tally| (tally.kind, tally.probes))
+            .collect();
+
+        for (kind, floor) in &recorded {
+            match executed.get(kind) {
+                None => found.push(Shortfall::Missing {
+                    kind: *kind,
+                    recorded: *floor,
+                }),
+                Some(0) => found.push(Shortfall::RanNothing { kind: *kind }),
+                Some(count) if count < floor => found.push(Shortfall::Below {
+                    kind: *kind,
+                    recorded: *floor,
+                    executed: *count,
+                }),
+                Some(_) => {}
+            }
+        }
+        for (kind, count) in &executed {
+            if !recorded.contains_key(kind) {
+                found.push(Shortfall::Unrecorded {
+                    kind: *kind,
+                    executed: *count,
+                });
+            }
+        }
+        found
+    }
+}
+
+/// One way a run fell short of its recorded floor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Shortfall {
+    /// No probe ran. Reported alone, because every other reading of an empty
+    /// run is a consequence of this one.
+    NothingRan,
+    /// The baseline records no traits, so it is a floor under nothing.
+    NoFloorRecorded,
+    /// The baseline lists a trait twice, so one of the two numbers is a floor
+    /// nobody is enforcing.
+    RecordedTwice { kind: Trait },
+    /// A recorded trait executed no probes.
+    RanNothing { kind: Trait },
+    /// A recorded trait executed fewer probes than it used to.
+    Below {
+        kind: Trait,
+        recorded: usize,
+        executed: usize,
+    },
+    /// A recorded trait did not appear in the run at all.
+    Missing { kind: Trait, recorded: usize },
+    /// The run executed probes for a trait the baseline does not list.
+    Unrecorded { kind: Trait, executed: usize },
+}
+
+impl fmt::Display for Shortfall {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Shortfall::NothingRan => f.write_str(
+                "no probes executed. This run asserted nothing about anything, and an exit code \
+                 alone would have been indistinguishable from a clean one.",
+            ),
+            Shortfall::NoFloorRecorded => f.write_str(
+                "the baseline file records no traits, so it is a floor under nothing. Record one \
+                 with FORGER_RECORD_BASELINE=1.",
+            ),
+            Shortfall::RecordedTwice { kind } => write!(
+                f,
+                "the baseline lists {kind:?} twice, so one of the two numbers is being ignored. \
+                 Re-record it with FORGER_RECORD_BASELINE=1."
+            ),
+            Shortfall::RanNothing { kind } => write!(
+                f,
+                "{kind:?} executed no probes. Its case is registered and nothing ran against it, \
+                 which is a trait that has quietly stopped being covered."
+            ),
+            Shortfall::Below {
+                kind,
+                recorded,
+                executed,
+            } => write!(
+                f,
+                "{kind:?} executed {executed} probes, and the recorded floor is {recorded}. \
+                 Coverage went down. If that is deliberate, say so by re-recording the baseline \
+                 in the same change; if it is not, an assertion or a phase has gone missing."
+            ),
+            Shortfall::Missing { kind, recorded } => write!(
+                f,
+                "{kind:?} did not run at all, and the baseline records {recorded} probes for it. \
+                 A trait that stops being iterated takes its coverage with it and every other \
+                 check in this crate stays green, because they all iterate the same list."
+            ),
+            Shortfall::Unrecorded { kind, executed } => write!(
+                f,
+                "{kind:?} executed {executed} probes and the baseline does not list it. The \
+                 baseline is stale: re-record it with FORGER_RECORD_BASELINE=1 so the new trait \
+                 has a floor of its own."
+            ),
+        }
+    }
+}
+
+/// What can go wrong reading a recorded baseline.
+#[derive(Debug, Error)]
+pub enum BaselineError {
+    #[error(
+        "no baseline recorded at {}. The census has nothing to compare against, and an absent \
+         floor must not read as a floor of zero -- that is the check being skipped rather than \
+         passed. Record one with FORGER_RECORD_BASELINE=1 and commit it.",
+        .path.display()
+    )]
+    Absent { path: PathBuf },
+
+    #[error("reading the baseline: {0}")]
+    Read(#[source] std::io::Error),
+
+    /// Kept apart from [`Read`](Self::Read) rather than folded into it: this
+    /// change exists because failure output that misdescribes what happened is
+    /// worse than none, and "reading the baseline: permission denied" on a
+    /// failed write is exactly that.
+    #[error("writing the baseline: {0}")]
+    Write(#[source] std::io::Error),
+
+    #[error("the baseline is not the JSON a Baseline parses from: {0}")]
+    Parse(#[source] serde_json::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::failure::promise;
+
+    fn census() -> Census {
+        Census::take(Backing::Memory).expect("the census runs")
+    }
+
+    /// The run this crate's reporting is about: every trait, three phases, and
+    /// nothing wrong with any of it.
+    #[test]
+    fn a_census_covers_every_trait_in_every_phase() {
+        let census = census();
+        let tallies = census.tallies();
+
+        assert_eq!(tallies.len(), Trait::ALL.len());
+        for tally in &tallies {
+            let phases: Vec<Phase> = tally
+                .observations
+                .iter()
+                .map(|observation| observation.phase)
+                .collect();
+            assert_eq!(
+                phases,
+                vec![
+                    Phase::Case,
+                    Phase::Transformed,
+                    Phase::FromScratch,
+                    Phase::Empty
+                ],
+                "{:?}",
+                tally.kind
+            );
+            assert_eq!(tally.schemas, 3, "{:?}", tally.kind);
+        }
+        assert_eq!(census.schemas_exercised(), Trait::ALL.len() + 2);
+        assert_eq!(census.probes(), Trait::ALL.len() * 4);
+    }
+
+    /// The floor phase, asserted rather than assumed: no probe in the registry
+    /// reports that an empty database behaves.
+    ///
+    /// If this ever fails it is not this test that is wrong -- it is a probe
+    /// that has stopped asserting, and the census is the thing that would have
+    /// caught it in CI.
+    #[test]
+    fn no_probe_holds_against_a_database_with_nothing_in_it() {
+        for observation in census().observations() {
+            if observation.phase == Phase::Empty {
+                assert_ne!(
+                    observation.outcome,
+                    Outcome::Held,
+                    "{:?} held against an empty database",
+                    observation.kind
+                );
+            }
+        }
+    }
+
+    /// A clean run is clean, and says so through the same accessor CI reads.
+    #[test]
+    fn a_clean_run_reports_no_anomalies() {
+        let census = census();
+        let anomalies = census.anomalies();
+        assert!(
+            anomalies.is_empty(),
+            "{}",
+            anomalies
+                .iter()
+                .map(|anomaly| anomaly.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        assert!(census.differential().baseline_is_sound());
+    }
+
+    /// A run compared against the baseline it just recorded is at its floor.
+    #[test]
+    fn a_run_meets_the_baseline_it_recorded() {
+        let census = census();
+        assert_eq!(Baseline::of(&census).compare(&census), Vec::new());
+    }
+
+    /// The check that catches a variant dropped from `Trait::ALL`, modelled
+    /// here by taking a trait out of a real run rather than out of the array.
+    ///
+    /// This is the shortfall worth having, because it is the one nothing else
+    /// in this crate would notice: every other guard here iterates `Trait::ALL`
+    /// too, so a variant removed from it makes all of them exercise less and
+    /// stay green. Measured, not assumed -- removing `Trait::Trigger` from the
+    /// array and running the whole suite leaves every pre-existing test
+    /// passing, including `all_lists_each_variant_once`,
+    /// `every_case_carries_a_valid_schema` and `probes_are_non_vacuous`.
+    #[test]
+    fn a_trait_that_stops_running_is_a_named_shortfall() {
+        let full = census();
+        let baseline = Baseline::of(&full);
+
+        let mut without_trigger = full.clone();
+        without_trigger
+            .observations
+            .retain(|observation| observation.kind != Trait::Trigger);
+        without_trigger.schemas.remove(&Trait::Trigger);
+
+        assert_eq!(
+            baseline.compare(&without_trigger),
+            vec![Shortfall::Missing {
+                kind: Trait::Trigger,
+                recorded: 4,
+            }]
+        );
+    }
+
+    /// The other direction: a trait the run exercises and the baseline does not
+    /// list is a stale baseline rather than free coverage.
+    #[test]
+    fn a_trait_the_baseline_does_not_list_is_a_stale_baseline() {
+        let census = census();
+        let mut baseline = Baseline::of(&census);
+        baseline.traits.retain(|entry| entry.kind != Trait::Trigger);
+
+        assert_eq!(
+            baseline.compare(&census),
+            vec![Shortfall::Unrecorded {
+                kind: Trait::Trigger,
+                executed: 4,
+            }]
+        );
+    }
+
+    /// A baseline that lists a trait twice is enforcing one of the two numbers
+    /// and ignoring the other, which is a floor nobody can read.
+    #[test]
+    fn a_baseline_listing_a_trait_twice_is_refused() {
+        let census = census();
+        let mut baseline = Baseline::of(&census);
+        baseline.traits.push(BaselineEntry {
+            kind: Trait::Trigger,
+            probes: 4,
+        });
+
+        assert_eq!(
+            baseline.compare(&census),
+            vec![Shortfall::RecordedTwice {
+                kind: Trait::Trigger
+            }]
+        );
+    }
+
+    /// Coverage going down is a failure, not a smaller number in a report.
+    #[test]
+    fn fewer_probes_than_recorded_is_a_shortfall() {
+        let census = census();
+        let mut baseline = Baseline::of(&census);
+        for entry in &mut baseline.traits {
+            entry.probes += 1;
+        }
+        let shortfalls = baseline.compare(&census);
+        assert_eq!(shortfalls.len(), Trait::ALL.len());
+        assert!(shortfalls.iter().all(|shortfall| matches!(
+            shortfall,
+            Shortfall::Below {
+                recorded: 5,
+                executed: 4,
+                ..
+            }
+        )));
+    }
+
+    /// The branch a healthy run can never reach, which is why it is tested
+    /// here rather than left as an unreachable `if` in somebody's `main`.
+    #[test]
+    fn a_census_that_observed_nothing_is_a_failure_rather_than_a_fast_pass() {
+        let mut empty = census();
+        empty.observations.clear();
+        empty.schemas.clear();
+        empty.schemas_exercised = 0;
+
+        assert_eq!(empty.probes(), 0);
+        assert!(matches!(
+            empty.anomalies().as_slice(),
+            [Anomaly::NothingRan]
+        ));
+        assert_eq!(
+            Baseline::of(&empty).compare(&empty),
+            vec![Shortfall::NothingRan]
+        );
+        // And against a real floor, still refused rather than trivially met.
+        assert_eq!(
+            Baseline::of(&census()).compare(&empty),
+            vec![Shortfall::NothingRan]
+        );
+    }
+
+    /// A baseline with nothing in it is a floor under nothing.
+    #[test]
+    fn a_baseline_recording_no_traits_is_refused() {
+        let census = census();
+        let hollow = Baseline {
+            note: BASELINE_NOTE.to_string(),
+            traits: Vec::new(),
+        };
+        assert_eq!(hollow.compare(&census), vec![Shortfall::NoFloorRecorded]);
+    }
+
+    /// A baseline that is not there is not a baseline of zero.
+    #[test]
+    fn an_absent_baseline_is_a_refusal() {
+        let error = Baseline::load(Path::new("does/not/exist/baseline.json"))
+            .expect_err("there is no file there");
+        assert!(matches!(error, BaselineError::Absent { .. }));
+        assert!(error.to_string().contains("FORGER_RECORD_BASELINE"));
+    }
+
+    /// The file round-trips, so a recorded baseline is one the next run can
+    /// read.
+    #[test]
+    fn a_baseline_round_trips_through_json() {
+        let baseline = Baseline::of(&census());
+        let json = baseline.to_json();
+        assert!(json.ends_with('\n'));
+        let parsed: Baseline = serde_json::from_str(&json).expect("it parses");
+        assert_eq!(parsed, baseline);
+    }
+
+    /// Every anomaly that is about a trait renders a finding that names it,
+    /// says what the trait promises, and carries a schema.
+    #[test]
+    fn every_trait_shaped_anomaly_renders_something_a_reader_can_act_on() {
+        let anomalies = [
+            Anomaly::GreenOnAnEmptyDatabase {
+                kind: Trait::Trigger,
+            },
+            Anomaly::CaseDidNotHold {
+                kind: Trait::TypelessColumn,
+                outcome: Outcome::Broke("it did not".into()),
+            },
+            Anomaly::BaselineUnsound {
+                kind: Trait::GeneratedStored,
+                outcome: Outcome::Erred("no such table".into()),
+            },
+            Anomaly::TransformedDidNotHold {
+                kind: Trait::ColumnOnConflict,
+                outcome: Outcome::NothingToObserve("empty".into()),
+            },
+        ];
+        for anomaly in anomalies {
+            let rendered = anomaly.to_string();
+            // The prose is wrapped to a column, so it is compared with the
+            // wrapping taken back out rather than line by line.
+            let flowed = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
+            let kind = anomaly.finding().expect("a trait-shaped anomaly").kind;
+            assert!(flowed.contains(&format!("{kind:?}")), "{rendered}");
+            assert!(
+                flowed.contains(
+                    &promise(kind)
+                        .split_whitespace()
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                ),
+                "{rendered}"
+            );
+            assert!(rendered.contains("schema()"), "{rendered}");
+            assert!(rendered.contains("before"), "{rendered}");
+            assert!(rendered.contains("after"), "{rendered}");
+        }
+    }
+}

--- a/crates/smugglr-forger/src/failure.rs
+++ b/crates/smugglr-forger/src/failure.rs
@@ -1,0 +1,1102 @@
+//! What a failure says, for someone who has never opened forger.
+//!
+//! A gate whose failures are unreadable trains its audience to re-run rather
+//! than read, and a gate people learn to bypass has negative value: it costs
+//! time and supplies false assurance. The reviewer this crate is for cannot
+//! re-derive a twelve-step rebuild by hand, so the failure message is the
+//! entire signal they get. FR-FORGER-008.
+//!
+//! Every failure this crate emits goes through [`Finding`], and a finding
+//! answers four questions in a fixed order: which trait, what it did before,
+//! what it did after, and what that means. Nothing here prints a diff of two
+//! generated blobs -- that comparison is the one [`oracle`](crate::oracle)
+//! refuses to make, for reasons written down there, and rendering it would
+//! quietly reintroduce it.
+//!
+//! # Why the schema is emitted as builder source rather than as DDL
+//!
+//! A reader who gets DDL can read it and cannot *run* it: to reproduce the
+//! failure they have to translate it back into a [`Schema`] by hand, and the
+//! translation is where the reproduction stops being the thing that failed.
+//! Emitting the builder chain means the block in the failure output is a block
+//! that goes in a test file. [`builder_source`] therefore refuses rather than
+//! degrades: where the builder cannot express a schema faithfully it says which
+//! table and why, and falls back to [`Schema::to_ddl`], which is honest about
+//! being a different artifact. A renderer that silently emitted
+//! almost-equivalent source would be handing someone a reproduction of a
+//! different bug.
+//!
+//! # Why the minimal schema is the registry's own
+//!
+//! [`TraitCase::schema`](crate::registry::TraitCase) is documented as "a schema
+//! carrying the trait, and as little else as the behaviour allows" -- it is
+//! already the minimal one, arrived at when the case was written, and shrinking
+//! a caller's schema at failure time would produce a second, less-tested
+//! answer to a question that is already answered.
+
+use std::fmt;
+
+use crate::oracle::{Arm, Divergence, Outcome, Report, TraitOutcome};
+use crate::registry::TraitCase;
+use crate::schema::{
+    Column, ColumnConstraint, ColumnType, DefaultValue, Generated, IndexedColumn, OnConflict,
+    Schema, SortOrder, Table, TableConstraint, Trait, Trigger, TriggerEvent, TriggerTiming,
+};
+
+/// How wide prose is wrapped. Narrow enough to stay readable in a CI log pane
+/// that nobody widens.
+const WIDTH: usize = 88;
+
+/// The label column every finding lines its answers up in.
+const LABEL: usize = 10;
+
+// ---------------------------------------------------------------------------
+// A finding
+// ---------------------------------------------------------------------------
+
+/// One failure, in the four parts a reader needs.
+///
+/// Constructed by whoever found it -- [`Divergence`] converts into one, and the
+/// [`census`](crate::census) builds its own -- so that every failure this crate
+/// emits has the same shape and the same four answers, whichever mechanism
+/// noticed.
+#[derive(Debug, Clone)]
+pub struct Finding {
+    /// The trait that failed. Named first, always: it is the only word in the
+    /// output a reader can search the codebase for.
+    pub kind: Trait,
+    /// One line saying what the run was doing when it looked.
+    pub headline: String,
+    /// What the database did *before* -- the arm nobody transformed, or the
+    /// case's own database, or whatever the unchanged side was.
+    pub before: String,
+    /// What it did *after*.
+    pub after: String,
+    /// What the difference means for anyone about to trust a green check.
+    pub consequence: String,
+}
+
+impl Finding {
+    /// The finding, rendered. Indented by two so it sits under a header.
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("  {:?} -- {}\n\n", self.kind, self.headline));
+        out.push_str(&labelled("the trait", promise(self.kind)));
+        out.push_str(&labelled("before", &self.before));
+        out.push_str(&labelled("after", &self.after));
+        out.push_str(&labelled("so", &self.consequence));
+        out.push('\n');
+        out.push_str(
+            "    the smallest schema that carries this trait, as the builder writes it --\n\
+             \x20   paste it into a test file and hand it to `differential` as both the start\n\
+             \x20   and the target schema. A transformation scoped to these tables reproduces\n\
+             \x20   the failure directly; one written against a wider schema needs the tables\n\
+             \x20   it expects added, or it will refuse to run rather than diverge:\n\n",
+        );
+        out.push_str(&indent(
+            &builder_source(&TraitCase::for_trait(self.kind).schema).to_string(),
+            8,
+        ));
+        out
+    }
+}
+
+impl fmt::Display for Finding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.render())
+    }
+}
+
+/// What a trait promises, in one sentence, for a reader who does not know what
+/// the variant name means.
+///
+/// Exhaustive with no catch-all arm, for the reason
+/// [`registry`](crate::registry) gives: a new [`Trait`] must not be able to
+/// arrive with a rendering that says nothing, and the compiler is what makes
+/// sure it cannot. It lives here rather than on [`Trait`] because it is prose
+/// for a failure report, and the model is where a feature is named rather than
+/// where it is explained.
+pub fn promise(kind: Trait) -> &'static str {
+    match kind {
+        Trait::ForeignKeyWithAction => {
+            "a foreign key declared ON DELETE CASCADE takes its children with the parent row, \
+             and one declared ON DELETE RESTRICT refuses the delete. A key rebuilt without its \
+             action still looks like a key and has quietly become NO ACTION -- no row count \
+             changes on the day of the migration."
+        }
+        Trait::GeneratedVirtual => {
+            "a GENERATED ALWAYS AS (...) VIRTUAL column computes its value on every read and \
+             stores nothing. Re-created as an ordinary column it occupies the same position and \
+             reads NULL, so anything copying rows by position either fails or writes into a \
+             column that refuses writes."
+        }
+        Trait::GeneratedStored => {
+            "a GENERATED ALWAYS AS (...) STORED column recomputes when its inputs move. \
+             Re-created as an ordinary column holding the value a rebuild copied into it, it is \
+             byte-identical in a row dump and has stopped computing -- only moving the input and \
+             re-reading tells them apart."
+        }
+        Trait::ColumnOnConflict => {
+            "a conflict algorithm on a column constraint decides what an INSERT does to the rows \
+             already there: REPLACE absorbs, IGNORE skips, ABORT undoes its statement, ROLLBACK \
+             takes the enclosing transaction with it. Dropping it changes a data outcome rather \
+             than a schema."
+        }
+        Trait::ExpressionDefault => {
+            "DEFAULT (expression) evaluates when a row is inserted. The parentheses are \
+             load-bearing: re-rendered without them the expression becomes the literal text of \
+             itself, which is either a syntax error or, worse, a string that looks like data."
+        }
+        Trait::TypelessColumn => {
+            "a column declared with no type at all has blank affinity and stores each value as \
+             what it is. A transformation that invents a type for it converts the values (TEXT) \
+             or leaves behaviour identical while changing the declaration (BLOB), and the second \
+             is invisible to every behavioural check."
+        }
+        Trait::Trigger => {
+            "a trigger fires when its table is written to. Dropping and re-creating a table \
+             takes its triggers with it and nothing complains -- and a rebuild that re-creates \
+             the trigger before copying the rows in fires it again over rows that were already \
+             audited."
+        }
+        Trait::DescendingPrimaryKey => {
+            "INTEGER PRIMARY KEY is the rowid under another name; INTEGER PRIMARY KEY DESC is \
+             not, so it allocates no key of its own and the table keeps a separate rowid \
+             underneath. Reconstructing one spelling as the other changes what an INSERT that \
+             omits the key does."
+        }
+    }
+}
+
+/// What one arm's outcome reads as, in prose rather than as a variant name.
+pub fn reads(outcome: &Outcome) -> String {
+    match outcome {
+        Outcome::Held => "it did what the target schema says it does".to_string(),
+        Outcome::Broke(message) => message.clone(),
+        Outcome::NothingToObserve(message) => format!(
+            "there was nothing there to observe, so the assertion would have been vacuous \
+             ({message})"
+        ),
+        Outcome::Erred(message) => format!(
+            "SQLite refused a statement the probe did not expect it to refuse, which usually \
+             means a table or column the target schema promises is no longer there ({message})"
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering a report
+// ---------------------------------------------------------------------------
+
+/// A whole [`Report`], rendered.
+///
+/// The soundness verdict comes first and comes out on every run, clean or not.
+/// A clean report over an unsound baseline is the most dangerous output this
+/// crate can produce -- it is a green check that means the two arms agreed
+/// about a database neither of them got right -- and burying that under the
+/// divergence list would put it where nobody looks.
+pub fn render_report(report: &Report) -> String {
+    let mut out = String::new();
+
+    match report.unsound_baseline().as_slice() {
+        [] => out.push_str(
+            "the baseline is sound: the arm built from the target schema and never transformed \
+             held on every trait, so the comparison below rests on something.\n",
+        ),
+        unsound => {
+            out.push_str(&fill(
+                "THE BASELINE IS NOT SOUND, so nothing below means anything. The arm nobody \
+                 transformed -- plain CREATE TABLE from the target schema, no migration \
+                 involved -- did not behave the way that schema says it does. Two arms that \
+                 break the same way do not disagree, so this run could report clean while \
+                 losing everything. Fix the target schema, the start schema or the probe before \
+                 reading any verdict here.",
+                0,
+            ));
+            for outcome in unsound {
+                out.push_str(&format!(
+                    "\n  {:?} in the arm built from scratch: {}\n",
+                    outcome.kind,
+                    reads(&outcome.from_scratch)
+                ));
+            }
+        }
+    }
+
+    let divergences = report.divergences();
+    if divergences.is_empty() {
+        out.push_str("no divergence: both arms answered every question the same way.\n");
+        return out;
+    }
+
+    out.push('\n');
+    out.push_str(&fill(
+        &format!(
+            "{} divergence(s) between the database your transformation produced and the same \
+             schema built from scratch:",
+            divergences.len()
+        ),
+        0,
+    ));
+    out.push_str("\n\n");
+    for divergence in &divergences {
+        out.push_str(&render_divergence(divergence));
+        out.push('\n');
+    }
+    out
+}
+
+/// One divergence, rendered.
+pub fn render_divergence(divergence: &Divergence) -> String {
+    match divergence {
+        Divergence::Trait(outcome) => finding_for(outcome).render(),
+        Divergence::Table { name, present_in } => {
+            let (had, lacked) = match present_in {
+                Arm::Transformed => (
+                    "the database your transformation produced",
+                    "the same schema built from scratch",
+                ),
+                Arm::FromScratch => (
+                    "the same schema built from scratch",
+                    "the database your transformation produced",
+                ),
+            };
+            let mut out = format!("  table {name:?} -- present in one arm and not the other.\n\n");
+            out.push_str(&labelled("before", &format!("{had} has it")));
+            out.push_str(&labelled("after", &format!("{lacked} does not")));
+            out.push_str(&labelled(
+                "so",
+                match present_in {
+                    Arm::FromScratch => {
+                        "the transformation lost a table the target schema declares. No \
+                         behavioural question can be asked of a table that is not there, so every \
+                         probe that would have touched it is reporting about nothing."
+                    }
+                    Arm::Transformed => {
+                        "the transformation left behind a table the target schema does not \
+                         declare. If it is bookkeeping your engine owns, name it in the \
+                         `ignore_tables` argument -- forger does not know which tables are yours."
+                    }
+                },
+            ));
+            out
+        }
+    }
+}
+
+/// The finding a diverged trait makes.
+fn finding_for(outcome: &TraitOutcome) -> Finding {
+    Finding {
+        kind: outcome.kind,
+        headline: "the two arms answered differently.".to_string(),
+        before: format!(
+            "the same schema built from scratch, never transformed: {}",
+            reads(&outcome.from_scratch)
+        ),
+        after: format!(
+            "the database your transformation produced: {}",
+            reads(&outcome.transformed)
+        ),
+        consequence:
+            "the transformation changed what this construct does. Nothing about the schema text \
+             has to differ for that to be true, which is why comparing DDL would not have caught \
+             it."
+            .to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Emitting a schema as builder source
+// ---------------------------------------------------------------------------
+
+/// A schema, written out for a reader.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Rendered {
+    /// Rust that compiles: paste it into a test file and it builds the schema
+    /// it was made from.
+    Builder(String),
+    /// The builder cannot express this schema faithfully. Says which part and
+    /// why, and falls back to DDL -- which is a different artifact and is
+    /// labelled as one rather than passed off as source.
+    Ddl { because: String, ddl: String },
+}
+
+impl Rendered {
+    /// The text itself, without the explanation a [`Ddl`](Self::Ddl) carries.
+    pub fn text(&self) -> &str {
+        match self {
+            Rendered::Builder(source) => source,
+            Rendered::Ddl { ddl, .. } => ddl,
+        }
+    }
+
+    /// Whether this is Rust a reader can paste.
+    pub fn is_builder(&self) -> bool {
+        matches!(self, Rendered::Builder(_))
+    }
+}
+
+impl fmt::Display for Rendered {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Rendered::Builder(source) => f.write_str(source),
+            Rendered::Ddl { because, ddl } => {
+                writeln!(
+                    f,
+                    "// The builder cannot express this schema: {because}\n\
+                     // What follows is the rendered DDL instead, which is SQL rather than Rust.\n"
+                )?;
+                f.write_str(ddl)
+            }
+        }
+    }
+}
+
+/// A schema as the builder writes it -- the authoring surface, not the model.
+///
+/// The output is an expression: the `use` lines are scoped inside it (legal
+/// inside a function body, and exactly the ones it needs, so it does not
+/// collect an unused-import warning wherever it lands), and it ends in
+/// `.build().expect(...)`. Wrap it in a function returning [`Schema`] and it
+/// compiles.
+///
+/// Refuses rather than degrades. Three of the model's shapes have no builder
+/// spelling -- a primary-key column carrying any other constraint, a
+/// column-level key with a conflict algorithm, and a typeless primary key --
+/// because `pk_int`/`pk_text`/`pk_col` take no attributes. Emitting
+/// almost-equivalent source for one of those would hand a reader a
+/// reproduction of a different schema, so it says so and gives DDL instead.
+pub fn builder_source(schema: &Schema) -> Rendered {
+    let mut needs = Needs::default();
+    let mut tables = Vec::with_capacity(schema.tables.len());
+    for table in &schema.tables {
+        match render_table(table, &mut needs) {
+            Ok(source) => tables.push(source),
+            Err(because) => {
+                return Rendered::Ddl {
+                    because,
+                    ddl: schema.to_ddl(),
+                }
+            }
+        }
+    }
+
+    let mut out = needs.use_lines();
+    out.push_str("schema()\n");
+    for table in tables {
+        out.push_str("    .table(\n");
+        out.push_str(&indent(&table, 8));
+        out.push_str("    )\n");
+    }
+    out.push_str("    .build()\n    .expect(\"a valid schema\")\n");
+    Rendered::Builder(out)
+}
+
+/// Which names the emitted source has to import. Tracked while rendering
+/// rather than guessed at afterwards, because an import the source does not use
+/// is a warning wherever `-D warnings` is set, and this crate's own tests are
+/// built that way.
+#[derive(Default)]
+struct Needs {
+    attr: bool,
+    column_type: bool,
+    default_value: bool,
+    indexed_column: bool,
+    on_conflict: bool,
+    referential_action: bool,
+    sort_order: bool,
+    table_constraint: bool,
+    trigger: bool,
+}
+
+impl Needs {
+    fn use_lines(&self) -> String {
+        let mut builder = vec!["schema", "table"];
+        if self.attr {
+            builder.push("Attr");
+        }
+        let mut model: Vec<&str> = Vec::new();
+        if self.column_type {
+            model.push("ColumnType::*");
+        }
+        if self.default_value {
+            model.push("DefaultValue");
+        }
+        if self.indexed_column {
+            model.push("IndexedColumn");
+        }
+        if self.on_conflict {
+            model.push("OnConflict");
+        }
+        if self.referential_action {
+            model.push("ReferentialAction");
+        }
+        if self.sort_order {
+            model.push("SortOrder");
+        }
+        if self.table_constraint {
+            model.push("TableConstraint");
+        }
+        if self.trigger {
+            model.extend(["Trigger", "TriggerEvent", "TriggerTiming"]);
+        }
+
+        let mut out = use_line("smugglr_forger::schema::builder", &builder);
+        if !model.is_empty() {
+            out.push_str(&use_line("smugglr_forger::schema", &model));
+        }
+        out.push('\n');
+        out
+    }
+}
+
+/// One `use` line, braced only when it needs to be.
+///
+/// A single-item brace group is what rustfmt removes, and the emitted source
+/// has to survive being pasted into a file somebody then formats -- so it is
+/// emitted the way rustfmt would leave it.
+fn use_line(path: &str, items: &[&str]) -> String {
+    match items {
+        [only] => format!("use {path}::{only};\n"),
+        many => format!("use {path}::{{{}}};\n", many.join(", ")),
+    }
+}
+
+/// One table's builder chain, or why it has no builder spelling.
+fn render_table(table: &Table, needs: &mut Needs) -> Result<String, String> {
+    let key = primary_key_column(table)?;
+    let mut out = format!("table({})\n", literal(&table.name));
+
+    for (index, column) in table.columns.iter().enumerate() {
+        if Some(index) == key.map(|(at, _)| at) {
+            let (autoincrement, order) = match key {
+                Some((_, constraint)) => constraint,
+                // `key` is Some here by the condition above.
+                None => unreachable!("the key column is the key column"),
+            };
+            out.push_str(&render_key_column(table, column, order, needs)?);
+            if autoincrement {
+                out.push_str("    .autoincrement()\n");
+            }
+        } else {
+            out.push_str(&render_column(column, needs));
+        }
+    }
+
+    for constraint in &table.constraints {
+        out.push_str(&render_table_constraint(constraint, needs));
+    }
+    for trigger in &table.triggers {
+        needs.trigger = true;
+        out.push_str(&format!(
+            "    .trigger({})\n",
+            indent_after_first(&render_trigger(trigger), 4)
+        ));
+    }
+    if table.strict {
+        out.push_str("    .strict()\n");
+    }
+    if table.without_rowid {
+        // Available only once a key exists, which `primary_key_column` and the
+        // table-level constraint below are between them responsible for. A
+        // WITHOUT ROWID table with no key is not a valid schema at all, so
+        // there is no third case.
+        if key.is_none() && !declares_table_level_key(table) {
+            return Err(format!(
+                "table {:?} is WITHOUT ROWID and declares no PRIMARY KEY, which the builder \
+                 refuses because SQLite does",
+                table.name
+            ));
+        }
+        out.push_str("    .without_rowid()\n");
+    }
+
+    // The chain is one expression; the caller wraps it in `.table(...)`.
+    Ok(trim_trailing_newline(out) + ",\n")
+}
+
+/// The column that declares the key, its position, whether it is
+/// `AUTOINCREMENT`, and which way it sorts.
+///
+/// `Err` where the model holds a key the builder has no spelling for. Those
+/// shapes are real -- `id INTEGER PRIMARY KEY NOT NULL` is ordinary SQLite --
+/// and the builder's `pk_*` constructors deliberately take no attributes, so
+/// there is nothing to emit that would round-trip.
+#[allow(clippy::type_complexity)]
+fn primary_key_column(table: &Table) -> Result<Option<(usize, (bool, SortOrder))>, String> {
+    let mut found: Option<(usize, (bool, SortOrder))> = None;
+    for (index, column) in table.columns.iter().enumerate() {
+        for constraint in &column.constraints {
+            let ColumnConstraint::PrimaryKey {
+                order,
+                autoincrement,
+                on_conflict,
+            } = constraint
+            else {
+                continue;
+            };
+            if on_conflict.is_some() {
+                return Err(format!(
+                    "column {:?}.{:?} declares PRIMARY KEY with a conflict algorithm, and the \
+                     builder's pk_int/pk_text/pk_col take no attributes",
+                    table.name, column.name
+                ));
+            }
+            if column.constraints.len() > 1 {
+                return Err(format!(
+                    "column {:?}.{:?} is the PRIMARY KEY and carries other constraints too, and \
+                     the builder's pk_int/pk_text/pk_col take no attributes",
+                    table.name, column.name
+                ));
+            }
+            if found.is_some() {
+                return Err(format!(
+                    "table {:?} declares more than one column-level PRIMARY KEY, which SQLite \
+                     refuses",
+                    table.name
+                ));
+            }
+            found = Some((index, (*autoincrement, *order)));
+        }
+    }
+    Ok(found)
+}
+
+fn declares_table_level_key(table: &Table) -> bool {
+    table
+        .constraints
+        .iter()
+        .any(|constraint| matches!(constraint, TableConstraint::PrimaryKey { .. }))
+}
+
+fn render_key_column(
+    table: &Table,
+    column: &Column,
+    order: SortOrder,
+    needs: &mut Needs,
+) -> Result<String, String> {
+    let name = literal(&column.name);
+    match (&column.decl_type, order) {
+        (Some(ColumnType::Integer), SortOrder::Asc) => Ok(format!("    .pk_int({name})\n")),
+        (Some(ColumnType::Text), SortOrder::Asc) => Ok(format!("    .pk_text({name})\n")),
+        (Some(decl_type), order) => {
+            needs.column_type = true;
+            needs.sort_order = true;
+            Ok(format!(
+                "    .pk_col({name}, {}, {})\n",
+                column_type(decl_type),
+                sort_order(order)
+            ))
+        }
+        // `pk_col` takes a ColumnType rather than an Option, so a key declared
+        // with no type at all has no spelling here.
+        (None, _) => Err(format!(
+            "column {:?}.{:?} is the PRIMARY KEY and is declared with no type, and the builder's \
+             pk_col takes one",
+            table.name, column.name
+        )),
+    }
+}
+
+fn render_column(column: &Column, needs: &mut Needs) -> String {
+    let name = literal(&column.name);
+    let attrs = render_attrs(column, needs);
+    match &column.decl_type {
+        Some(decl_type) => {
+            needs.column_type = true;
+            format!("    .col({name}, {}, {attrs})\n", column_type(decl_type))
+        }
+        None => format!("    .typeless({name}, {attrs})\n"),
+    }
+}
+
+/// A column's constraints as the flat attribute list the builder takes.
+///
+/// A conflict algorithm is not free-standing in SQLite -- it binds to the
+/// constraint in front of it -- and the builder writes that binding as the
+/// algorithm following the constraint. Emitting it that way is what makes the
+/// output round-trip: `attach_conflict` folds it back on.
+fn render_attrs(column: &Column, needs: &mut Needs) -> String {
+    let mut attrs: Vec<String> = Vec::new();
+    for constraint in &column.constraints {
+        match constraint {
+            ColumnConstraint::PrimaryKey { .. } => {
+                // Handled by the pk_* constructor; `primary_key_column` has
+                // already refused any shape where that is not enough.
+            }
+            ColumnConstraint::NotNull(algorithm) => {
+                attrs.push("Attr::NotNull".to_string());
+                attrs.extend(conflict_attr(*algorithm));
+            }
+            ColumnConstraint::Unique(algorithm) => {
+                attrs.push("Attr::Unique".to_string());
+                attrs.extend(conflict_attr(*algorithm));
+            }
+            ColumnConstraint::Check(expr) => {
+                attrs.push(format!("Attr::Check({}.into())", literal(expr)))
+            }
+            ColumnConstraint::Default(value) => {
+                needs.default_value = true;
+                attrs.push(format!("Attr::Default({})", default_value(value)));
+            }
+            ColumnConstraint::Collate(name) => {
+                attrs.push(format!("Attr::Collate({}.into())", literal(name)))
+            }
+            ColumnConstraint::Generated { expr, storage } => attrs.push(format!(
+                "Attr::{}({}.into())",
+                match storage {
+                    Generated::Virtual => "Virtual",
+                    Generated::Stored => "Stored",
+                },
+                literal(expr)
+            )),
+        }
+    }
+    if attrs.is_empty() {
+        return "[]".to_string();
+    }
+    needs.attr = true;
+    format!("[{}]", attrs.join(", "))
+}
+
+fn conflict_attr(algorithm: Option<OnConflict>) -> Option<String> {
+    algorithm.map(|algorithm| {
+        format!(
+            "Attr::OnConflict{}",
+            match algorithm {
+                OnConflict::Rollback => "Rollback",
+                OnConflict::Abort => "Abort",
+                OnConflict::Fail => "Fail",
+                OnConflict::Ignore => "Ignore",
+                OnConflict::Replace => "Replace",
+            }
+        )
+    })
+}
+
+/// A table-level constraint.
+///
+/// A foreign key gets the sugar, because that is how anyone authoring one
+/// writes it and the referential action is the part transformations lose. A
+/// composite key without a conflict algorithm gets `pk_composite`, which is
+/// what puts the builder into the state `without_rowid` needs. Everything else
+/// goes through `.constraint`, the verbatim escape hatch -- there is nothing
+/// lost by it, since the value emitted is the model value itself.
+fn render_table_constraint(constraint: &TableConstraint, needs: &mut Needs) -> String {
+    match constraint {
+        TableConstraint::ForeignKey(fk) => {
+            let mut out = format!(
+                "    .fk({}, {}, {})\n",
+                string_array(&fk.columns),
+                literal(&fk.parent_table),
+                string_array(&fk.parent_columns)
+            );
+            if let Some(action) = fk.on_delete {
+                needs.referential_action = true;
+                out.push_str(&format!("    .on_delete(ReferentialAction::{action:?})\n"));
+            }
+            if let Some(action) = fk.on_update {
+                needs.referential_action = true;
+                out.push_str(&format!("    .on_update(ReferentialAction::{action:?})\n"));
+            }
+            out
+        }
+        TableConstraint::PrimaryKey {
+            columns,
+            on_conflict: None,
+        } => {
+            needs.indexed_column = true;
+            needs.sort_order = true;
+            format!("    .pk_composite({})\n", indexed_columns(columns))
+        }
+        other => {
+            needs.table_constraint = true;
+            format!(
+                "    .constraint({})\n",
+                indent_after_first(&table_constraint(other, needs), 4)
+            )
+        }
+    }
+}
+
+fn table_constraint(constraint: &TableConstraint, needs: &mut Needs) -> String {
+    match constraint {
+        TableConstraint::PrimaryKey {
+            columns,
+            on_conflict,
+        } => {
+            needs.indexed_column = true;
+            needs.sort_order = true;
+            format!(
+                "TableConstraint::PrimaryKey {{\n    columns: {},\n    on_conflict: {},\n}}",
+                indexed_columns_vec(columns),
+                conflict_option(*on_conflict, needs)
+            )
+        }
+        TableConstraint::Unique {
+            columns,
+            on_conflict,
+        } => {
+            needs.indexed_column = true;
+            needs.sort_order = true;
+            format!(
+                "TableConstraint::Unique {{\n    columns: {},\n    on_conflict: {},\n}}",
+                indexed_columns_vec(columns),
+                conflict_option(*on_conflict, needs)
+            )
+        }
+        TableConstraint::Check(expr) => {
+            format!("TableConstraint::Check({}.into())", literal(expr))
+        }
+        // Foreign keys never reach here: `render_table_constraint` sends them
+        // to the sugar. Rendering the model value keeps this total rather than
+        // panicking on a shape the caller can construct.
+        TableConstraint::ForeignKey(fk) => format!(
+            "TableConstraint::ForeignKey(smugglr_forger::schema::ForeignKey {{\n    \
+             columns: {},\n    parent_table: {}.into(),\n    parent_columns: {},\n    \
+             on_delete: {},\n    on_update: {},\n}})",
+            string_vec(&fk.columns),
+            literal(&fk.parent_table),
+            string_vec(&fk.parent_columns),
+            match fk.on_delete {
+                Some(action) => {
+                    needs.referential_action = true;
+                    format!("Some(ReferentialAction::{action:?})")
+                }
+                None => "None".to_string(),
+            },
+            match fk.on_update {
+                Some(action) => {
+                    needs.referential_action = true;
+                    format!("Some(ReferentialAction::{action:?})")
+                }
+                None => "None".to_string(),
+            },
+        ),
+    }
+}
+
+fn conflict_option(algorithm: Option<OnConflict>, needs: &mut Needs) -> String {
+    match algorithm {
+        Some(algorithm) => {
+            needs.on_conflict = true;
+            format!("Some(OnConflict::{algorithm:?})")
+        }
+        None => "None".to_string(),
+    }
+}
+
+fn render_trigger(trigger: &Trigger) -> String {
+    format!(
+        "Trigger {{\n    name: {}.into(),\n    timing: TriggerTiming::{},\n    \
+         event: {},\n    when: {},\n    body: {},\n}}",
+        literal(&trigger.name),
+        match trigger.timing {
+            TriggerTiming::Before => "Before",
+            TriggerTiming::After => "After",
+        },
+        match &trigger.event {
+            TriggerEvent::Insert => "TriggerEvent::Insert".to_string(),
+            TriggerEvent::Delete => "TriggerEvent::Delete".to_string(),
+            TriggerEvent::Update => "TriggerEvent::Update".to_string(),
+            TriggerEvent::UpdateOf(columns) =>
+                format!("TriggerEvent::UpdateOf({})", string_vec(columns)),
+        },
+        match &trigger.when {
+            Some(guard) => format!("Some({}.into())", literal(guard)),
+            None => "None".to_string(),
+        },
+        string_vec(&trigger.body)
+    )
+}
+
+fn column_type(decl_type: &ColumnType) -> String {
+    match decl_type {
+        ColumnType::Other(name) => format!("Other({}.into())", literal(name)),
+        named => format!("{named:?}"),
+    }
+}
+
+fn sort_order(order: SortOrder) -> String {
+    format!("SortOrder::{order:?}")
+}
+
+fn default_value(value: &DefaultValue) -> String {
+    match value {
+        DefaultValue::Null => "DefaultValue::Null".to_string(),
+        DefaultValue::Integer(number) => format!("DefaultValue::Integer({number})"),
+        // `{:?}` on an f64 is the shortest representation that reads back as
+        // the same value, and it always carries a decimal point, so the literal
+        // is an f64 rather than an integer the compiler has to infer.
+        DefaultValue::Real(number) => format!("DefaultValue::Real({number:?})"),
+        DefaultValue::Text(text) => format!("DefaultValue::text({})", literal(text)),
+        DefaultValue::Blob(bytes) => format!(
+            "DefaultValue::Blob(vec![{}])",
+            bytes
+                .iter()
+                .map(|byte| format!("{byte}u8"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        DefaultValue::Expr(expr) => format!("DefaultValue::expr({})", literal(expr)),
+    }
+}
+
+fn indexed_columns(columns: &[IndexedColumn]) -> String {
+    format!("[{}]", indexed_column_items(columns).join(", "))
+}
+
+fn indexed_columns_vec(columns: &[IndexedColumn]) -> String {
+    format!("vec![{}]", indexed_column_items(columns).join(", "))
+}
+
+fn indexed_column_items(columns: &[IndexedColumn]) -> Vec<String> {
+    columns
+        .iter()
+        .map(|column| {
+            format!(
+                "IndexedColumn::new({}, {})",
+                literal(&column.name),
+                sort_order(column.order)
+            )
+        })
+        .collect()
+}
+
+fn string_array(values: &[String]) -> String {
+    format!(
+        "[{}]",
+        values
+            .iter()
+            .map(|value| literal(value))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn string_vec(values: &[String]) -> String {
+    format!(
+        "vec![{}]",
+        values
+            .iter()
+            .map(|value| format!("{}.into()", literal(value)))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+/// A Rust string literal for an arbitrary string.
+///
+/// `{:?}` on a `str` is defined to produce one, escaping quotes, backslashes
+/// and control characters -- which matters here because the strings being
+/// emitted are SQL expressions and trigger bodies, and those are full of
+/// double quotes.
+fn literal(value: &str) -> String {
+    format!("{value:?}")
+}
+
+// ---------------------------------------------------------------------------
+// Layout
+// ---------------------------------------------------------------------------
+
+/// A labelled paragraph, wrapped and hanging under its label.
+fn labelled(label: &str, body: &str) -> String {
+    let first = format!("    {label:<LABEL$}");
+    let wrapped = fill(body, first.len());
+    format!("{first}{}\n", wrapped.trim_start())
+}
+
+/// Wrap prose to [`WIDTH`], indenting every line by `hang`.
+fn fill(text: &str, hang: usize) -> String {
+    let pad = " ".repeat(hang);
+    let mut lines: Vec<String> = Vec::new();
+    let mut line = pad.clone();
+    for word in text.split_whitespace() {
+        if line.len() > hang && line.chars().count() + 1 + word.chars().count() > WIDTH {
+            lines.push(line);
+            line = pad.clone();
+        }
+        if line.len() > hang {
+            line.push(' ');
+        }
+        line.push_str(word);
+    }
+    lines.push(line);
+    lines.join("\n")
+}
+
+/// Indent every non-empty line.
+fn indent(text: &str, by: usize) -> String {
+    let pad = " ".repeat(by);
+    let mut out = String::new();
+    for line in text.lines() {
+        if line.is_empty() {
+            out.push('\n');
+        } else {
+            out.push_str(&pad);
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Indent every line but the first, which is already sitting after something.
+fn indent_after_first(text: &str, by: usize) -> String {
+    let pad = " ".repeat(by);
+    text.lines()
+        .enumerate()
+        .map(|(index, line)| {
+            if index == 0 || line.is_empty() {
+                line.to_string()
+            } else {
+                format!("{pad}{line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn trim_trailing_newline(mut text: String) -> String {
+    while text.ends_with('\n') {
+        text.pop();
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::builder::{schema, table, Attr};
+    use crate::schema::{ColumnType::*, ReferentialAction};
+
+    /// The property the "paste it into a test file" criterion rests on, for
+    /// every schema this crate will ever emit: the source describes the schema
+    /// it came from. Compilation is proved by
+    /// `tests/the_emitted_schema_source_compiles.rs`, which is a target cargo
+    /// builds; this is the other half, and neither alone is enough.
+    #[test]
+    fn every_case_schema_emits_builder_source() {
+        for kind in Trait::ALL {
+            let rendered = builder_source(&TraitCase::for_trait(kind).schema);
+            assert!(
+                rendered.is_builder(),
+                "{kind:?} did not emit builder source: {rendered}"
+            );
+        }
+    }
+
+    /// The union of all eight, which is the schema the oracle is actually run
+    /// against.
+    #[test]
+    fn the_union_of_every_case_emits_builder_source() {
+        let mut all = Schema::default();
+        for kind in Trait::ALL {
+            all.tables.extend(TraitCase::for_trait(kind).schema.tables);
+        }
+        assert!(builder_source(&all).is_builder());
+    }
+
+    /// Shapes the sugar does not cover, and one it does, all in one schema.
+    #[test]
+    fn the_shapes_the_sugar_does_not_cover_still_emit_builder_source() {
+        let awkward = schema()
+            .table(table("parent").pk_text("key").col(
+                "v",
+                Real,
+                [Attr::Default(DefaultValue::Real(1.5))],
+            ))
+            .table(
+                table("wide")
+                    .col("a", Integer, [])
+                    .col("b", Text, [Attr::Collate("NOCASE".into())])
+                    .col("c", Other("DECIMAL(4, 2)".into()), [])
+                    .typeless("d", [Attr::Check("\"d\" IS NOT 'x'".into())])
+                    .pk_composite([
+                        IndexedColumn::new("a", SortOrder::Asc),
+                        IndexedColumn::new("b", SortOrder::Desc),
+                    ])
+                    .constraint(TableConstraint::Unique {
+                        columns: vec![IndexedColumn::new("c", SortOrder::Asc)],
+                        on_conflict: Some(OnConflict::Ignore),
+                    })
+                    .fk(["a"], "parent", ["key"])
+                    .on_update(ReferentialAction::SetNull)
+                    .without_rowid(),
+            )
+            .build()
+            .expect("valid");
+
+        let rendered = builder_source(&awkward);
+        assert!(rendered.is_builder(), "{rendered}");
+        // Every one of the awkward parts is in the output rather than silently
+        // dropped, which is the failure mode an emitter has.
+        for expected in [
+            ".pk_text(\"key\")",
+            "DefaultValue::Real(1.5)",
+            "Other(\"DECIMAL(4, 2)\".into())",
+            ".typeless(\"d\"",
+            ".pk_composite(",
+            "TableConstraint::Unique",
+            "OnConflict::Ignore",
+            ".on_update(ReferentialAction::SetNull)",
+            ".without_rowid()",
+        ] {
+            assert!(
+                rendered.text().contains(expected),
+                "the emitted source lost {expected}:\n{rendered}"
+            );
+        }
+    }
+
+    /// A key the builder has no spelling for is refused by name rather than
+    /// emitted as something that would build a different schema.
+    #[test]
+    fn a_key_the_builder_cannot_spell_is_refused_with_a_reason() {
+        let literal = Schema {
+            tables: vec![Table {
+                name: "t".into(),
+                columns: vec![Column {
+                    name: "id".into(),
+                    decl_type: Some(ColumnType::Integer),
+                    constraints: vec![
+                        ColumnConstraint::PrimaryKey {
+                            order: SortOrder::Asc,
+                            autoincrement: false,
+                            on_conflict: None,
+                        },
+                        ColumnConstraint::NotNull(None),
+                    ],
+                }],
+                constraints: Vec::new(),
+                without_rowid: false,
+                strict: false,
+                triggers: Vec::new(),
+            }],
+        };
+
+        match builder_source(&literal) {
+            Rendered::Ddl { because, ddl } => {
+                assert!(because.contains("carries other constraints"), "{because}");
+                assert!(ddl.contains("CREATE TABLE"), "{ddl}");
+            }
+            Rendered::Builder(source) => {
+                panic!("the builder cannot express this key, and said it could:\n{source}")
+            }
+        }
+    }
+
+    /// Every trait has a sentence, and none of them is a restatement of the
+    /// variant name.
+    #[test]
+    fn every_trait_says_what_it_promises() {
+        for kind in Trait::ALL {
+            let said = promise(kind);
+            assert!(said.len() > 80, "{kind:?} says only {said:?}");
+            assert!(
+                said.contains(' '),
+                "{kind:?} promises a token rather than a sentence"
+            );
+        }
+    }
+}

--- a/crates/smugglr-forger/src/failure.rs
+++ b/crates/smugglr-forger/src/failure.rs
@@ -468,18 +468,14 @@ fn render_table(table: &Table, needs: &mut Needs) -> Result<String, String> {
     let mut out = format!("table({})\n", literal(&table.name));
 
     for (index, column) in table.columns.iter().enumerate() {
-        if Some(index) == key.map(|(at, _)| at) {
-            let (autoincrement, order) = match key {
-                Some((_, constraint)) => constraint,
-                // `key` is Some here by the condition above.
-                None => unreachable!("the key column is the key column"),
-            };
-            out.push_str(&render_key_column(table, column, order, needs)?);
-            if autoincrement {
-                out.push_str("    .autoincrement()\n");
+        match key {
+            Some(key) if key.at == index => {
+                out.push_str(&render_key_column(table, column, key.order, needs)?);
+                if key.autoincrement {
+                    out.push_str("    .autoincrement()\n");
+                }
             }
-        } else {
-            out.push_str(&render_column(column, needs));
+            _ => out.push_str(&render_column(column, needs)),
         }
     }
 
@@ -515,16 +511,24 @@ fn render_table(table: &Table, needs: &mut Needs) -> Result<String, String> {
     Ok(trim_trailing_newline(out) + ",\n")
 }
 
-/// The column that declares the key, its position, whether it is
-/// `AUTOINCREMENT`, and which way it sorts.
+/// The column-level primary key: which column it is on, and how it is spelled.
+#[derive(Clone, Copy)]
+struct KeyColumn {
+    /// Its position among the table's columns, so the `pk_*` constructor is
+    /// emitted where the column actually sits rather than first.
+    at: usize,
+    autoincrement: bool,
+    order: SortOrder,
+}
+
+/// The column that declares the key, if one does.
 ///
 /// `Err` where the model holds a key the builder has no spelling for. Those
 /// shapes are real -- `id INTEGER PRIMARY KEY NOT NULL` is ordinary SQLite --
 /// and the builder's `pk_*` constructors deliberately take no attributes, so
 /// there is nothing to emit that would round-trip.
-#[allow(clippy::type_complexity)]
-fn primary_key_column(table: &Table) -> Result<Option<(usize, (bool, SortOrder))>, String> {
-    let mut found: Option<(usize, (bool, SortOrder))> = None;
+fn primary_key_column(table: &Table) -> Result<Option<KeyColumn>, String> {
+    let mut found: Option<KeyColumn> = None;
     for (index, column) in table.columns.iter().enumerate() {
         for constraint in &column.constraints {
             let ColumnConstraint::PrimaryKey {
@@ -556,7 +560,11 @@ fn primary_key_column(table: &Table) -> Result<Option<(usize, (bool, SortOrder))
                     table.name
                 ));
             }
-            found = Some((index, (*autoincrement, *order)));
+            found = Some(KeyColumn {
+                at: index,
+                autoincrement: *autoincrement,
+                order: *order,
+            });
         }
     }
     Ok(found)

--- a/crates/smugglr-forger/src/lib.rs
+++ b/crates/smugglr-forger/src/lib.rs
@@ -30,6 +30,11 @@
 //!   where they part company.
 //! * [`corpus`] -- a failure written down as JSON and committed, so a defect
 //!   found once runs thereafter as an ordinary test input.
+//! * [`census`] -- what a run executed, counted per trait and held to a
+//!   committed floor, because an exit code cannot tell a clean run from an
+//!   empty one.
+//! * [`failure`] -- what a failure says: the trait, the before and the after,
+//!   and the schema that carries it as source a reader can paste.
 //!
 //! ```
 //! use smugglr_forger::fixture::{Backing, Fixture, Route};
@@ -50,15 +55,19 @@
 //! fixture.bring_to(Route::Schema(&target)).unwrap();
 //! ```
 
+pub mod census;
 pub mod corpus;
 pub mod error;
+pub mod failure;
 pub mod fixture;
 pub mod oracle;
 pub mod registry;
 pub mod schema;
 
+pub use census::{Anomaly, Baseline, Census, Shortfall};
 pub use corpus::Regression;
 pub use error::{BoxError, ForgeError, ProbeError, ValidationError};
+pub use failure::{builder_source, Finding, Rendered};
 pub use fixture::{Backing, Fixture, Route};
 pub use oracle::{differential, Arm, Divergence, Outcome, Report, TraitOutcome};
 pub use registry::TraitCase;

--- a/crates/smugglr-forger/src/oracle.rs
+++ b/crates/smugglr-forger/src/oracle.rs
@@ -134,6 +134,35 @@ pub enum Outcome {
 }
 
 impl Outcome {
+    /// What a probe said, as an outcome.
+    ///
+    /// The mapping is one-to-one and lives here rather than in each caller so
+    /// that two callers cannot disagree about what `Unseeded` means. The
+    /// [`census`](crate::census) runs probes outside the two arms -- against a
+    /// case's own database, and against an empty one -- and has to classify
+    /// them by the same rule the oracle uses, or the two would be reporting in
+    /// different currencies.
+    pub fn of(reported: Result<(), ProbeError>) -> Outcome {
+        match reported {
+            Ok(()) => Outcome::Held,
+            Err(ProbeError::Failed(message)) => Outcome::Broke(message),
+            Err(ProbeError::Unseeded(message)) => Outcome::NothingToObserve(message),
+            Err(ProbeError::Sqlite(error)) => Outcome::Erred(error.to_string()),
+        }
+    }
+
+    /// The outcome kind as one word, for a column in a run report. The message
+    /// is deliberately not in it: a table of outcomes is read for its shape,
+    /// and the wording belongs in [`failure`](crate::failure)'s prose.
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Outcome::Held => "held",
+            Outcome::Broke(_) => "broke",
+            Outcome::NothingToObserve(_) => "nothing-to-observe",
+            Outcome::Erred(_) => "erred",
+        }
+    }
+
     /// Same *kind* of outcome, ignoring the message.
     ///
     /// The messages carry row counts, values and SQLite's own wording, and two
@@ -176,8 +205,9 @@ pub enum Divergence {
 /// The whole record is kept rather than only the disagreements, because "both
 /// arms broke identically" is not a divergence and is still something a caller
 /// needs to see -- it means the from-scratch arm is not a sound baseline, and
-/// the comparison underneath it proves nothing. Rendering any of this is
-/// FR-FORGER-008's problem, not this module's.
+/// the comparison underneath it proves nothing.
+/// [`unsound_baseline`](Self::unsound_baseline) is where that reading lives;
+/// [`failure`](crate::failure) is where it is rendered.
 #[derive(Debug, Clone)]
 pub struct Report {
     /// One record per [`Trait`], in [`Trait::ALL`] order.
@@ -223,6 +253,46 @@ impl Report {
     /// Whether the arms disagreed at all.
     pub fn diverged(&self) -> bool {
         !self.divergences().is_empty()
+    }
+
+    /// Every trait the arm nobody transformed did not hold on.
+    ///
+    /// # Why this is a query on the report rather than a divergence
+    ///
+    /// Two arms that broke identically do not diverge -- the comparison is on
+    /// the outcome kind, deliberately, because two arms wording the same
+    /// behavioural fact differently is not a finding. The cost of that choice
+    /// is that "no divergence" is also what a mislocated probe, a start schema
+    /// missing a case's tables, or a bad target schema produces. Whether the
+    /// baseline was sound is therefore the first thing anyone reading a clean
+    /// report needs, and until now it was derivable only by a caller who
+    /// thought to derive it. Every caller who did not think of it got the
+    /// false-clean this crate exists to prevent.
+    ///
+    /// It is not folded into [`divergences`](Self::divergences), and that is
+    /// the load-bearing half. A divergence says *the arms disagreed*, which is
+    /// a statement about the caller's transformation; an unsound baseline says
+    /// *the arms may agree for a bad reason*, which is a statement about the
+    /// measurement. A gate that reported the second as the first would go red
+    /// on runs where the transformation did nothing wrong, and a gate that
+    /// cries wolf is one people learn to bypass.
+    ///
+    /// Nor is it an `Err`. The report is still worth reading -- which trait
+    /// failed in the baseline is exactly what says whether the schemas or the
+    /// probes are at fault -- and [`ForgeError`] is reserved for a run that
+    /// could not produce a report at all.
+    pub fn unsound_baseline(&self) -> Vec<&TraitOutcome> {
+        self.traits
+            .iter()
+            .filter(|outcome| outcome.from_scratch != Outcome::Held)
+            .collect()
+    }
+
+    /// Whether the arm nobody transformed held on every trait. See
+    /// [`unsound_baseline`](Self::unsound_baseline) for why this is worth
+    /// asking separately from [`diverged`](Self::diverged).
+    pub fn baseline_is_sound(&self) -> bool {
+        self.unsound_baseline().is_empty()
     }
 
     /// What both arms said about one trait.
@@ -351,12 +421,7 @@ fn observe(
     if let Some(failure) = seed_failure {
         return Outcome::NothingToObserve(format!("the seed did not take: {failure}"));
     }
-    match case.probe_against(promised, conn) {
-        Ok(()) => Outcome::Held,
-        Err(ProbeError::Failed(message)) => Outcome::Broke(message),
-        Err(ProbeError::Unseeded(message)) => Outcome::NothingToObserve(message),
-        Err(ProbeError::Sqlite(error)) => Outcome::Erred(error.to_string()),
-    }
+    Outcome::of(case.probe_against(promised, conn))
 }
 
 /// The user tables in a database, by name, minus what the caller excluded.

--- a/crates/smugglr-forger/tests/a_failure_says_what_broke.rs
+++ b/crates/smugglr-forger/tests/a_failure_says_what_broke.rs
@@ -1,0 +1,213 @@
+//! Break something for real, and read what the report says about it.
+//!
+//! FR-FORGER-008's criteria are about output, and output is the one thing a
+//! unit test of a renderer will happily agree with itself about. So these run
+//! the actual oracle over an actual dropped construct and assert on the text a
+//! reviewer would be handed: the trait is named, the before and the after are
+//! there in those terms, the schema comes out as source rather than as SQL, and
+//! nothing in it is a word you would have to open this crate to look up.
+//!
+//! # Why "does not contain" assertions carry weight here
+//!
+//! Two of the criteria are negative. "Not a diff of two generated blobs" and
+//! "no failure output requires reading forger's source to interpret" are both
+//! satisfied by absence, and absence is what drifts back in silently when
+//! someone adds a debugging line. So the internal vocabulary -- variant names,
+//! type names, the rendered DDL -- is asserted out of the report rather than
+//! left to taste.
+
+use rusqlite::Connection;
+
+use smugglr_forger::census;
+use smugglr_forger::error::BoxError;
+use smugglr_forger::failure::{promise, render_divergence, render_report};
+use smugglr_forger::fixture::Backing;
+use smugglr_forger::oracle::{differential, Arm, Divergence, Outcome, Report, TraitOutcome};
+use smugglr_forger::schema::Trait;
+
+/// smugglr#341's shape: the rebuild reconstructs the foreign key and leaves the
+/// referential action behind. The same transformation
+/// `the_oracle_catches_a_silent_drop.rs` uses to prove the oracle sees it; here
+/// it is used to see what the oracle then says.
+const DROPS_THE_CASCADE: &str = r#"
+    CREATE TABLE "cascade_child_new" (
+        "id" INTEGER PRIMARY KEY,
+        "keeper_id" INTEGER,
+        "label" TEXT,
+        FOREIGN KEY ("keeper_id") REFERENCES "keeper" ("id")
+    );
+    INSERT INTO "cascade_child_new" ("id", "keeper_id", "label")
+        SELECT "id", "keeper_id", "label" FROM "cascade_child";
+    DROP TABLE "cascade_child";
+    ALTER TABLE "cascade_child_new" RENAME TO "cascade_child";
+"#;
+
+fn report_after(statements: &str) -> Report {
+    let schema = census::every_trait_schema();
+    let mut transform = |conn: &mut Connection| -> Result<(), BoxError> {
+        conn.execute_batch(statements)?;
+        Ok(())
+    };
+    differential(
+        Backing::Memory,
+        &schema,
+        &schema,
+        &mut transform,
+        std::iter::empty::<&str>(),
+    )
+    .expect("the transformation runs")
+}
+
+/// Every criterion FR-FORGER-008 states, against one real failure.
+#[test]
+fn a_dropped_referential_action_reports_the_trait_the_before_and_the_after() {
+    let report = report_after(DROPS_THE_CASCADE);
+    let rendered = render_report(&report);
+    let one_line = flowed(&rendered);
+
+    // Names the trait.
+    assert!(
+        one_line.contains("ForeignKeyWithAction"),
+        "the report does not name the trait:\n{rendered}"
+    );
+    // And says what that name means, so the name is not the whole explanation.
+    assert!(
+        one_line.contains(&flowed(promise(Trait::ForeignKeyWithAction))),
+        "the report names a trait and never says what it promises:\n{rendered}"
+    );
+
+    // Before and after, in those words.
+    assert!(one_line.contains("before"), "{rendered}");
+    assert!(one_line.contains("after"), "{rendered}");
+    assert!(
+        one_line.contains("never transformed"),
+        "the report does not say which side was the unchanged one:\n{rendered}"
+    );
+    // The observation itself, in the probe's own words rather than a code.
+    // The rebuild left the key with the NO ACTION default, so SQLite refused
+    // the delete outright -- and the report says that, not "diverged".
+    assert!(
+        one_line.contains("a child declared ON DELETE CASCADE does not refuse it"),
+        "the report does not say what the database actually did:\n{rendered}"
+    );
+
+    // The schema, as source rather than as SQL.
+    assert!(
+        rendered.contains("schema()")
+            && rendered.contains(".on_delete(ReferentialAction::Cascade)"),
+        "the report does not carry the schema as builder source:\n{rendered}"
+    );
+
+    // Not a diff of two generated blobs: no DDL anywhere in it.
+    assert!(
+        !rendered.contains("CREATE TABLE"),
+        "the report renders DDL, which is the comparison the oracle refuses to \
+         make:\n{rendered}"
+    );
+
+    // Nothing a reader would have to open forger to interpret.
+    for internal in [
+        "Outcome::",
+        "ProbeError::",
+        "Divergence::",
+        "TraitOutcome",
+        "NothingToObserve",
+        "Erred",
+        "Broke",
+        "from_scratch",
+    ] {
+        assert!(
+            !rendered.contains(internal),
+            "the report leaks {internal:?}, which only forger's source explains:\n{rendered}"
+        );
+    }
+}
+
+/// The soundness verdict leads, and it leads on a clean run too.
+///
+/// A clean report over an unsound baseline is the most dangerous thing this
+/// crate can emit, so it is the first line either way rather than a note under
+/// the divergences.
+#[test]
+fn the_soundness_verdict_comes_first_on_a_clean_run_and_on_a_failing_one() {
+    let clean = render_report(&report_after(r#"SELECT 1;"#));
+    assert!(
+        clean.starts_with("the baseline is sound"),
+        "a clean report does not open with the verdict:\n{clean}"
+    );
+    assert!(clean.contains("no divergence"), "{clean}");
+
+    let failing = render_report(&report_after(DROPS_THE_CASCADE));
+    assert!(
+        failing.starts_with("the baseline is sound"),
+        "a failing report does not open with the verdict:\n{failing}"
+    );
+}
+
+/// And when the baseline is not sound, the report says so before it says
+/// anything a reader might act on.
+#[test]
+fn an_unsound_baseline_is_the_first_thing_the_report_says() {
+    let unsound = Report {
+        traits: vec![TraitOutcome {
+            kind: Trait::GeneratedStored,
+            transformed: Outcome::Broke("the transformed arm broke".into()),
+            from_scratch: Outcome::Broke("so did the arm nobody transformed".into()),
+        }],
+        transformed_tables: Default::default(),
+        from_scratch_tables: Default::default(),
+    };
+
+    // The two arms broke the same way, so by the oracle's own rule nothing
+    // diverged -- which is exactly the run this warning exists for.
+    assert!(!unsound.diverged());
+
+    let rendered = render_report(&unsound);
+    assert!(
+        rendered.starts_with("THE BASELINE IS NOT SOUND"),
+        "an unsound baseline is not the first thing said:\n{rendered}"
+    );
+    assert!(flowed(&rendered).contains("GeneratedStored"), "{rendered}");
+    assert!(
+        flowed(&rendered).contains("so did the arm nobody transformed"),
+        "{rendered}"
+    );
+}
+
+/// A table in one arm and not the other is not about a trait, and the report
+/// says what to do about each direction rather than only which side had it.
+#[test]
+fn a_table_divergence_says_which_direction_it_is_and_what_to_do() {
+    let left_behind = render_divergence(&Divergence::Table {
+        name: "_smugglr_migrations".to_string(),
+        present_in: Arm::Transformed,
+    });
+    assert!(
+        flowed(&left_behind).contains("_smugglr_migrations"),
+        "{left_behind}"
+    );
+    assert!(
+        flowed(&left_behind).contains("ignore_tables"),
+        "a table only the transformed arm has is usually the caller's bookkeeping, and the \
+         report should say so:\n{left_behind}"
+    );
+
+    let lost = render_divergence(&Divergence::Table {
+        name: "audit".to_string(),
+        present_in: Arm::FromScratch,
+    });
+    assert!(
+        flowed(&lost).contains("lost a table the target schema declares"),
+        "{lost}"
+    );
+    assert!(
+        !flowed(&lost).contains("ignore_tables"),
+        "a table the transformation destroyed is not something to hide:\n{lost}"
+    );
+}
+
+/// Prose is wrapped to a column, so it is compared with the wrapping taken back
+/// out rather than line by line.
+fn flowed(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}

--- a/crates/smugglr-forger/tests/execution-baseline.json
+++ b/crates/smugglr-forger/tests/execution-baseline.json
@@ -1,0 +1,37 @@
+{
+  "note": "The floor under forger's execution accounting (FR-FORGER-007). Each entry is the number of probes that trait executed on the run that recorded this file, and the census fails when a trait executes fewer -- or stops being executed at all. Raise it deliberately: run the census with FORGER_RECORD_BASELINE=1 and commit the rewritten file in the same change as the work that earned the new number. Lowering an entry is how coverage leaves without anyone noticing, so a decrease is reported as a decrease.",
+  "traits": [
+    {
+      "trait": "ForeignKeyWithAction",
+      "probes": 4
+    },
+    {
+      "trait": "GeneratedVirtual",
+      "probes": 4
+    },
+    {
+      "trait": "GeneratedStored",
+      "probes": 4
+    },
+    {
+      "trait": "ColumnOnConflict",
+      "probes": 4
+    },
+    {
+      "trait": "ExpressionDefault",
+      "probes": 4
+    },
+    {
+      "trait": "TypelessColumn",
+      "probes": 4
+    },
+    {
+      "trait": "Trigger",
+      "probes": 4
+    },
+    {
+      "trait": "DescendingPrimaryKey",
+      "probes": 4
+    }
+  ]
+}

--- a/crates/smugglr-forger/tests/execution_census.rs
+++ b/crates/smugglr-forger/tests/execution_census.rs
@@ -1,0 +1,216 @@
+//! Run every probe, say what ran, and refuse to pass on nothing.
+//!
+//! # Why this target brings its own main
+//!
+//! `harness = false`, for the reason `corpus_runs.rs` documents and states more
+//! sharply here: FR-FORGER-007 requires the schemas exercised and the probes
+//! executed to be reported on a *passing* run, and libtest captures the stdout
+//! of a passing test. Under the default harness this report would appear only
+//! under `--nocapture` -- which is to say only once someone already suspected
+//! something, which is exactly when a count proves nothing they did not already
+//! believe. The requirement is unsatisfiable as written on the default harness,
+//! and it would be easy to ship a "report" nobody ever sees and believe it met.
+//!
+//! The cost is that this binary owns its exit status, which it takes seriously
+//! in four places: a run whose probes fell below the recorded floor, a baseline
+//! that is not there, a probe that reports a healthy answer about an empty
+//! database, and a divergence between two arms nothing came between.
+//!
+//! Arguments are ignored rather than parsed, exactly as the corpus runner
+//! ignores them: `cargo test -- --nocapture` and any `--skip` a CI job passes
+//! reach this binary too, and a runner that refused an argument it did not
+//! recognize would break the command that runs the suite. The one switch it
+//! does read comes from the environment for the same reason.
+//!
+//! # Raising the baseline
+//!
+//! `FORGER_RECORD_BASELINE=1 cargo test -p smugglr-forger --test execution_census`
+//! rewrites `tests/execution-baseline.json` from the run it just took and exits
+//! non-zero, so a recording run can never be mistaken for a passing one. Commit
+//! the rewritten file in the same change as the work that earned the new
+//! numbers; the diff is the review.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+use smugglr_forger::census::{Baseline, Census, Phase, TraitTally};
+use smugglr_forger::failure::render_report;
+use smugglr_forger::fixture::Backing;
+use smugglr_forger::oracle::Outcome;
+
+/// The recorded floor, relative to the crate. From `CARGO_MANIFEST_DIR` rather
+/// than the working directory, which cargo sets to the workspace root for a
+/// workspace-wide run and to the crate for a crate-scoped one.
+fn baseline_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/execution-baseline.json")
+}
+
+/// The switch that rewrites the baseline. Read from the environment rather than
+/// from argv: see the module docs on why argv is not ours to parse.
+const RECORD: &str = "FORGER_RECORD_BASELINE";
+
+fn main() -> ExitCode {
+    let started = Instant::now();
+    let census = match Census::take(Backing::Memory) {
+        Ok(census) => census,
+        Err(error) => {
+            println!(
+                "forger census: the run could not be taken, so nothing was measured.\n  {error}"
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let elapsed = started.elapsed();
+
+    print_tally(&census, elapsed);
+
+    if std::env::var_os(RECORD).is_some() {
+        return record(&census);
+    }
+
+    let baseline = match Baseline::load(&baseline_path()) {
+        Ok(baseline) => baseline,
+        Err(error) => {
+            println!("\nforger census: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let shortfalls = baseline.compare(&census);
+    let anomalies = census.anomalies();
+
+    if shortfalls.is_empty() && anomalies.is_empty() {
+        println!(
+            "forger census: at or above the recorded floor in {}.",
+            baseline_path().display()
+        );
+        return ExitCode::SUCCESS;
+    }
+
+    if !shortfalls.is_empty() {
+        println!("\nforger census: FEWER PROBES RAN THAN THE RECORDED FLOOR.\n");
+        for shortfall in &shortfalls {
+            println!("  {shortfall}\n");
+        }
+    }
+    if !anomalies.is_empty() {
+        println!("\nforger census: {} FAILED.\n", plural(anomalies.len()));
+        for anomaly in &anomalies {
+            println!("{anomaly}");
+        }
+        // The oracle's own account of the run, which says whether the arm
+        // nobody transformed was sound before it says anything else.
+        println!("{}", render_report(census.differential()));
+    }
+    ExitCode::FAILURE
+}
+
+/// What ran, broken down by trait. Printed on every run, passing or not.
+fn print_tally(census: &Census, elapsed: Duration) {
+    let tallies = census.tallies();
+    println!(
+        "forger census: {} schemas exercised, {} probes executed, {} traits, {}",
+        census.schemas_exercised(),
+        census.probes(),
+        tallies.len(),
+        millis(elapsed)
+    );
+    println!(
+        "  each trait is probed on its own case, on both arms of the differential, and \
+         against a database\n  with nothing in it -- which it has to refuse, or it is not \
+         asserting anything.\n"
+    );
+
+    // Widest name rather than a fixed column: the next trait is as long as it
+    // needs to be.
+    let width = tallies
+        .iter()
+        .map(|tally| format!("{:?}", tally.kind).chars().count())
+        .max()
+        .unwrap_or_default();
+
+    println!(
+        "  {:<width$}  {:>7}  {:>6}  what each phase said",
+        "trait", "schemas", "probes"
+    );
+    for tally in &tallies {
+        println!(
+            "  {:<width$}  {:>7}  {:>6}  {}",
+            format!("{:?}", tally.kind),
+            tally.schemas,
+            tally.probes,
+            phases(tally)
+        );
+    }
+    println!("\n  {} traits, {} probes.", tallies.len(), census.probes());
+    match census.differential().unsound_baseline().len() {
+        0 => println!(
+            "  the arm nobody transformed held on every trait, so the comparison rests on \
+             something.\n"
+        ),
+        unsound => println!(
+            "  THE ARM NOBODY TRANSFORMED DID NOT HOLD ON {unsound} TRAIT(S) -- see below.\n"
+        ),
+    }
+}
+
+/// One trait's phases, as `phase:outcome` pairs in the order they ran.
+fn phases(tally: &TraitTally) -> String {
+    tally
+        .observations
+        .iter()
+        .map(|observation| {
+            format!(
+                "{}:{}",
+                observation.phase,
+                // The empty phase is the one where refusing is the pass, so it
+                // reads that way rather than as a failure word.
+                match (observation.phase, &observation.outcome) {
+                    (Phase::Empty, Outcome::Held) => "HELD, WHICH IS THE FAILURE",
+                    (Phase::Empty, _) => "refused",
+                    (_, outcome) => outcome.kind_name(),
+                }
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("  ")
+}
+
+/// Rewrite the floor from this run, and fail anyway.
+///
+/// A recording run rewrites the thing the check compares against, so it cannot
+/// also be allowed to report success -- that is a green check whose gate was
+/// removed by the same command that produced it.
+fn record(census: &Census) -> ExitCode {
+    let baseline = Baseline::of(census);
+    let path = baseline_path();
+    match baseline.store(&path) {
+        Ok(()) => {
+            println!(
+                "\nforger census: recorded a new floor in {}.\n  {} traits, {} probes. Review the \
+                 diff and commit it with the work that earned it.\n  This run exits non-zero on \
+                 purpose: a run that rewrote the check cannot also have passed it.",
+                path.display(),
+                baseline.traits.len(),
+                census.probes()
+            );
+            ExitCode::FAILURE
+        }
+        Err(error) => {
+            println!("\nforger census: could not record a baseline: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn plural(count: usize) -> String {
+    match count {
+        1 => "1 CHECK".to_string(),
+        many => format!("{many} CHECKS"),
+    }
+}
+
+/// Milliseconds to one decimal, as the corpus runner reports them.
+fn millis(duration: Duration) -> String {
+    format!("{:.1}ms", duration.as_secs_f64() * 1000.0)
+}

--- a/crates/smugglr-forger/tests/the_emitted_schema_source_compiles.rs
+++ b/crates/smugglr-forger/tests/the_emitted_schema_source_compiles.rs
@@ -1,0 +1,304 @@
+//! The emitted schema source, pasted into a test file -- which is this one.
+//!
+//! FR-FORGER-008 requires a failure to print the minimal reproducing schema in
+//! the builder's readable form, and requires that output to be pasteable into a
+//! test file that compiles. Eyeballing it is not evidence, so this target is the
+//! evidence: every block below is
+//! [`failure::builder_source`](smugglr_forger::failure::builder_source) output,
+//! copied in unaltered, and cargo compiles this file like any other test target.
+//! If the emitter ever produced something that does not compile, this crate
+//! stops building.
+//!
+//! Compiling is only half of it -- a block that compiles and describes some
+//! other schema is worse than one that does not compile at all -- so two tests
+//! close the loop:
+//!
+//! * the pasted source builds a schema equal to the registry case it came from,
+//!   which is what makes it a *reproduction*; and
+//! * the pasted text still matches what the emitter emits today, read back out
+//!   of this very file, which is what stops it from quietly becoming a
+//!   hand-maintained copy of an emitter that has since changed.
+//!
+//! Each function carries `#[rustfmt::skip]`. The text is machine-written and is
+//! compared against a machine, so rustfmt must not be a third author of it.
+//! When the emitter changes, the comparison test fails naming the trait whose
+//! block drifted and printing the replacement text -- paste that between the
+//! markers and the file is current again.
+
+use smugglr_forger::failure::builder_source;
+use smugglr_forger::registry::TraitCase;
+use smugglr_forger::schema::{Schema, Trait};
+
+/// This file, read back at compile time, so the test can compare the text that
+/// was compiled against the text the emitter produces now. A literal filename
+/// rather than `file!()`, which resolves against a different root.
+const THIS_FILE: &str = include_str!("the_emitted_schema_source_compiles.rs");
+
+#[rustfmt::skip]
+fn foreign_key_with_action() -> Schema {
+    // >>> ForeignKeyWithAction
+    use smugglr_forger::schema::builder::{schema, table};
+    use smugglr_forger::schema::{ColumnType::*, ReferentialAction};
+
+    schema()
+        .table(
+            table("keeper")
+                .pk_int("id")
+                .col("label", Text, []),
+        )
+        .table(
+            table("cascade_child")
+                .pk_int("id")
+                .col("keeper_id", Integer, [])
+                .col("label", Text, [])
+                .fk(["keeper_id"], "keeper", ["id"])
+                .on_delete(ReferentialAction::Cascade),
+        )
+        .table(
+            table("restrict_child")
+                .pk_int("id")
+                .col("keeper_id", Integer, [])
+                .col("label", Text, [])
+                .fk(["keeper_id"], "keeper", ["id"])
+                .on_delete(ReferentialAction::Restrict),
+        )
+        .build()
+        .expect("a valid schema")
+    // <<< ForeignKeyWithAction
+}
+
+#[rustfmt::skip]
+fn generated_virtual() -> Schema {
+    // >>> GeneratedVirtual
+    use smugglr_forger::schema::builder::{schema, table, Attr};
+    use smugglr_forger::schema::ColumnType::*;
+
+    schema()
+        .table(
+            table("virtual_generated")
+                .pk_int("id")
+                .col("base", Integer, [])
+                .col("doubled", Integer, [Attr::Virtual("\"base\" * 2".into())])
+                .col("label", Text, []),
+        )
+        .build()
+        .expect("a valid schema")
+    // <<< GeneratedVirtual
+}
+
+#[rustfmt::skip]
+fn generated_stored() -> Schema {
+    // >>> GeneratedStored
+    use smugglr_forger::schema::builder::{schema, table, Attr};
+    use smugglr_forger::schema::ColumnType::*;
+
+    schema()
+        .table(
+            table("stored_generated")
+                .pk_int("id")
+                .col("base", Integer, [])
+                .col("tripled", Integer, [Attr::Stored("\"base\" * 3".into())])
+                .col("label", Text, []),
+        )
+        .build()
+        .expect("a valid schema")
+    // <<< GeneratedStored
+}
+
+#[rustfmt::skip]
+fn column_on_conflict() -> Schema {
+    // >>> ColumnOnConflict
+    use smugglr_forger::schema::builder::{schema, table, Attr};
+    use smugglr_forger::schema::ColumnType::*;
+
+    schema()
+        .table(
+            table("replace_absorbs")
+                .pk_int("id")
+                .col("k", Text, [Attr::Unique, Attr::OnConflictReplace])
+                .col("label", Text, []),
+        )
+        .table(
+            table("ignore_absorbs")
+                .pk_int("id")
+                .col("v", Text, [Attr::NotNull, Attr::OnConflictIgnore])
+                .col("label", Text, []),
+        )
+        .table(
+            table("abort_throws")
+                .pk_int("id")
+                .col("v", Text, [Attr::NotNull, Attr::OnConflictAbort])
+                .col("label", Text, []),
+        )
+        .table(
+            table("rollback_throws")
+                .pk_int("id")
+                .col("v", Text, [Attr::NotNull, Attr::OnConflictRollback])
+                .col("label", Text, []),
+        )
+        .build()
+        .expect("a valid schema")
+    // <<< ColumnOnConflict
+}
+
+#[rustfmt::skip]
+fn expression_default() -> Schema {
+    // >>> ExpressionDefault
+    use smugglr_forger::schema::builder::{schema, table, Attr};
+    use smugglr_forger::schema::{ColumnType::*, DefaultValue};
+
+    schema()
+        .table(
+            table("expression_default")
+                .pk_int("id")
+                .col("made_at", Text, [Attr::Default(DefaultValue::expr("datetime('now')"))])
+                .col("computed", Integer, [Attr::Default(DefaultValue::expr("2 + 3"))])
+                .col("label", Text, []),
+        )
+        .build()
+        .expect("a valid schema")
+    // <<< ExpressionDefault
+}
+
+#[rustfmt::skip]
+fn typeless_column() -> Schema {
+    // >>> TypelessColumn
+    use smugglr_forger::schema::builder::{schema, table};
+    use smugglr_forger::schema::ColumnType::*;
+
+    schema()
+        .table(
+            table("typeless")
+                .pk_int("id")
+                .typeless("v", [])
+                .col("label", Text, []),
+        )
+        .build()
+        .expect("a valid schema")
+    // <<< TypelessColumn
+}
+
+#[rustfmt::skip]
+fn trigger() -> Schema {
+    // >>> Trigger
+    use smugglr_forger::schema::builder::{schema, table};
+    use smugglr_forger::schema::{ColumnType::*, Trigger, TriggerEvent, TriggerTiming};
+
+    schema()
+        .table(
+            table("evented")
+                .pk_int("id")
+                .col("note", Text, [])
+                .trigger(Trigger {
+                    name: "evented_audit".into(),
+                    timing: TriggerTiming::After,
+                    event: TriggerEvent::Insert,
+                    when: None,
+                    body: vec!["INSERT INTO \"audit\" (\"note\") VALUES (new.\"note\")".into()],
+                }),
+        )
+        .table(
+            table("audit")
+                .pk_int("id")
+                .col("note", Text, []),
+        )
+        .build()
+        .expect("a valid schema")
+    // <<< Trigger
+}
+
+#[rustfmt::skip]
+fn descending_primary_key() -> Schema {
+    // >>> DescendingPrimaryKey
+    use smugglr_forger::schema::builder::{schema, table};
+    use smugglr_forger::schema::{ColumnType::*, SortOrder};
+
+    schema()
+        .table(
+            table("descending_key")
+                .pk_col("id", Integer, SortOrder::Desc)
+                .col("label", Text, []),
+        )
+        .build()
+        .expect("a valid schema")
+    // <<< DescendingPrimaryKey
+}
+
+/// The block for a trait, exhaustively and with no catch-all arm -- the same
+/// mechanism the registry uses, and for the same reason: a new [`Trait`] must
+/// not be able to arrive without someone pasting its emitted source in here and
+/// watching it compile.
+fn pasted(kind: Trait) -> Schema {
+    match kind {
+        Trait::ForeignKeyWithAction => foreign_key_with_action(),
+        Trait::GeneratedVirtual => generated_virtual(),
+        Trait::GeneratedStored => generated_stored(),
+        Trait::ColumnOnConflict => column_on_conflict(),
+        Trait::ExpressionDefault => expression_default(),
+        Trait::TypelessColumn => typeless_column(),
+        Trait::Trigger => trigger(),
+        Trait::DescendingPrimaryKey => descending_primary_key(),
+    }
+}
+
+/// The pasted source describes the schema it was emitted from.
+///
+/// Without this the file would prove only that the emitter produces *something*
+/// that compiles, and something that compiles and builds a different schema is
+/// a reproduction of a different bug.
+#[test]
+fn the_pasted_source_builds_the_schema_it_came_from() {
+    for kind in Trait::ALL {
+        assert_eq!(
+            pasted(kind),
+            TraitCase::for_trait(kind).schema,
+            "the source pasted in for {kind:?} builds a different schema than the case it \
+             came from"
+        );
+    }
+}
+
+/// The pasted source is still what the emitter emits.
+///
+/// Compared with whitespace collapsed, because the paste is indented to sit in
+/// a function body and the emitter writes at column zero. Everything that is
+/// not whitespace has to match: a changed identifier, a dropped attribute or a
+/// moved comma all read as drift.
+#[test]
+fn the_pasted_source_is_what_the_emitter_emits_today() {
+    for kind in Trait::ALL {
+        let emitted = builder_source(&TraitCase::for_trait(kind).schema);
+        assert!(
+            emitted.is_builder(),
+            "{kind:?} no longer emits builder source at all: {emitted}"
+        );
+        // The failure carries the replacement, so re-emitting a drifted block
+        // is copying it out of this message rather than finding a tool.
+        assert_eq!(
+            collapsed(&block(kind)),
+            collapsed(emitted.text()),
+            "the block pasted in for {kind:?} is not what the emitter emits now. Replace the \
+             text between this file's markers for {kind:?} with:\n\n{}\n",
+            emitted.text()
+        );
+    }
+}
+
+/// The text between this trait's markers in this file.
+fn block(kind: Trait) -> String {
+    let open = format!("// >>> {kind:?}\n");
+    let close = format!("// <<< {kind:?}");
+    let start = THIS_FILE
+        .find(&open)
+        .unwrap_or_else(|| panic!("{kind:?} has no pasted block in this file"))
+        + open.len();
+    let end = THIS_FILE[start..]
+        .find(&close)
+        .unwrap_or_else(|| panic!("{kind:?}'s pasted block is never closed"));
+    THIS_FILE[start..start + end].to_string()
+}
+
+/// Every run of whitespace as one space, so indentation is not a difference.
+fn collapsed(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}

--- a/crates/smugglr-forger/tests/the_oracle_catches_a_silent_drop.rs
+++ b/crates/smugglr-forger/tests/the_oracle_catches_a_silent_drop.rs
@@ -21,15 +21,17 @@
 //! Two arms that broke identically do not diverge. "No divergence" is therefore
 //! also what a bad schema or a mislocated probe produces, so before any
 //! comparison is trusted the arm nobody transformed is required to have held on
-//! all eight traits. That check lives here rather than in [`Report`] -- what a
-//! failure report should say is FR-FORGER-008's problem.
+//! all eight traits. That reading now lives on [`Report`] itself
+//! ([`unsound_baseline`](Report::unsound_baseline)), because a caller who has to
+//! remember to derive it is a caller who will one day not -- the assertion here
+//! delegates to it rather than re-deriving it.
 
 use rusqlite::Connection;
 
+use smugglr_forger::census;
 use smugglr_forger::error::BoxError;
 use smugglr_forger::fixture::{Backing, Fixture, Route};
 use smugglr_forger::oracle::{differential, Arm, Divergence, Outcome, Report};
-use smugglr_forger::registry::TraitCase;
 use smugglr_forger::schema::{Schema, Trait};
 
 /// smugglr's migration ledger, which exists in the transformed arm and not in
@@ -320,13 +322,7 @@ fn a_transformation_that_fails_is_reported_as_a_failure_and_not_as_a_divergence(
 /// than a merge -- and each probe still finds its own construct by reading the
 /// schema, which is the property that lets one schema carry all eight.
 fn every_trait() -> Schema {
-    let mut all = Schema::default();
-    for kind in Trait::ALL {
-        all.tables.extend(TraitCase::for_trait(kind).schema.tables);
-    }
-    all.validate()
-        .expect("the union of the case schemas is one SQLite would accept");
-    all
+    census::every_trait_schema()
 }
 
 #[test]
@@ -399,15 +395,16 @@ fn stored_ddl_after(statements: Option<&str>, table: &str) -> String {
 /// produce, and every comparison in this file would be an agreement between two
 /// wrong answers.
 fn assert_baseline_is_sound(report: &Report) {
-    for outcome in &report.traits {
-        assert_eq!(
-            outcome.from_scratch,
-            Outcome::Held,
-            "{:?} did not hold in the arm built from scratch, so nothing compared against it \
-             means anything",
-            outcome.kind
-        );
-    }
+    let unsound: Vec<(Trait, &Outcome)> = report
+        .unsound_baseline()
+        .into_iter()
+        .map(|outcome| (outcome.kind, &outcome.from_scratch))
+        .collect();
+    assert!(
+        unsound.is_empty(),
+        "these did not hold in the arm built from scratch, so nothing compared against it means \
+         anything: {unsound:?}"
+    );
 }
 
 /// The transformed arm ran the probe and the probe failed -- the construct is


### PR DESCRIPTION
Closes #357. Closes #358. They land together because they are one surface: what the harness says when it passes, and what it says when it fails.

## Acceptance criteria mapping

### A passing run prints schemas exercised and probes executed, broken down by trait

Three phases per trait, and the third is the one that matters: the case's own schema (must hold), both differential arms under a do-nothing transform (must hold), and the same probe against **a database with nothing in it** (must *refuse*). An empty database is green on every behavioural assertion ever written, so a probe reporting "held" against one is asserting nothing.

Evidence, verbatim from `cargo test -p smugglr-forger --test execution_census`, identical under a bare `cargo test`:

```
forger census: 10 schemas exercised, 32 probes executed, 8 traits, 4.6ms

  trait                 schemas  probes  what each phase said
  ForeignKeyWithAction        3       4  case:held  transformed:held  from-scratch:held  empty:refused
  ...
  8 traits, 32 probes.
  the arm nobody transformed held on every trait, so the comparison rests on something.
```

`harness = false`, because libtest captures the stdout of a *passing* test and this requirement is unsatisfiable as written on the default harness. Follows `corpus_runs.rs`, the existing precedent.

### A run executing zero probes exits non-zero and says so in terms an operator can act on

An absent baseline is a loud named refusal rather than a floor of zero; a baseline with no entries, or one listing a trait twice, is refused too. The "empty database" phase is the per-trait equivalent -- a probe that holds against nothing is reported as the failure it is, not counted as a pass.

Evidence: the failing-run output names the trait, then says *"nothing can behave correctly with nothing in it, so this probe is asserting nothing and every green it has reported is a statement about nothing. Look for an assertion that was removed, short-circuited, or left returning Ok."*

### CI fails when the probe count drops below a recorded baseline

`tests/execution-baseline.json`, one entry per trait in `Trait` order, each carrying a `note` field holding its own maintenance instructions -- JSON has no comments, same precedent as `Regression::provenance`.

Raised with `FORGER_RECORD_BASELINE=1`, which rewrites the file **and exits non-zero**: a run that rewrote the check cannot also have passed it. The diff is the review.

Evidence: see the break-2 measurement below, which is what this criterion exists for.

### Verified by deliberately disabling a probe and observing the check go red

Two breaks, both measured, and the second is the important one.

**Break 1 -- `probe_trigger` stubbed to `return Ok(())`.** Census went red naming `Trigger`. The probe count stayed at **32** -- a bare counter would not have moved, which is the whole argument for the empty-database phase. Five other targets also caught it, so the census is not the only detector here; its contribution is the per-trait, operator-legible report.

**Break 2 -- `Trait::Trigger` removed from `Trait::ALL`.** Tally dropped to 7 traits / 28 probes and the runner said: *"Trigger did not run at all, and the baseline records 4 probes for it. A trait that stops being iterated takes its coverage with it and every other check in this crate stays green, because they all iterate the same list."*

Under break 2, **every pre-existing test in the crate passed** -- `all_lists_each_variant_once`, `every_case_carries_a_valid_schema`, `probes_are_non_vacuous`, the entire oracle suite. Only the new check went red. That is the real coverage hole the baseline closes, measured rather than argued.

Both experiments reverted; `git diff` on `schema/mod.rs` and `registry/cases.rs` is empty.

### A failure names the trait that failed

The trait is the first thing in the finding, and it is followed immediately by a plain-language statement of what that trait is *for* rather than by the mechanism that failed. That ordering is deliberate: a reader who has never opened this crate needs to know what was being protected before they can evaluate a report that it stopped working. Naming the trait alone would satisfy the letter of the criterion and leave the reader looking up an enum variant.

Evidence: the failing-run output above opens with `Trigger -- its probe reports that an empty database behaves correctly`, then `the trait  a trigger fires when its table is written to...` before any `before`/`after` detail.

### It prints the minimal reproducing schema in the builder's readable form, and that output compiles

`tests/the_emitted_schema_source_compiles.rs` is a real test target whose eight functions contain the emitter's own output pasted in unaltered -- **cargo compiles the file, so compilation is proved by the build itself** rather than by inspection.

Evidence: two tests close the loop. The pasted source builds a `Schema` equal to the registry case it came from -- a block that compiles and describes some *other* schema is worse than one that does not compile. And `include_str!` reads the blocks back out of the file and compares them, whitespace-collapsed, to live emitter output, printing the replacement text on failure so re-emitting is a copy rather than a tool hunt. `#[rustfmt::skip]` keeps rustfmt from becoming a third author of machine-compared text.

The emitter **refuses rather than degrades**: three model shapes have no builder spelling, and it names the table and the reason and falls back to `to_ddl()` labelled as SQL, not passed off as source.

### It states observed versus expected in before/after terms, not a diff of two blobs

The rendering is four labelled parts -- trait, `before`, `after`, `so` -- then the reproducing schema. `before` is not a serialisation of the expected schema; it is a sentence about what the untransformed arm actually *did*, which is the only form of "expected" that means anything for a behavioural oracle. `so` is what turns the pair into a finding rather than a pair of observations, stating what follows from the difference. A structural diff was available and rejected: two `CREATE TABLE` texts differing in whitespace tell a reader nothing about whether a cascade still cascades.

Evidence: a dropped `ON DELETE CASCADE` renders `before` = *"the same schema built from scratch, never transformed: it did what the target schema says it does"* and `after` = *"deleting keeper.id = 1 was refused (FOREIGN KEY constraint failed), and a child declared ON DELETE CASCADE does not refuse it -- the action was reconstructed as something else, or dropped, which leaves NO ACTION"*.

### No failure output requires reading forger's source to interpret

Every finding is self-contained prose: what the trait is for, what the sound arm did, what the transformed arm did, and what follows from the difference. No output names an internal type, a module path, or a function a reader would have to go look up. The reproducing schema carries its own usage instructions rather than assuming the reader knows how `differential` is called, and it states the one constraint that would otherwise waste their time -- that a transformation scoped to those tables reproduces the failure directly, while one written against a wider schema needs the tables it expects added or it will refuse to run rather than diverge.

Evidence: the failing-run output quoted above, in full, is what an operator sees; nothing in it requires opening the crate. The `so` clause is the test of this criterion -- it converts an observation into an instruction, telling the reader to look for an assertion that was removed, short-circuited, or left returning `Ok`.

## The deferred decision, resolved

`oracle.rs` left baseline-soundness in a *test helper* deliberately, because what a failure should say was this issue's problem. Resolved as **`Report::baseline_is_sound()` / `unsound_baseline()` -- a query, not a field, not a `Divergence`, not an `Err`.**

Not a field, because the data is already in `traits` and a stored copy is a second representation able to disagree. Not a `Divergence` -- the load-bearing half -- because a divergence says *the arms disagreed*, a statement about the caller's transformation, while unsoundness says *the arms may agree for a bad reason*, a statement about the measurement; folding them together would make `diverged()` true on runs where the transformation did nothing wrong, and a gate that cries wolf is one people learn to bypass. Not an `Err`, because the report is still worth reading -- *which* trait failed in the baseline is exactly what distinguishes a schema problem from a probe problem.

It now leads every rendered report, clean or failing, because **a clean verdict over an unsound baseline is the most dangerous thing this crate can emit.**

## Not done

- **Nothing states the coverage boundary** -- native rusqlite only, not http-sql/D1/wasm. That is #360, and the tally's wording was kept from implying completeness.
- `probes_are_non_vacuous.rs`, the corpus fixtures (#359) and `schema/mod.rs` (#371) untouched.

## Defects found

**`Trait::ALL` is scaffolding with nothing behind it**, and its own doc comment says the compiler protects it. The compiler catches a *missing case*, not a *missing iteration*, and those are different holes. Every guard in the crate iterates that list, so removing a variant makes all of them exercise less and stay green -- measured under break 2, now closed by the per-trait baseline.

**`Report` could not say whether its own baseline was sound.** The derivation lived only in a test helper, so any consumer outside forger got the false-clean by default.

**In this PR's own new code, caught in review before commit:** `Baseline::store` mapped write failures to `BaselineError::Read`, rendering *"reading the baseline: permission denied"* on a failed write -- a lying error message inside a change whose entire thesis is that failure output must not lie. Split into a `Write` variant.

**Pre-existing, out of scope:** `ci.yml`'s `test` and `clippy` jobs run without `--workspace`, resolving to `default-members`. Forger is in that set so the census gates as intended, but the pattern is the #339 shape one edit away from recurring.