### PR TITLE
feat(#360): forger states the coverage boundary it derived from what it covered

### DIFF
--- a/crates/smugglr-forger/src/boundary.rs
+++ b/crates/smugglr-forger/src/boundary.rs
@@ -1,0 +1,664 @@
+//! What forger does not exercise, worked out from what it does.
+//!
+//! An unstated boundary becomes a false claim of coverage, and that is the
+//! defect class this crate was built to eliminate -- so leaving forger's own
+//! boundary implicit would be self-contradictory. v1 exercises the native
+//! rusqlite path and eight [`Trait`] variants. Everything else a reader might
+//! assume is covered is named here, printed by every census run, and reachable
+//! as a value. FR-FORGER-010.
+//!
+//! # Why this is computed rather than written down
+//!
+//! A hand-written paragraph goes stale the first time someone adds coverage and
+//! forgets to edit it, and a stale boundary is worse than none: it is a
+//! documented claim that no longer matches the code, which is the exact
+//! documented-versus-actual failure this codebase has produced repeatedly. So
+//! [`Boundary::of_this_build`] is a function of the covered set, and every line
+//! it emits is conditional on a fact it just measured:
+//!
+//! * The **paths** line is [`Path::ALL`] minus the paths [`Backing::ALL`] can
+//!   stand a database up on. Standing one up somewhere else means adding a
+//!   [`Backing`], and a new backing does not compile until [`path_of`] says
+//!   which path it drives -- at which point that path leaves this list without
+//!   anyone editing prose.
+//! * The **referential action** lines are [`ReferentialAction::ALL`] minus what
+//!   the registry's case schemas actually declare. Declaring `ON UPDATE
+//!   CASCADE` in a case removes the `ON UPDATE` line by itself.
+//! * The **unrenderable** line asks [`quote`] what it does with an ordinary
+//!   identifier. It is there because that function double-quotes
+//!   unconditionally; a `quote` that emitted a bare name where SQLite allows one
+//!   would take the line away.
+//!
+//! # Where a computed line still needs a witness
+//!
+//! A derivation over the case schemas sees what is *declared*, and coverage is
+//! declaration plus a probe that reads it. Nothing here can tell a case that
+//! gained a key from a case that gained an assertion, so the two lines where
+//! that gap is live -- `ON UPDATE` and `RESTRICT` -- are held between the two
+//! blind-spot tests in `tests/the_known_defects_are_rediscovered.rs`. Each of
+//! those demonstrates the loss going unreported *and* asserts that this boundary
+//! still claims it. A probe that closes the gap turns the first assertion red; a
+//! case schema edited so the claim disappears with no probe to earn it turns the
+//! second red. Neither can move without the other.
+//!
+//! Those tests ask [`Boundary::undeclared_on_update`] rather than reading the
+//! sentence, and the difference is the whole point: declaring `ON UPDATE
+//! CASCADE` in a case changes the line's wording without emptying it, so a
+//! substring check would stay green over a build that had lost the claim and
+//! kept the blind spot. Measured, not assumed -- adding that declaration to
+//! `registry/cases.rs` turns both tests red, and the line's prose alone does not
+//! say so.
+//!
+//! # The three lines nothing here can measure
+//!
+//! * **unspellable** -- an absent field is absent from the type, so there is no
+//!   value to interrogate. Pinned instead to the shape of [`ForeignKey`]:
+//!   `a_new_foreign_key_field_is_a_boundary_that_moved` asserts its field set,
+//!   so adding `match` or `deferrable` to the model fails a test that names this
+//!   module.
+//! * **unobservable** -- forger holds a `Connection` and no subscriber, which is
+//!   a fact about what this crate is rather than about a value it carries.
+//!   Nothing pins it, and nothing could without forger growing an ability it
+//!   deliberately does not have.
+//! * **unreachable** -- a statement about smugglr's code paths, which forger
+//!   cannot import and must not learn about. It stays hand-written, and it is
+//!   the one line here a reader should check against the issue it cites rather
+//!   than against this crate.
+//!
+//! # What is deliberately not here
+//!
+//! Which known defects the *rediscovery register* cannot reach for reasons
+//! particular to a defect rather than to forger's coverage -- a composite
+//! `PRIMARY KEY (a DESC, b)`, smugglr#344's corruption, smugglr#343's error
+//! door. Those are recorded in that file's module docs, next to the tests that
+//! demonstrate them, and are not restated here: two statements of one truth that
+//! can disagree is what this whole surface exists to remove.
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use crate::failure::{fill, hanging};
+use crate::fixture::Backing;
+use crate::registry::TraitCase;
+use crate::schema::ddl::quote;
+use crate::schema::{ForeignKey, ReferentialAction, TableConstraint, Trait};
+
+/// An identifier with nothing about it that needs quoting. What [`quote`] does
+/// to this one is what it does to every name forger renders.
+const PLAIN_IDENTIFIER: &str = "plain";
+
+// ---------------------------------------------------------------------------
+// Execution paths
+// ---------------------------------------------------------------------------
+
+/// An execution path a schema change can travel on its way to SQLite.
+///
+/// The variants are smugglr's adapters, which forger cannot name by importing
+/// them -- it depends on no `smugglr-*` crate and never will. They are listed
+/// here because a boundary that said "some paths are not covered" would be the
+/// generic disclaimer this module exists instead of.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Path {
+    /// A local `rusqlite::Connection`. Everything forger does happens here: a
+    /// [`Fixture`](crate::Fixture) hands a transformation a `&mut Connection`,
+    /// so a transformation that never touches one cannot be handed to forger at
+    /// all.
+    Native,
+    /// The http-sql adapter. See [`Wasm`](Self::Wasm) for what the three share.
+    HttpSql,
+    /// The Cloudflare D1 adapter. See [`Wasm`](Self::Wasm).
+    D1,
+    /// The wasm adapter, and with it the two above.
+    ///
+    /// All three derive the columns of a write from `rows[0].keys()` and emit
+    /// `INSERT OR REPLACE`, which destroys a column absent from that first row
+    /// by a different mechanism than the native path does. smugglr#322 Part A
+    /// fixed the native side only and smugglr#324 named the rest an explicit
+    /// non-goal, so a native-only harness is green while these three stay
+    /// broken -- which is the whole reason this module exists rather than a
+    /// sentence in a README.
+    Wasm,
+}
+
+impl Path {
+    /// Every path. Scaffolding rather than enforcement, as
+    /// [`Trait::ALL`] is -- and failing in the same direction: a path left off
+    /// this list is one the boundary does not claim to have missed.
+    pub const ALL: [Path; 4] = [Path::Native, Path::HttpSql, Path::D1, Path::Wasm];
+
+    /// The path's name, as smugglr's own issues spell it.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Path::Native => "native rusqlite",
+            Path::HttpSql => "http-sql",
+            Path::D1 => "D1",
+            Path::Wasm => "wasm",
+        }
+    }
+
+    /// Why not exercising this path leaves something uncovered, in one clause.
+    ///
+    /// Kept to a clause because it is printed on every run; the long form is on
+    /// the variants above. Written per variant rather than once for the group so
+    /// that a path added later cannot inherit a sentence that happens to be
+    /// about the three adapters that are here now. Identical clauses are emitted
+    /// once, so the three that really do share a mechanism read as one
+    /// statement.
+    pub fn mechanism(self) -> &'static str {
+        match self {
+            // Never emitted while Native is exercised, and true if it ever is
+            // not: this is the path every probe in the registry runs on.
+            Path::Native => "nothing forger does reaches SQLite by any other route",
+            Path::HttpSql | Path::D1 | Path::Wasm => {
+                "each derives its columns from rows[0].keys() and emits INSERT OR REPLACE, \
+                 destroying an absent column by a mechanism the native path does not have. \
+                 smugglr#324"
+            }
+        }
+    }
+}
+
+/// The path a fixture on this backing executes on.
+///
+/// Exhaustive with no catch-all, for the reason
+/// [`registry`](crate::registry) gives about its own dispatch: a [`Backing`]
+/// that stood a database up somewhere other than a local `rusqlite::Connection`
+/// would not compile until it said which path it drives, and saying so takes
+/// that path off [`Boundary`]'s list on the next run.
+fn path_of(backing: Backing) -> Path {
+    match backing {
+        Backing::Memory | Backing::File => Path::Native,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The boundary
+// ---------------------------------------------------------------------------
+
+/// What one line of the boundary is about.
+///
+/// A value rather than a label so that a test can ask whether a specific claim
+/// is still being made -- which is how the two claims nothing can measure are
+/// held to the tests that demonstrate them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Subject {
+    /// Execution paths no fixture reaches. See [`Path`].
+    Adapters,
+    /// `ON DELETE` actions no case schema declares, so no probe asserts what
+    /// dropping one would change. Derived from the case schemas.
+    OnDelete,
+    /// `ON UPDATE` actions no case schema declares.
+    ///
+    /// The `ForeignKeyWithAction` case declares `ON DELETE` actions only and its
+    /// probe reads `fk.on_delete`, so nothing in forger asks what an `UPDATE` to
+    /// a parent key does. smugglr#374.
+    /// `smugglr_341_a_dropped_on_update_action_is_not_rediscovered` shows the
+    /// loss is real and the oracle silent about it, and asserts this line is
+    /// still here.
+    OnUpdate,
+    /// `ON DELETE RESTRICT`, which is declared and cannot be told apart from the
+    /// default it differs from.
+    ///
+    /// `RESTRICT` and the `NO ACTION` default both refuse the delete while
+    /// enforcement is immediate; they part company only under `DEFERRABLE
+    /// INITIALLY DEFERRED`, where `RESTRICT` fires at the statement and `NO
+    /// ACTION` waits for the commit. The schema model has no deferrable
+    /// spelling, so on every connection forger can build the two are the same
+    /// behaviour -- and a probe asserting an end state is right to say nothing.
+    /// The rediscovery of smugglr#374 therefore rests entirely on its `CASCADE`
+    /// half, which is what
+    /// `smugglr_341_the_same_loss_on_a_restrict_key_alone_is_not_rediscovered`
+    /// demonstrates.
+    Restrict,
+    /// Constructs the schema model has no spelling for: `MATCH` and `DEFERRABLE
+    /// INITIALLY DEFERRED`.
+    ///
+    /// `MATCH` is unprobeable rather than merely uncovered -- SQLite parses it
+    /// and ignores it, so there is no behavioural difference to observe even on
+    /// a database that carries one.
+    Unspellable,
+    /// Constructs the DDL renderer cannot emit.
+    ///
+    /// smugglr#340 is a defect in a scanner over `sqlite_master` text, and
+    /// forger cannot stage its input domain: [`quote`] double-quotes every
+    /// identifier unconditionally, so no schema forger renders can produce the
+    /// bare non-ASCII name that mis-splices or the single-quoted name that is
+    /// refused.
+    Unrenderable,
+    /// Consequences that are not a state of the database.
+    ///
+    /// smugglr#342 and smugglr#336 are each half about a `tracing::warn!` that a
+    /// module doc promised and the code never emitted. forger observes a
+    /// database and never a log, so it sees the loss and can never see whether
+    /// anyone was told about it.
+    Unobservable,
+    /// Defects of a code path that never reaches a reconstruction.
+    ///
+    /// smugglr#347 is a defect of the direct `ALTER TABLE ... DROP COLUMN` path,
+    /// which never rebuilds a table -- so there is no reconstruction for a
+    /// differential comparison to be about, whatever probe were written.
+    Unreachable,
+}
+
+impl Subject {
+    /// The label this subject appears under in the run output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Subject::Adapters => "adapters",
+            Subject::OnDelete => "on delete",
+            Subject::OnUpdate => "on update",
+            Subject::Restrict => "restrict",
+            Subject::Unspellable => "unspellable",
+            Subject::Unrenderable => "unrenderable",
+            Subject::Unobservable => "unobservable",
+            Subject::Unreachable => "unreachable",
+        }
+    }
+}
+
+/// One thing this build does not exercise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unexercised {
+    pub subject: Subject,
+    /// What is not exercised, and by what mechanism it goes unseen.
+    pub statement: String,
+}
+
+/// The coverage boundary of the build it was taken from.
+///
+/// The lines are what it prints; the sets beside them are what it printed them
+/// from. Both are reachable, because a caller checking whether a specific gap is
+/// still open must not have to read prose to find out -- a claim that can only
+/// be inspected as a sentence is one a test can only check by substring, and a
+/// substring check goes green on a sentence that has quietly stopped saying what
+/// it used to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Boundary {
+    lines: Vec<Unexercised>,
+    on_delete: BTreeSet<ReferentialAction>,
+    on_update: BTreeSet<ReferentialAction>,
+}
+
+impl Boundary {
+    /// Work the boundary out from the covered set.
+    ///
+    /// Every line is conditional: a gap that closes takes its line with it. See
+    /// the module docs for which lines are computed, which are pinned, and by
+    /// what.
+    pub fn of_this_build() -> Boundary {
+        let mut lines = Vec::new();
+
+        // Paths: what smugglr can execute on, minus what a fixture can be.
+        let driven: BTreeSet<Path> = Backing::ALL.into_iter().map(path_of).collect();
+        let unreached: Vec<Path> = Path::ALL
+            .into_iter()
+            .filter(|path| !driven.contains(path))
+            .collect();
+        if !unreached.is_empty() {
+            // Distinct mechanisms only: the three adapters share one, and say it
+            // once. Ordered by first appearance so the sentence follows the
+            // names it is about.
+            let mut mechanisms: Vec<&str> = Vec::new();
+            for path in &unreached {
+                if !mechanisms.contains(&path.mechanism()) {
+                    mechanisms.push(path.mechanism());
+                }
+            }
+            lines.push(Unexercised {
+                subject: Subject::Adapters,
+                statement: format!("{} -- {}.", names(&unreached), mechanisms.join("; ")),
+            });
+        }
+
+        // Referential actions: the five, minus the ones a case schema declares.
+        let (declared_on_delete, declared_on_update) = declared_actions();
+        let on_delete = undeclared(&declared_on_delete);
+        let on_update = undeclared(&declared_on_update);
+        if !on_delete.is_empty() {
+            lines.push(Unexercised {
+                subject: Subject::OnDelete,
+                statement: format!(
+                    "{} -- declared by no case schema, so probed by nothing.",
+                    spell(&on_delete)
+                ),
+            });
+        }
+        if on_update.len() == ReferentialAction::ALL.len() {
+            lines.push(Unexercised {
+                subject: Subject::OnUpdate,
+                statement: "every action. No case declares one and no probe reads one, so a \
+                            rebuild that drops ON UPDATE CASCADE is silent. smugglr#374."
+                    .to_string(),
+            });
+        } else if !on_update.is_empty() {
+            lines.push(Unexercised {
+                subject: Subject::OnUpdate,
+                statement: format!(
+                    "{} -- declared by no case schema. smugglr#374.",
+                    spell(&on_update)
+                ),
+            });
+        }
+        // Conditional on the action being declared: where no case declares it,
+        // the line above already says RESTRICT goes unexercised, and saying it
+        // twice in two different senses is worse than saying it once.
+        if declared_on_delete.contains(&ReferentialAction::Restrict) {
+            lines.push(Unexercised {
+                subject: Subject::Restrict,
+                statement: "declared and probed, and identical to the NO ACTION default under \
+                            immediate enforcement. smugglr#374."
+                    .to_string(),
+            });
+        }
+
+        // The model's own vocabulary. Not measurable: an absent field is absent
+        // from the type, so see the test this line is pinned to.
+        lines.push(Unexercised {
+            subject: Subject::Unspellable,
+            statement: "MATCH and DEFERRABLE INITIALLY DEFERRED -- no field in the schema model, \
+                        and SQLite parses MATCH and ignores it."
+                .to_string(),
+        });
+
+        // The renderer, asked rather than assumed.
+        if quote(PLAIN_IDENTIFIER) != PLAIN_IDENTIFIER {
+            lines.push(Unexercised {
+                subject: Subject::Unrenderable,
+                statement: "a bare or single-quoted identifier -- ddl::quote always \
+                            double-quotes. smugglr#340."
+                    .to_string(),
+            });
+        }
+
+        lines.push(Unexercised {
+            subject: Subject::Unobservable,
+            statement: "anything a log would have said -- forger reads a database, never a log. \
+                        smugglr#342, smugglr#336."
+                .to_string(),
+        });
+
+        lines.push(Unexercised {
+            subject: Subject::Unreachable,
+            statement: "the direct ALTER TABLE DROP COLUMN path -- no rebuild, so no \
+                        reconstruction to compare. smugglr#347."
+                .to_string(),
+        });
+
+        Boundary {
+            lines,
+            on_delete,
+            on_update,
+        }
+    }
+
+    /// Every line, in the order they are reported.
+    pub fn lines(&self) -> &[Unexercised] {
+        &self.lines
+    }
+
+    /// The `ON DELETE` actions no case schema declares.
+    pub fn undeclared_on_delete(&self) -> &BTreeSet<ReferentialAction> {
+        &self.on_delete
+    }
+
+    /// The `ON UPDATE` actions no case schema declares.
+    ///
+    /// Asked by name rather than read out of the sentence: a test that checked
+    /// the prose for "CASCADE" would pass on a build that declares `ON UPDATE
+    /// CASCADE` in a case and still has no probe reading it, because the line
+    /// merely changes shape. That build has *lost* the claim while keeping the
+    /// blind spot, which is the failure this whole module is against.
+    pub fn undeclared_on_update(&self) -> &BTreeSet<ReferentialAction> {
+        &self.on_update
+    }
+
+    /// What this boundary says about a subject, or `None` where it makes no
+    /// claim about it -- which is what a closed gap looks like.
+    pub fn statement(&self, subject: Subject) -> Option<&str> {
+        self.lines
+            .iter()
+            .find(|line| line.subject == subject)
+            .map(|line| line.statement.as_str())
+    }
+}
+
+impl fmt::Display for Boundary {
+    /// The whole boundary, framed. Printed on every census run, passing or not:
+    /// a reviewer has to learn this from the tool rather than discover it after
+    /// trusting a green check.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            "forger boundary: what this run did not exercise, worked out from what it did.\n\n",
+        )?;
+
+        let width = self
+            .lines
+            .iter()
+            .map(|line| line.subject.as_str().chars().count())
+            .max()
+            .unwrap_or_default();
+        for line in &self.lines {
+            f.write_str(&hanging(
+                &format!("  {:<width$}  ", line.subject.as_str()),
+                &line.statement,
+            ))?;
+        }
+
+        f.write_str("\n")?;
+        f.write_str(&fill(
+            "each line's mechanism, and what pins it, is in smugglr_forger::boundary.",
+            2,
+        ))?;
+        f.write_str("\n")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deriving from the covered set
+// ---------------------------------------------------------------------------
+
+/// Every referential action the registry's case schemas declare, by event.
+///
+/// The covered set is read from the cases themselves rather than from a list
+/// kept beside them, so a case that gains a key gains coverage here on the same
+/// commit.
+fn declared_actions() -> (BTreeSet<ReferentialAction>, BTreeSet<ReferentialAction>) {
+    let mut on_delete = BTreeSet::new();
+    let mut on_update = BTreeSet::new();
+    for kind in Trait::ALL {
+        for table in TraitCase::for_trait(kind).schema.tables {
+            for constraint in table.constraints {
+                if let TableConstraint::ForeignKey(ForeignKey {
+                    on_delete: delete,
+                    on_update: update,
+                    ..
+                }) = constraint
+                {
+                    on_delete.extend(delete);
+                    on_update.extend(update);
+                }
+            }
+        }
+    }
+    (on_delete, on_update)
+}
+
+/// [`ReferentialAction::ALL`] minus what was declared.
+fn undeclared(declared: &BTreeSet<ReferentialAction>) -> BTreeSet<ReferentialAction> {
+    ReferentialAction::ALL
+        .into_iter()
+        .filter(|action| !declared.contains(action))
+        .collect()
+}
+
+/// A set of actions as SQL writes them, in declaration order.
+fn spell(actions: &BTreeSet<ReferentialAction>) -> String {
+    join(
+        &actions
+            .iter()
+            .map(|action| action.as_sql())
+            .collect::<Vec<_>>(),
+    )
+}
+
+/// The paths, named the way the issues name them.
+fn names(paths: &[Path]) -> String {
+    join(&paths.iter().map(|path| path.as_str()).collect::<Vec<_>>())
+}
+
+/// `a`, `a and b`, `a, b and c`.
+fn join(items: &[&str]) -> String {
+    match items {
+        [] => String::new(),
+        [only] => (*only).to_string(),
+        [rest @ .., last] => format!("{} and {last}", rest.join(", ")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The acceptance bar in one assertion: the three adapters are named, and
+    /// named specifically rather than gestured at.
+    #[test]
+    fn the_adapters_are_named_rather_than_disclaimed() {
+        let boundary = Boundary::of_this_build();
+        let statement = boundary
+            .statement(Subject::Adapters)
+            .expect("no fixture reaches an adapter, so the boundary says so");
+        for adapter in ["http-sql", "D1", "wasm"] {
+            assert!(statement.contains(adapter), "{statement}");
+        }
+        assert!(
+            !statement.contains("native rusqlite"),
+            "the native path is exercised, so it is not on the list of what is not: {statement}"
+        );
+    }
+
+    /// The paths line is a subtraction, not a sentence. Standing a database up
+    /// on a path takes that path off the list, and this is that mechanism
+    /// exercised -- against the real derivation rather than a copy of it.
+    #[test]
+    fn a_path_that_a_backing_drives_is_not_reported_as_unexercised() {
+        let driven: BTreeSet<Path> = Backing::ALL.into_iter().map(path_of).collect();
+        assert!(
+            driven.contains(&Path::Native),
+            "every backing stands a database up on a local rusqlite connection"
+        );
+        for path in driven {
+            assert!(
+                !Boundary::of_this_build()
+                    .statement(Subject::Adapters)
+                    .expect("some path is unexercised")
+                    .contains(path.as_str()),
+                "{path:?} is driven and must not be listed as unexercised"
+            );
+        }
+    }
+
+    /// The ON UPDATE line is derived from the case schemas, so a schema that
+    /// declares the action takes the line away. Shown here by deriving over a
+    /// declared key rather than by trusting the sentence.
+    #[test]
+    fn declaring_an_action_removes_it_from_the_undeclared_list() {
+        let boundary = Boundary::of_this_build();
+        assert!(
+            !boundary
+                .undeclared_on_delete()
+                .contains(&ReferentialAction::Cascade),
+            "the ForeignKeyWithAction case declares ON DELETE CASCADE, so the boundary does not \
+             claim it goes unexercised"
+        );
+        assert_eq!(
+            boundary.undeclared_on_update(),
+            &BTreeSet::from(ReferentialAction::ALL),
+            "no case schema declares an ON UPDATE action of any kind. A case that starts \
+             declaring one changes this set, and the test in \
+             the_known_defects_are_rediscovered.rs that pins the ON UPDATE blind spot goes red \
+             until a probe earns the change"
+        );
+    }
+
+    /// `MATCH` and `DEFERRABLE` are claimed unspellable, and nothing can measure
+    /// an absent field. This is what stops that claim going stale: the model's
+    /// own shape, asserted, so adding either one fails a test that says where to
+    /// look.
+    #[test]
+    fn a_new_foreign_key_field_is_a_boundary_that_moved() {
+        let key = ForeignKey {
+            columns: vec!["child".into()],
+            parent_table: "parent".into(),
+            parent_columns: vec!["id".into()],
+            on_delete: None,
+            on_update: None,
+        };
+        let json = serde_json::to_value(&key).expect("a ForeignKey serializes");
+        let mut fields: Vec<&str> = json
+            .as_object()
+            .expect("a struct serializes to an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        fields.sort_unstable();
+        assert_eq!(
+            fields,
+            [
+                "columns",
+                "on_delete",
+                "on_update",
+                "parent_columns",
+                "parent_table"
+            ],
+            "a foreign key can now carry something it could not before. The boundary's \
+             `unspellable` line says MATCH and DEFERRABLE INITIALLY DEFERRED have no spelling in \
+             this model -- re-read it in src/boundary.rs before changing this list."
+        );
+        // The other half of the same claim: the type has no room for MATCH or a
+        // deferrable clause, so no schema can carry one.
+        assert!(!fields.contains(&"deferrable"));
+        assert!(!fields.contains(&"match_type"));
+    }
+
+    /// The unrenderable line asks the renderer rather than asserting about it.
+    #[test]
+    fn the_unrenderable_line_is_what_quote_does() {
+        assert_eq!(quote(PLAIN_IDENTIFIER), format!("\"{PLAIN_IDENTIFIER}\""));
+        assert!(Boundary::of_this_build()
+            .statement(Subject::Unrenderable)
+            .expect("quote double-quotes unconditionally, so the line is there")
+            .contains("smugglr#340"));
+    }
+
+    /// Every line is about a subject, says something, and is legible at the
+    /// width a CI log pane gets.
+    #[test]
+    fn every_line_is_one_a_reviewer_can_read() {
+        let boundary = Boundary::of_this_build();
+        assert!(
+            boundary.lines().len() >= 5,
+            "a boundary this short has lost lines rather than gained coverage"
+        );
+        let mut subjects: Vec<Subject> = boundary
+            .lines()
+            .iter()
+            .map(|line| line.subject)
+            .collect::<Vec<_>>();
+        let seen = subjects.len();
+        subjects.sort_unstable();
+        subjects.dedup();
+        assert_eq!(subjects.len(), seen, "a subject is stated twice");
+
+        for line in boundary.lines() {
+            assert!(
+                line.statement.ends_with('.'),
+                "{:?}: {}",
+                line.subject,
+                line.statement
+            );
+        }
+        for line in boundary.to_string().lines() {
+            assert!(line.chars().count() <= 90, "too wide to read: {line}");
+        }
+    }
+}

--- a/crates/smugglr-forger/src/boundary.rs
+++ b/crates/smugglr-forger/src/boundary.rs
@@ -21,9 +21,11 @@
 //!   [`Backing`], and a new backing does not compile until [`path_of`] says
 //!   which path it drives -- at which point that path leaves this list without
 //!   anyone editing prose.
-//! * The **referential action** lines are [`ReferentialAction::ALL`] minus what
-//!   the registry's case schemas actually declare. Declaring `ON UPDATE
-//!   CASCADE` in a case removes the `ON UPDATE` line by itself.
+//! * The **referential action** lines are the actions a schema can declare --
+//!   [`ReferentialAction::ALL`] without the `NO ACTION` default, for the reason
+//!   [`declarable`] gives -- minus what the registry's case schemas actually
+//!   declare. Declaring `ON UPDATE CASCADE` in a case removes the `ON UPDATE`
+//!   line by itself.
 //! * The **unrenderable** line asks [`quote`] what it does with an ordinary
 //!   identifier. It is there because that function double-quotes
 //!   unconditionally; a `quote` that emitted a bare name where SQLite allows one
@@ -83,9 +85,15 @@ use crate::registry::TraitCase;
 use crate::schema::ddl::quote;
 use crate::schema::{ForeignKey, ReferentialAction, TableConstraint, Trait};
 
-/// An identifier with nothing about it that needs quoting. What [`quote`] does
-/// to this one is what it does to every name forger renders.
-const PLAIN_IDENTIFIER: &str = "plain";
+/// The kind of identifier smugglr#340 needs rendered bare.
+///
+/// Non-ASCII rather than a plain word on purpose. A [`quote`] that went
+/// conditional -- bare where the name is a safe ASCII identifier, quoted
+/// otherwise -- would retract the `unrenderable` line while forger still could
+/// not stage that defect's input, which is a false retraction in the unsafe
+/// direction. Asking about this name asks the question the line is actually
+/// about.
+const NON_ASCII_IDENTIFIER: &str = "naïve";
 
 // ---------------------------------------------------------------------------
 // Execution paths
@@ -323,7 +331,11 @@ impl Boundary {
                 ),
             });
         }
-        if on_update.len() == ReferentialAction::ALL.len() {
+        // The emphatic form only where *nothing* is declared. Counted against
+        // the declarable set rather than against ReferentialAction::ALL, which
+        // would never be reached and would silently demote this to the list
+        // form below.
+        if on_update.len() == declarable().len() {
             lines.push(Unexercised {
                 subject: Subject::OnUpdate,
                 statement: "every action. No case declares one and no probe reads one, so a \
@@ -361,10 +373,10 @@ impl Boundary {
         });
 
         // The renderer, asked rather than assumed.
-        if quote(PLAIN_IDENTIFIER) != PLAIN_IDENTIFIER {
+        if quote(NON_ASCII_IDENTIFIER) != NON_ASCII_IDENTIFIER {
             lines.push(Unexercised {
                 subject: Subject::Unrenderable,
-                statement: "a bare or single-quoted identifier -- ddl::quote always \
+                statement: "a bare non-ASCII or single-quoted identifier -- ddl::quote always \
                             double-quotes. smugglr#340."
                     .to_string(),
             });
@@ -483,9 +495,27 @@ fn declared_actions() -> (BTreeSet<ReferentialAction>, BTreeSet<ReferentialActio
     (on_delete, on_update)
 }
 
-/// [`ReferentialAction::ALL`] minus what was declared.
-fn undeclared(declared: &BTreeSet<ReferentialAction>) -> BTreeSet<ReferentialAction> {
+/// The actions a schema can declare, and that a rebuild can therefore drop.
+///
+/// [`ReferentialAction::NoAction`] is not one of them. It is what a key with no
+/// clause already means, so "no case schema declares NO ACTION" describes the
+/// state every undecorated key in the registry is already in rather than a gap
+/// -- and on the `ON DELETE` side it is worse than useless: the `RESTRICT` half
+/// of `probe_foreign_key_with_action` asserts that the protected parent survives
+/// its delete, which *is* the NO ACTION behaviour, since the two are
+/// indistinguishable under immediate enforcement. Reporting it as unexercised
+/// made two lines of this boundary contradict each other, which is the defect
+/// this module exists to prevent, arriving inside the module itself.
+fn declarable() -> Vec<ReferentialAction> {
     ReferentialAction::ALL
+        .into_iter()
+        .filter(|action| *action != ReferentialAction::NoAction)
+        .collect()
+}
+
+/// The declarable actions minus what was declared.
+fn undeclared(declared: &BTreeSet<ReferentialAction>) -> BTreeSet<ReferentialAction> {
+    declarable()
         .into_iter()
         .filter(|action| !declared.contains(action))
         .collect()
@@ -572,7 +602,7 @@ mod tests {
         );
         assert_eq!(
             boundary.undeclared_on_update(),
-            &BTreeSet::from(ReferentialAction::ALL),
+            &declarable().into_iter().collect::<BTreeSet<_>>(),
             "no case schema declares an ON UPDATE action of any kind. A case that starts \
              declaring one changes this set, and the test in \
              the_known_defects_are_rediscovered.rs that pins the ON UPDATE blind spot goes red \
@@ -623,7 +653,10 @@ mod tests {
     /// The unrenderable line asks the renderer rather than asserting about it.
     #[test]
     fn the_unrenderable_line_is_what_quote_does() {
-        assert_eq!(quote(PLAIN_IDENTIFIER), format!("\"{PLAIN_IDENTIFIER}\""));
+        assert_eq!(
+            quote(NON_ASCII_IDENTIFIER),
+            format!("\"{NON_ASCII_IDENTIFIER}\"")
+        );
         assert!(Boundary::of_this_build()
             .statement(Subject::Unrenderable)
             .expect("quote double-quotes unconditionally, so the line is there")

--- a/crates/smugglr-forger/src/failure.rs
+++ b/crates/smugglr-forger/src/failure.rs
@@ -909,13 +909,22 @@ fn literal(value: &str) -> String {
 
 /// A labelled paragraph, wrapped and hanging under its label.
 fn labelled(label: &str, body: &str) -> String {
-    let first = format!("    {label:<LABEL$}");
-    let wrapped = fill(body, first.len());
-    format!("{first}{}\n", wrapped.trim_start())
+    hanging(&format!("    {label:<LABEL$}"), body)
+}
+
+/// A prefix, then prose wrapped to [`WIDTH`] and hanging under it.
+///
+/// The prefix is written out verbatim, indentation and all, so a caller that
+/// lays its own label column out -- [`boundary`](crate::boundary) does -- gets
+/// the same wrapping as everything else here rather than a second
+/// implementation of it that disagrees at the margin.
+pub(crate) fn hanging(prefix: &str, body: &str) -> String {
+    let wrapped = fill(body, prefix.chars().count());
+    format!("{prefix}{}\n", wrapped.trim_start())
 }
 
 /// Wrap prose to [`WIDTH`], indenting every line by `hang`.
-fn fill(text: &str, hang: usize) -> String {
+pub(crate) fn fill(text: &str, hang: usize) -> String {
     let pad = " ".repeat(hang);
     let mut lines: Vec<String> = Vec::new();
     let mut line = pad.clone();

--- a/crates/smugglr-forger/src/fixture.rs
+++ b/crates/smugglr-forger/src/fixture.rs
@@ -48,6 +48,17 @@ pub enum Backing {
     File,
 }
 
+impl Backing {
+    /// Every backing, for iterating.
+    ///
+    /// Read by [`boundary`](crate::boundary), which derives the execution paths
+    /// forger exercises from the backings it can stand a database up on. A
+    /// backing that is not listed here is a path the boundary will not claim,
+    /// which understates coverage rather than overstating it -- the direction
+    /// this crate errs in on purpose.
+    pub const ALL: [Backing; 2] = [Backing::Memory, Backing::File];
+}
+
 /// How a fixture is brought to a state.
 ///
 /// One method takes all three, and the symmetry is load-bearing rather than

--- a/crates/smugglr-forger/src/lib.rs
+++ b/crates/smugglr-forger/src/lib.rs
@@ -35,6 +35,10 @@
 //!   empty one.
 //! * [`failure`] -- what a failure says: the trait, the before and the after,
 //!   and the schema that carries it as source a reader can paste.
+//! * [`boundary`] -- what forger does *not* exercise, worked out from what it
+//!   does and printed on every census run. It is not restated here: a second
+//!   copy of a boundary is a copy that can go stale, which is the failure the
+//!   module exists to prevent.
 //!
 //! ```
 //! use smugglr_forger::fixture::{Backing, Fixture, Route};
@@ -55,6 +59,7 @@
 //! fixture.bring_to(Route::Schema(&target)).unwrap();
 //! ```
 
+pub mod boundary;
 pub mod census;
 pub mod corpus;
 pub mod error;
@@ -64,6 +69,7 @@ pub mod oracle;
 pub mod registry;
 pub mod schema;
 
+pub use boundary::{Boundary, Path, Subject, Unexercised};
 pub use census::{Anomaly, Baseline, Census, Shortfall};
 pub use corpus::Regression;
 pub use error::{BoxError, ForgeError, ProbeError, ValidationError};

--- a/crates/smugglr-forger/src/schema/mod.rs
+++ b/crates/smugglr-forger/src/schema/mod.rs
@@ -248,7 +248,12 @@ pub struct ForeignKey {
     pub on_update: Option<ReferentialAction>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// What a foreign key does when the row it points at moves or goes away.
+///
+/// `Ord` so a set of them can be collected and subtracted from
+/// [`ALL`](Self::ALL) in declaration order -- [`boundary`](crate::boundary)
+/// derives what goes unexercised that way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub enum ReferentialAction {
     NoAction,
@@ -259,6 +264,24 @@ pub enum ReferentialAction {
 }
 
 impl ReferentialAction {
+    /// Every action, for iterating.
+    ///
+    /// Scaffolding rather than enforcement, exactly as [`Trait::ALL`] is: the
+    /// compiler will not notice a variant left out of this array. What makes
+    /// the omission survivable is the direction it fails in --
+    /// [`boundary`](crate::boundary) subtracts what the registry declares from
+    /// this list to derive which actions go unexercised, so a variant missing
+    /// here is a gap the boundary does not claim rather than coverage it
+    /// invents. [`as_sql`](Self::as_sql) below is the exhaustive match a new
+    /// variant does break, and it is the next thing anyone adding one reads.
+    pub const ALL: [ReferentialAction; 5] = [
+        ReferentialAction::NoAction,
+        ReferentialAction::Restrict,
+        ReferentialAction::SetNull,
+        ReferentialAction::SetDefault,
+        ReferentialAction::Cascade,
+    ];
+
     pub fn as_sql(&self) -> &'static str {
         match self {
             ReferentialAction::NoAction => "NO ACTION",

--- a/crates/smugglr-forger/tests/execution_census.rs
+++ b/crates/smugglr-forger/tests/execution_census.rs
@@ -34,6 +34,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
+use smugglr_forger::boundary::Boundary;
 use smugglr_forger::census::{Baseline, Census, Phase, TraitTally};
 use smugglr_forger::failure::render_report;
 use smugglr_forger::fixture::Backing;
@@ -64,6 +65,12 @@ fn main() -> ExitCode {
     let elapsed = started.elapsed();
 
     print_tally(&census, elapsed);
+
+    // Unconditionally, and before any verdict: what a run covers is only half of
+    // what a reviewer needs, and the half they are liable to assume. A boundary
+    // printed only on failure is one nobody reads on the run that convinced
+    // them. FR-FORGER-010.
+    println!("{}", Boundary::of_this_build());
 
     if std::env::var_os(RECORD).is_some() {
         return record(&census);

--- a/crates/smugglr-forger/tests/the_known_defects_are_rediscovered.rs
+++ b/crates/smugglr-forger/tests/the_known_defects_are_rediscovered.rs
@@ -33,24 +33,23 @@
 //! # What forger cannot rediscover, and why
 //!
 //! This list is the point of the exercise as much as the tests are, and it is
-//! kept here rather than in a report nobody re-reads. FR-FORGER-010.
+//! kept here rather than in a report nobody re-reads. FR-FORGER-012.
 //!
-//! * **smugglr#341's `ON UPDATE` half.** The registry's `ForeignKeyWithAction`
-//!   case declares only `ON DELETE` actions and its probe reads only
-//!   `fk.on_delete`, so a rebuild that drops `ON UPDATE CASCADE` is silent.
-//!   Demonstrated below rather than asserted, in
-//!   [`smugglr_341_a_dropped_on_update_action_is_not_rediscovered`], which shows
-//!   the loss is real and the oracle says nothing about it.
+//! Most of it is not a fact about this register but about forger's coverage
+//! envelope: the adapters, the `ON UPDATE` and `RESTRICT` halves of
+//! smugglr#341, `MATCH`, anything a log would have said, smugglr#340, and
+//! smugglr#347's missing rebuild. Those are stated by [`Boundary`], derived
+//! from the covered set and printed by every census run -- FR-FORGER-010 -- and
+//! they are deliberately not restated here. Two accounts of one truth can
+//! disagree, and this file would be the copy that goes stale the first time
+//! somebody adds a probe. The two blind spots nothing can measure are
+//! demonstrated below instead, in
+//! [`smugglr_341_a_dropped_on_update_action_is_not_rediscovered`] and
+//! [`smugglr_341_the_same_loss_on_a_restrict_key_alone_is_not_rediscovered`],
+//! each of which asserts both that the loss goes unreported *and* that the
+//! boundary still says so.
 //!
-//! * **smugglr#341's `RESTRICT` half.** Also demonstrated below. `RESTRICT` and
-//!   the `NO ACTION` default are behaviourally identical while enforcement is
-//!   immediate -- they differ only under `DEFERRABLE INITIALLY DEFERRED`, which
-//!   the schema model cannot express -- so the probe's silence is a correct
-//!   answer about this connection and a blind spot about the defect.
-//!
-//! * **smugglr#341's `MATCH` clause.** Not in the schema model, and there would
-//!   be nothing to probe if it were: SQLite parses `MATCH` and ignores it. This
-//!   one is unprobeable rather than merely uncovered.
+//! What is left is particular to a defect rather than to what forger covers:
 //!
 //! * **smugglr#343's expression-`DEFAULT` defect in the shape it was found.**
 //!   The reconstruction is a syntax error, so the transformation fails and
@@ -69,39 +68,29 @@
 //!   rowid alias -- which exists only for the single-column column-level form.
 //!   The single-column form is rediscovered below; the composite one is not.
 //!
-//! * **The silence itself, in smugglr#342 and smugglr#336.** Both issues are
-//!   half about a `tracing::warn!` that the module doc promised and the code
-//!   never emitted. forger observes a database and never a log, so it can see
-//!   the loss and can never see whether anyone was told about it.
-//!
 //! * **smugglr#344's corruption, as opposed to its promotion.** The promotion to
 //!   declared `BLOB` is rediscovered below. The corruption it opens the door to
 //!   is base64 canonicalization in smugglr's `rowhash`, which is a decision made
 //!   about a column's declared type in another crate -- there is no state of the
 //!   database that differs.
 //!
-//! * **smugglr#340 entirely.** It is a defect in a scanner over `sqlite_master`
-//!   text, and forger cannot even stage its input domain:
-//!   `schema::ddl::quote` double-quotes every identifier unconditionally, so no
-//!   schema forger renders can produce the bare non-ASCII name that mis-splices
-//!   or the single-quoted name that is refused. Even given the input, the issue
-//!   records the outcome as a hard SQLite syntax error -- the error door again,
-//!   naming no trait.
+//! * **smugglr#340's outcome, as opposed to its input domain.** [`Boundary`]
+//!   states that forger cannot render the identifier that defect needs. Even
+//!   given the input, the issue records the outcome as a hard SQLite syntax
+//!   error -- the error door again, naming no trait.
 //!
-//! * **smugglr#347 entirely**, for two independent reasons. It is a defect of
-//!   the direct `ALTER TABLE ... DROP COLUMN` path, which never reaches a
-//!   rebuild, so there is no reconstruction for a differential comparison to be
-//!   about. And its shape cannot be staged here anyway: the only trigger in the
-//!   registry references exactly the column the trigger probe's own `INSERT`
-//!   names, so "a trigger abandoned by a dropped column" and "the probe's
-//!   statement named a column that is gone" are the same observation. Separating
-//!   them needs a registry case with a trigger over a column no probe writes,
-//!   which is a change to `registry/cases.rs` and is not made here -- a
-//!   committed corpus fixture is run against a case's schema, so editing one
-//!   can stop a pinned defect reproducing.
+//! * **smugglr#347's shape, beyond the missing rebuild [`Boundary`] states.**
+//!   The only trigger in the registry references exactly the column the trigger
+//!   probe's own `INSERT` names, so "a trigger abandoned by a dropped column"
+//!   and "the probe's statement named a column that is gone" are the same
+//!   observation. Separating them needs a registry case with a trigger over a
+//!   column no probe writes, which is a change to `registry/cases.rs` and is not
+//!   made here -- a committed corpus fixture is run against a case's schema, so
+//!   editing one can stop a pinned defect reproducing.
 
 use rusqlite::Connection;
 
+use smugglr_forger::boundary::{Boundary, Subject};
 use smugglr_forger::error::BoxError;
 use smugglr_forger::fixture::{Backing, Fixture, Route};
 use smugglr_forger::oracle::{differential, Divergence, Outcome, Report};
@@ -165,8 +154,24 @@ fn smugglr_341_a_rebuild_that_dropped_every_referential_action_is_rediscovered()
 ///
 /// So the rediscovery above rests entirely on its `CASCADE` half. The same
 /// defect on a database whose only referential action is a `RESTRICT` passes.
+///
+/// The second half of the lock is the assertion that [`Boundary`] still says so.
+/// Nothing can measure "these two are the same behaviour here" -- it is a fact
+/// about a spelling the schema model does not have -- so the claim is held
+/// between two assertions that fail in opposite directions: this test goes red
+/// if the blind spot closes, and red again if the statement disappears without
+/// it closing.
 #[test]
 fn smugglr_341_the_same_loss_on_a_restrict_key_alone_is_not_rediscovered() {
+    assert!(
+        Boundary::of_this_build()
+            .statement(Subject::Restrict)
+            .is_some(),
+        "this test demonstrates a blind spot the boundary no longer states. Either the boundary \
+         stopped deriving the line -- no case schema declares ON DELETE RESTRICT any more -- or \
+         the statement was edited away while the blind spot below is still open"
+    );
+
     // The premise, checked rather than assumed: this transformation really does
     // leave the key without its action. A test that records a blind spot has to
     // fail when the blind spot closes *and* when it has quietly stopped removing
@@ -239,8 +244,23 @@ fn stored_ddl(fixture: &Fixture, table: &str) -> String {
 /// does. The first half of this test proves the loss is real -- the same rebuild
 /// against a fixture stops the update cascading -- and the second half runs the
 /// oracle over a schema carrying that key and gets silence.
+///
+/// The boundary's `ON UPDATE` line is derived: it is there because no case
+/// schema declares an `ON UPDATE` action. That derivation cannot tell a case
+/// that gained a key from a case that gained a *probe*, so the assertion below
+/// closes the gap from the other side -- declaring the action without reading it
+/// removes the line and turns this test red.
 #[test]
 fn smugglr_341_a_dropped_on_update_action_is_not_rediscovered() {
+    assert!(
+        Boundary::of_this_build()
+            .undeclared_on_update()
+            .contains(&ReferentialAction::Cascade),
+        "the boundary no longer claims ON UPDATE CASCADE goes unexercised, and the run below \
+         still shows the loss going unreported. A case schema that declares the action without a \
+         probe that reads it takes the claim away and leaves the blind spot open"
+    );
+
     const SEED: &str = r#"
         INSERT INTO "updating_keeper" ("id", "label") VALUES (1, 'renumbered');
         INSERT INTO "updating_child" ("id", "keeper_id", "label") VALUES (10, 1, 'follows');


### PR DESCRIPTION
Closes #360. Implements FR-FORGER-010. Last of the eleven forger issues.

forger now states what it did **not** exercise, worked out from what it did.

## Acceptance criteria mapping

### The output names the adapters and paths not exercised, specifically, rather than a generic disclaimer

Eight named lines, each carrying its mechanism and its issue reference rather than a category. The adapters line says *why* they differ -- each derives its columns from `rows[0].keys()` and emits `INSERT OR REPLACE`, destroying an absent column by a mechanism the native path does not have -- so a reader learns the shape of the gap, not just its existence.

Evidence, verbatim, appended to every census run whether passing or failing:

```
forger boundary: what this run did not exercise, worked out from what it did.

  adapters      http-sql, D1 and wasm -- each derives its columns from rows[0].keys()
                and emits INSERT OR REPLACE, destroying an absent column by a mechanism
                the native path does not have. smugglr#324.
  on delete     SET NULL and SET DEFAULT -- declared by no case schema, so probed by
                nothing.
  on update     every action. No case declares one and no probe reads one, so a rebuild
                that drops ON UPDATE CASCADE is silent. smugglr#374.
  restrict      declared and probed, and identical to the NO ACTION default under
                immediate enforcement. smugglr#374.
  unspellable   MATCH and DEFERRABLE INITIALLY DEFERRED -- no field in the schema model,
                and SQLite parses MATCH and ignores it.
  unrenderable  a bare non-ASCII or single-quoted identifier -- ddl::quote always
                double-quotes. smugglr#340.
  unobservable  anything a log would have said -- forger reads a database, never a log.
                smugglr#342, smugglr#336.
  unreachable   the direct ALTER TABLE DROP COLUMN path -- no rebuild, so no
                reconstruction to compare. smugglr#347.
```

About twenty lines against the tally's twenty -- it matches the report it qualifies rather than doubling it.

### The statement is derived from the covered set, so extending coverage requires it to change

Three lines are computed, and each was verified by **tampering rather than by asserting**. `adapters` is `Path::ALL` minus the paths `Backing::ALL` stands a database up on -- remapping `Backing::File => Path::D1` made the line print `http-sql and wasm` with no prose edited. `referential actions` is the declarable set minus what the registry's case schemas declare, read out of `TraitCase::for_trait(kind).schema` rather than from a list kept beside it. `unrenderable` asks `ddl::quote` what it does with a non-ASCII identifier rather than asserting that it double-quotes.

Three cannot be computed and the module doc says so under its own heading. `unspellable` has no value to interrogate, since an absent field is absent from the type -- pinned instead to the *shape* of `ForeignKey`, so adding `match` or `deferrable` fails a test whose message names the boundary. `unobservable` is a statement about a capability forger deliberately does not have. `unreachable` is a statement about smugglr's code paths, which forger cannot import and must not learn about -- flagged as the one line a reader should check against the issue it cites rather than against this crate.

Evidence: **the first attempt at the derivation lock failed, and that failure is the most useful result here.** The pin was written as `statement(Subject::OnUpdate).is_some()`, then `ON UPDATE CASCADE` was declared in `registry/cases.rs` to check it bit -- and the test **stayed green**. The derived line had merely changed shape, from the emphatic form to a list, while the blind spot stayed wide open. A boundary inspectable only as prose is one a test can check only by substring, and a substring check goes green on a sentence that has quietly stopped saying what it used to. `Boundary` now exposes the derived sets, the pin asks `contains(&ReferentialAction::Cascade)`, and the same tamper turns two tests red.

### A reviewer learns the boundary from the tool rather than after trusting a green check

Printed unconditionally and **before any verdict branch** -- a boundary printed only on failure is one nobody reads on the run that convinced them.

Evidence: `tests/execution_census.rs:73`, above the pass/fail split. The crate rustdoc gains one bullet saying where the boundary lives and that it is deliberately not restated there; the census output ends with a pointer back to the module. Run output is the index, rustdoc is the account, one statement at two depths.

## Not restated, deliberately

The six shared claims were **moved out of** `tests/the_known_defects_are_rediscovered.rs` rather than duplicated beside it -- that file now points at `Boundary` for the adapters, `ON UPDATE`, `RESTRICT`, `MATCH`, the log, and smugglr#340/#347's missing rebuild. What stays is what is particular to a defect rather than to forger's envelope, so FR-FORGER-012's "record what cannot be rediscovered" is still discharged there.

Two statements of one truth that can disagree is the defect this surface exists to remove, and one instance is already filed against my own spec (#365). Writing it twice here would have been repeating that mistake inside the fix for it.

## One asymmetry, stated rather than lumped

For `ON UPDATE` the enforcement is the derivation *and* the test. For `RESTRICT` it is **only** the test -- that line's presence is conditional on RESTRICT being declared, not on it being indistinguishable, so a future probe separating it under `DEFERRABLE INITIALLY DEFERRED` would close the gap while the line still printed. What catches that is an empty-divergences assertion going red.

## Defects found

**The boundary contradicted itself, and it shipped in the first commit.** The `on delete` line reported NO ACTION as declared by no case schema and therefore probed by nothing, while the `restrict` line reported RESTRICT as probed and behaviourally identical to the NO ACTION default. Both cannot be true. The cause: NO ACTION is the one variant whose *absence* of declaration is the declaration, so subtracting the declared set from every variant reports the default as a gap. Fixed in the second commit -- `declarable()` takes it out of the universe with the reason documented.

**`quote` was being asked the wrong question.** The unrenderable line originally probed a plain ASCII identifier, so a `quote` that went conditional for safe ASCII names while still double-quoting the rest would have *retracted the line* while forger still could not stage smugglr#340's input -- a false retraction in the unsafe direction.

**The print site is the one unpinned link in the chain, and it is named rather than excused.** Deleting the `println!` from `execution_census.rs:73` leaves every test green and silently fails the third criterion. That is structurally the same shape as a CI job that never runs `wasm-pack test` -- one of the four failures `census.rs`'s own module doc cites. `CARGO_BIN_EXE_` does not reach `harness = false` targets, so there is no cheap in-workspace harness for it.

**`Path::ALL` and `ReferentialAction::ALL` are scaffolding, not enforcement** -- the same admitted weakness `Trait::ALL` documents about itself, and the same missing-iteration hole the execution baseline was built to close for traits. A variant left off either array is a gap the boundary does not claim. It fails in the understating direction, and both docs say so at the array where someone adding a variant will meet it.

## Not done

- **Coverage is stated, not moved.** No named gap is closed here.
- `tests/execution-baseline.json` untouched -- this change adds no probes, so the recorded floor still matches.
- forger still depends on no smugglr crate; `scripts/check-forger-boundary.py` passes.